### PR TITLE
Fix for main tile issue

### DIFF
--- a/devicetypes/smartthings/aeon-multisensor-6.src/aeon-multisensor-6.groovy
+++ b/devicetypes/smartthings/aeon-multisensor-6.src/aeon-multisensor-6.groovy
@@ -92,6 +92,12 @@ metadata {
 			state "battery", label:'${currentValue}% battery', unit:""
 		}
 
+		//This tile is a temporary fix so users can select main tiles again
+		standardTile("CONVERTED-MULTI-device.motion", "device.motion", width: 4, height: 4) {
+			state "active", label:'motion', icon:"st.motion.motion.active", backgroundColor:"#53a7c0"
+			state "inactive", label:'no motion', icon:"st.motion.motion.inactive", backgroundColor:"#ffffff"
+		}
+
 		main(["motion", "temperature", "humidity", "illuminance"])
 		details(["motion", "temperature", "humidity", "illuminance", "battery"])
 	}

--- a/devicetypes/smartthings/aeon-multisensor-gen5.src/aeon-multisensor-gen5.groovy
+++ b/devicetypes/smartthings/aeon-multisensor-gen5.src/aeon-multisensor-gen5.groovy
@@ -91,6 +91,12 @@ metadata {
 			state "configure", label:'', action:"configureAfterSecure", icon:"st.secondary.configure"
 		}
 
+		//This tile is a temporary fix so users can select main tiles again
+		standardTile("CONVERTED-MULTI-device.motion", "device.motion", width: 4, height: 4) {
+			state "active", label:'motion', icon:"st.motion.motion.active", backgroundColor:"#53a7c0"
+			state "inactive", label:'no motion', icon:"st.motion.motion.inactive", backgroundColor:"#ffffff"
+		}
+
 		main(["motion", "temperature", "humidity", "illuminance"])
 		details(["motion", "temperature", "humidity", "illuminance", "battery", "configureAfterSecure"])
 	}

--- a/devicetypes/smartthings/aeon-multisensor.src/aeon-multisensor.groovy
+++ b/devicetypes/smartthings/aeon-multisensor.src/aeon-multisensor.groovy
@@ -88,6 +88,12 @@ metadata {
 			state "configure", label:'', action:"configuration.configure", icon:"st.secondary.configure"
 		}
 
+		//This tile is a temporary fix so users can select main tiles again
+		standardTile("CONVERTED-MULTI-device.motion", "device.motion", width: 4, height: 4) {
+			state "active", label:'motion', icon:"st.motion.motion.active", backgroundColor:"#53a7c0"
+			state "inactive", label:'no motion', icon:"st.motion.motion.inactive", backgroundColor:"#ffffff"
+		}
+
 		main(["motion", "temperature", "humidity", "illuminance"])
 		details(["motion", "temperature", "humidity", "illuminance", "battery", "configure"])
 	}

--- a/devicetypes/smartthings/smartsense-garage-door-multi.src/smartsense-garage-door-multi.groovy
+++ b/devicetypes/smartthings/smartsense-garage-door-multi.src/smartsense-garage-door-multi.groovy
@@ -74,6 +74,14 @@ metadata {
 			state "battery", label:'${currentValue}% battery', unit:""
 		}
 
+		//This tile is a temporary fix so users can select main tiles again
+		standardTile("CONVERTED-MULTI-device.status", "device.status", width: 4, height: 4) {
+			state "closed", label:'${name}', icon:"st.doors.garage.garage-closed", backgroundColor:"#79b821", nextState:"opening"
+			state "open", label:'${name}', icon:"st.doors.garage.garage-open", backgroundColor:"#ffa81e", nextState:"closing"
+			state "opening", label:'${name}', icon:"st.doors.garage.garage-opening", backgroundColor:"#ffe71e"
+			state "closing", label:'${name}', icon:"st.doors.garage.garage-closing", backgroundColor:"#ffe71e"
+		}
+
 		main(["status", "contact", "acceleration"])
 		details(["status", "contact", "acceleration", "temperature", "3axis", "battery"])
 	}

--- a/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
@@ -65,6 +65,12 @@ metadata {
 			state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
 		}
 		
+		//This tile is a temporary fix so users can select main tiles again
+		standardTile("CONVERTED-MULTI-device.water", "device.water", width: 4, height: 4) {
+			state "dry", icon:"st.alarm.water.dry", backgroundColor:"#ffffff"
+			state "wet", icon:"st.alarm.water.wet", backgroundColor:"#53a7c0"
+		}
+
 		main (["water", "temperature"])
 		details(["water", "temperature", "battery", "refresh"])
 	}

--- a/devicetypes/smartthings/smartsense-moisture.src/smartsense-moisture.groovy
+++ b/devicetypes/smartthings/smartsense-moisture.src/smartsense-moisture.groovy
@@ -47,6 +47,13 @@ metadata {
 		valueTile("battery", "device.battery", decoration: "flat", inactiveLabel: false, width: 2, height: 2) {
 			state "battery", label:'${currentValue}% battery', unit:""
 		}
+
+		//This tile is a temporary fix so users can select main tiles again
+		standardTile("CONVERTED-MULTI-device.water", "device.water", width: 4, height: 4) {
+			state "dry", icon:"st.alarm.water.dry", backgroundColor:"#ffffff"
+			state "wet", icon:"st.alarm.water.wet", backgroundColor:"#53a7c0"
+		}
+
 		main (["water", "temperature"])
 		details(["water", "temperature", "battery"])
 	}

