### PR TITLE
Rollback changes for active tile fix

### DIFF
--- a/devicetypes/smartthings/aeon-multisensor-6.src/aeon-multisensor-6.groovy
+++ b/devicetypes/smartthings/aeon-multisensor-6.src/aeon-multisensor-6.groovy
@@ -92,12 +92,6 @@ metadata {
 			state "battery", label:'${currentValue}% battery', unit:""
 		}
 
-		//This tile is a temporary fix so users can select main tiles again
-		standardTile("CONVERTED-MULTI-device.motion", "device.motion", width: 4, height: 4) {
-			state "active", label:'motion', icon:"st.motion.motion.active", backgroundColor:"#53a7c0"
-			state "inactive", label:'no motion', icon:"st.motion.motion.inactive", backgroundColor:"#ffffff"
-		}
-
 		main(["motion", "temperature", "humidity", "illuminance"])
 		details(["motion", "temperature", "humidity", "illuminance", "battery"])
 	}

--- a/devicetypes/smartthings/aeon-multisensor-gen5.src/aeon-multisensor-gen5.groovy
+++ b/devicetypes/smartthings/aeon-multisensor-gen5.src/aeon-multisensor-gen5.groovy
@@ -91,12 +91,6 @@ metadata {
 			state "configure", label:'', action:"configureAfterSecure", icon:"st.secondary.configure"
 		}
 
-		//This tile is a temporary fix so users can select main tiles again
-		standardTile("CONVERTED-MULTI-device.motion", "device.motion", width: 4, height: 4) {
-			state "active", label:'motion', icon:"st.motion.motion.active", backgroundColor:"#53a7c0"
-			state "inactive", label:'no motion', icon:"st.motion.motion.inactive", backgroundColor:"#ffffff"
-		}
-
 		main(["motion", "temperature", "humidity", "illuminance"])
 		details(["motion", "temperature", "humidity", "illuminance", "battery", "configureAfterSecure"])
 	}

--- a/devicetypes/smartthings/aeon-multisensor.src/aeon-multisensor.groovy
+++ b/devicetypes/smartthings/aeon-multisensor.src/aeon-multisensor.groovy
@@ -88,12 +88,6 @@ metadata {
 			state "configure", label:'', action:"configuration.configure", icon:"st.secondary.configure"
 		}
 
-		//This tile is a temporary fix so users can select main tiles again
-		standardTile("CONVERTED-MULTI-device.motion", "device.motion", width: 4, height: 4) {
-			state "active", label:'motion', icon:"st.motion.motion.active", backgroundColor:"#53a7c0"
-			state "inactive", label:'no motion', icon:"st.motion.motion.inactive", backgroundColor:"#ffffff"
-		}
-
 		main(["motion", "temperature", "humidity", "illuminance"])
 		details(["motion", "temperature", "humidity", "illuminance", "battery", "configure"])
 	}

--- a/devicetypes/smartthings/smartsense-garage-door-multi.src/smartsense-garage-door-multi.groovy
+++ b/devicetypes/smartthings/smartsense-garage-door-multi.src/smartsense-garage-door-multi.groovy
@@ -74,14 +74,6 @@ metadata {
 			state "battery", label:'${currentValue}% battery', unit:""
 		}
 
-		//This tile is a temporary fix so users can select main tiles again
-		standardTile("CONVERTED-MULTI-device.status", "device.status", width: 4, height: 4) {
-			state "closed", label:'${name}', icon:"st.doors.garage.garage-closed", backgroundColor:"#79b821", nextState:"opening"
-			state "open", label:'${name}', icon:"st.doors.garage.garage-open", backgroundColor:"#ffa81e", nextState:"closing"
-			state "opening", label:'${name}', icon:"st.doors.garage.garage-opening", backgroundColor:"#ffe71e"
-			state "closing", label:'${name}', icon:"st.doors.garage.garage-closing", backgroundColor:"#ffe71e"
-		}
-
 		main(["status", "contact", "acceleration"])
 		details(["status", "contact", "acceleration", "temperature", "3axis", "battery"])
 	}

--- a/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
@@ -73,12 +73,6 @@ metadata {
 		standardTile("refresh", "device.refresh", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
 			state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
 		}
-		
-		//This tile is a temporary fix so users can select main tiles again
-		standardTile("CONVERTED-MULTI-device.water", "device.water", width: 4, height: 4) {
-			state "dry", icon:"st.alarm.water.dry", backgroundColor:"#ffffff"
-			state "wet", icon:"st.alarm.water.wet", backgroundColor:"#53a7c0"
-		}
 
 		main (["water", "temperature"])
 		details(["water", "temperature", "battery", "refresh"])

--- a/devicetypes/smartthings/smartsense-moisture.src/smartsense-moisture.groovy
+++ b/devicetypes/smartthings/smartsense-moisture.src/smartsense-moisture.groovy
@@ -48,12 +48,6 @@ metadata {
 			state "battery", label:'${currentValue}% battery', unit:""
 		}
 
-		//This tile is a temporary fix so users can select main tiles again
-		standardTile("CONVERTED-MULTI-device.water", "device.water", width: 4, height: 4) {
-			state "dry", icon:"st.alarm.water.dry", backgroundColor:"#ffffff"
-			state "wet", icon:"st.alarm.water.wet", backgroundColor:"#53a7c0"
-		}
-
 		main (["water", "temperature"])
 		details(["water", "temperature", "battery"])
 	}

--- a/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
@@ -77,12 +77,6 @@ metadata {
 			state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
 		}
 
