### PR TITLE
CREX-2640: Adding labels to moisture sensor attribute states.

### DIFF
--- a/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
@@ -42,8 +42,8 @@ metadata {
 	tiles(scale: 2) {
 		multiAttributeTile(name:"water", type: "generic", width: 6, height: 4){
 			tileAttribute ("device.water", key: "PRIMARY_CONTROL") {
-				attributeState "dry", icon:"st.alarm.water.dry", backgroundColor:"#ffffff"
-				attributeState "wet", icon:"st.alarm.water.wet", backgroundColor:"#53a7c0"
+				attributeState "dry", label: "Dry", icon:"st.alarm.water.dry", backgroundColor:"#ffffff"
+				attributeState "wet", label: "Wet", icon:"st.alarm.water.wet", backgroundColor:"#53a7c0"
 			}
 		}
 		valueTile("temperature", "device.temperature", inactiveLabel: false, width: 2, height: 2) {

--- a/devicetypes/smartthings/smartsense-moisture.src/smartsense-moisture.groovy
+++ b/devicetypes/smartthings/smartsense-moisture.src/smartsense-moisture.groovy
@@ -35,8 +35,8 @@ metadata {
 	tiles(scale: 2) {
 		multiAttributeTile(name:"water", type: "generic", width: 6, height: 4){
 			tileAttribute ("device.water", key: "PRIMARY_CONTROL") {
-				attributeState "dry", icon:"st.alarm.water.dry", backgroundColor:"#ffffff"
-				attributeState "wet", icon:"st.alarm.water.wet", backgroundColor:"#53a7c0"
+				attributeState "dry", label: "Dry", icon:"st.alarm.water.dry", backgroundColor:"#ffffff"
+				attributeState "wet", label: "Wet", icon:"st.alarm.water.wet", backgroundColor:"#53a7c0"
 			}
 		}
 		standardTile("temperature", "device.temperature", width: 2, height: 2) {


### PR DESCRIPTION
We need to have labels present so that the states can be properly
labeled in the new versions of client applications. This causes a slight
experience degradation in older versions of the app, but the impact is
understood.