--- a/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
@@ -68,6 +68,12 @@ metadata {
 			state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
 		}
 
+		//This tile is a temporary fix so users can select main tiles again
+		standardTile("CONVERTED-MULTI-device.motion", "device.motion", width: 4, height: 4) {
+			state "active", label:'motion', icon:"st.motion.motion.active", backgroundColor:"#53a7c0"
+			state "inactive", label:'no motion', icon:"st.motion.motion.inactive", backgroundColor:"#ffffff"
+		}
+
 		main(["motion", "temperature"])
 		details(["motion", "temperature", "battery", "refresh"])
 	}

--- a/devicetypes/smartthings/smartsense-motion-temp-sensor.src/smartsense-motion-temp-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-temp-sensor.src/smartsense-motion-temp-sensor.groovy
@@ -67,6 +67,12 @@ metadata {
 			state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
 		}
 
+		//This tile is a temporary fix so users can select main tiles again
+		standardTile("CONVERTED-MULTI-device.motion", "device.motion", width: 4, height: 4) {
+			state "active", label:'motion', icon:"st.motion.motion.active", backgroundColor:"#53a7c0"
+			state "inactive", label:'no motion', icon:"st.motion.motion.inactive", backgroundColor:"#ffffff"
+		}
+
 		main(["motion", "temperature"])
 		details(["motion", "temperature", "battery", "refresh"])
 	}

--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -90,6 +90,12 @@
  			state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
  		}
 
+		//This tile is a temporary fix so users can select main tiles again
+		standardTile("CONVERTED-MULTI-device.contact", "device.contact", width: 4, height: 4) {
+			state "open", label:'${name}', icon:"st.contact.contact.open", backgroundColor:"#ffa81e"
+			state "closed", label:'${name}', icon:"st.contact.contact.closed", backgroundColor:"#79b821"
+		}
+
 		main(["contact", "acceleration", "temperature"])
 		details(["contact", "acceleration", "temperature", "3axis", "battery", "refresh"])
 	}

--- a/devicetypes/smartthings/smartsense-multi.src/smartsense-multi.groovy
+++ b/devicetypes/smartthings/smartsense-multi.src/smartsense-multi.groovy
@@ -79,6 +79,12 @@ metadata {
 			state "battery", label:'${currentValue}% battery', unit:""
 		}
 
+		//This tile is a temporary fix so users can select main tiles again
+		standardTile("CONVERTED-MULTI-device.contact", "device.contact", width: 4, height: 4) {
+			state "open", label:'${name}', icon:"st.contact.contact.open", backgroundColor:"#ffa81e"
+			state "closed", label:'${name}', icon:"st.contact.contact.closed", backgroundColor:"#79b821"
+		}
+
 		main(["contact", "acceleration", "temperature"])
 		details(["contact", "acceleration", "temperature", "3axis", "battery"])
 	}

--- a/devicetypes/smartthings/smartsense-open-closed-accelerometer-sensor.src/smartsense-open-closed-accelerometer-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-accelerometer-sensor.src/smartsense-open-closed-accelerometer-sensor.groovy
@@ -66,6 +66,12 @@
 			state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
 		}
 
+		//This tile is a temporary fix so users can select main tiles again
+		standardTile("CONVERTED-MULTI-device.contact", "device.contact", width: 4, height: 4) {
+			state "open", label:'${name}', icon:"st.contact.contact.open", backgroundColor:"#ffa81e"
+			state "closed", label:'${name}', icon:"st.contact.contact.closed", backgroundColor:"#79b821"
+		}
+
 		main (["contact", "acceleration", "temperature"])
 		details(["contact", "acceleration", "temperature", "battery", "refresh"])
 	}

--- a/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
@@ -66,6 +66,12 @@ metadata {
 			state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
 		}
 
+		//This tile is a temporary fix so users can select main tiles again
+		standardTile("CONVERTED-MULTI-device.contact", "device.contact", width: 4, height: 4) {
+			state "open", label:'${name}', icon:"st.contact.contact.open", backgroundColor:"#ffa81e"
+			state "closed", label:'${name}', icon:"st.contact.contact.closed", backgroundColor:"#79b821"
+		}
+
 		main (["contact", "temperature"])
 		details(["contact","temperature","battery","refresh"])
 	}

--- a/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
@@ -62,6 +62,20 @@ metadata {
 			state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
 		}
 
+		//This tile is a temporary fix so users can select main tiles again
+		standardTile("CONVERTED-MULTI-device.temperature", "device.temperature", width: 4, height: 4) {
+			state "temperature", label:'${currentValue}°',
+				backgroundColors:[
+					[value: 31, color: "#153591"],
+					[value: 44, color: "#1e9cbb"],
+					[value: 59, color: "#90d2a7"],
+					[value: 74, color: "#44b621"],
+					[value: 84, color: "#f1d801"],
+					[value: 95, color: "#d04e00"],
+					[value: 96, color: "#bc2323"]
+				]
+		}
+
 		main "temperature", "humidity"
 		details(["temperature", "humidity", "battery", "refresh"])
 	}


### PR DESCRIPTION
In our attempt to roll out an experimental new feature early, we prevented users from being able to choose which tile they want to set as the "main" tile.

This temporary fix will help users so they can continue to change the main tile. This is temporary because there is a better way to do it by changing back-end code, which we will get in soon. Once that happens we can rip out these weirdly named tiles.