-		//This tile is a temporary fix so users can select main tiles again
-		standardTile("CONVERTED-MULTI-device.motion", "device.motion", width: 4, height: 4) {
-			state "active", label:'motion', icon:"st.motion.motion.active", backgroundColor:"#53a7c0"
-			state "inactive", label:'no motion', icon:"st.motion.motion.inactive", backgroundColor:"#ffffff"
-		}
-
 		main(["motion", "temperature"])
 		details(["motion", "temperature", "battery", "refresh"])
 	}

--- a/devicetypes/smartthings/smartsense-motion-temp-sensor.src/smartsense-motion-temp-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-temp-sensor.src/smartsense-motion-temp-sensor.groovy
@@ -68,12 +68,6 @@ metadata {
 			state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
 		}
 
-		//This tile is a temporary fix so users can select main tiles again
-		standardTile("CONVERTED-MULTI-device.motion", "device.motion", width: 4, height: 4) {
-			state "active", label:'motion', icon:"st.motion.motion.active", backgroundColor:"#53a7c0"
-			state "inactive", label:'no motion', icon:"st.motion.motion.inactive", backgroundColor:"#ffffff"
-		}
-
 		main(["motion", "temperature"])
 		details(["motion", "temperature", "battery", "refresh"])
 	}

--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -109,13 +109,6 @@
  			state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
  		}
 
-		//This tile is a temporary fix so users can select main tiles again
-		standardTile("CONVERTED-MULTI-device.status", "device.status", width: 4, height: 4) {
-			state "open", label:'${name}', icon:"st.contact.contact.open", backgroundColor:"#ffa81e"
-			state "closed", label:'${name}', icon:"st.contact.contact.closed", backgroundColor:"#79b821"
-			state "garage-open", label:'${name}', icon:"st.doors.garage.garage-open", backgroundColor:"#ffa81e"
-			state "garage-closed", label:'${name}', icon:"st.doors.garage.garage-closed", backgroundColor:"#79b821"
-		}
 
 		main(["status", "acceleration", "temperature"])
 		details(["status", "acceleration", "temperature", "3axis", "battery", "refresh"])

--- a/devicetypes/smartthings/smartsense-multi.src/smartsense-multi.groovy
+++ b/devicetypes/smartthings/smartsense-multi.src/smartsense-multi.groovy
@@ -79,12 +79,6 @@ metadata {
 			state "battery", label:'${currentValue}% battery', unit:""
 		}
 
-		//This tile is a temporary fix so users can select main tiles again
-		standardTile("CONVERTED-MULTI-device.contact", "device.contact", width: 4, height: 4) {
-			state "open", label:'${name}', icon:"st.contact.contact.open", backgroundColor:"#ffa81e"
-			state "closed", label:'${name}', icon:"st.contact.contact.closed", backgroundColor:"#79b821"
-		}
-
 		main(["contact", "acceleration", "temperature"])
 		details(["contact", "acceleration", "temperature", "3axis", "battery"])
 	}

--- a/devicetypes/smartthings/smartsense-open-closed-accelerometer-sensor.src/smartsense-open-closed-accelerometer-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-accelerometer-sensor.src/smartsense-open-closed-accelerometer-sensor.groovy
@@ -66,12 +66,6 @@
 			state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
 		}
 
-		//This tile is a temporary fix so users can select main tiles again
-		standardTile("CONVERTED-MULTI-device.contact", "device.contact", width: 4, height: 4) {
-			state "open", label:'${name}', icon:"st.contact.contact.open", backgroundColor:"#ffa81e"
-			state "closed", label:'${name}', icon:"st.contact.contact.closed", backgroundColor:"#79b821"
-		}
-
 		main (["contact", "acceleration", "temperature"])
 		details(["contact", "acceleration", "temperature", "battery", "refresh"])
 	}

--- a/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
@@ -66,12 +66,6 @@ metadata {
 			state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
 		}
 
-		//This tile is a temporary fix so users can select main tiles again
-		standardTile("CONVERTED-MULTI-device.contact", "device.contact", width: 4, height: 4) {
-			state "open", label:'${name}', icon:"st.contact.contact.open", backgroundColor:"#ffa81e"
-			state "closed", label:'${name}', icon:"st.contact.contact.closed", backgroundColor:"#79b821"
-		}
-
 		main (["contact", "temperature"])
 		details(["contact","temperature","battery","refresh"])
 	}

--- a/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
@@ -62,20 +62,6 @@ metadata {
 			state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
 		}
 
-		//This tile is a temporary fix so users can select main tiles again
-		standardTile("CONVERTED-MULTI-device.temperature", "device.temperature", width: 4, height: 4) {
-			state "temperature", label:'${currentValue}°',
-				backgroundColors:[
-					[value: 31, color: "#153591"],
-					[value: 44, color: "#1e9cbb"],
-					[value: 59, color: "#90d2a7"],
-					[value: 74, color: "#44b621"],
-					[value: 84, color: "#f1d801"],
-					[value: 95, color: "#d04e00"],
-					[value: 96, color: "#bc2323"]
-				]
-		}
-
 		main "temperature", "humidity"
 		details(["temperature", "humidity", "battery", "refresh"])
 	}


### PR DESCRIPTION
This is to rollback the changes from #79. That was a temporary fix to help users that were having problems selecting active tiles. There is a change that will be deployed on the platform to fix the problem. Once that is deployed, we can merge this to rollback the temporary fix.

cc @workingmonk 
