### PR TITLE
New capabilities; buffering; scheduling

### DIFF
--- a/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
+++ b/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
@@ -239,6 +239,7 @@ def installed() {
 }
 
 def updated() {
+	atomicState.version = "1.0.18"
 	unsubscribe()
 
 	if (atomicState.bucketKey != null && atomicState.accessKey != null) {

--- a/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
+++ b/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
@@ -167,10 +167,6 @@ def subscribeToEvents() {
 	if (waterSensors != null) {
 		subscribe(waterSensors, "water", genericHandler)
 	}
-
-	if (canSchedule()) {
-		runEvery15Minutes(flushBuffer())
-	}
 }
 
 def getAccessKey() {
@@ -234,6 +230,8 @@ def installed() {
 	atomicState.isBucketCreated = false
 	atomicState.grokerSubdomain = "groker"
 	atomicState.eventBuffer = [];
+
+	runEvery15Minutes(flushBuffer)
 
 	log.debug "installed (version $atomicState.version)"
 }
@@ -317,7 +315,8 @@ def genericHandler(evt) {
 // This is a handler function for flushing the event buffer
 // after a specified amount of time to reduce the load on ST servers
 def flushBuffer() {
-	if (atomicState.eventBuffer.size() > 0) {
+	log.trace "About to flush the buffer on schedule"
+	if (atomicState.eventBuffer != null && atomicState.eventBuffer.size() > 0) {
 		shipEvents();
 	}
 }

--- a/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
+++ b/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
@@ -242,22 +242,26 @@ def updated() {
 	if (atomicState.bucketKey != null && atomicState.accessKey != null) {
 		atomicState.isBucketCreated = false
 	}
-	
+	if (atomicState.eventBuffer == null) {
+		atomicState.eventBuffer = [];
+	}
+
 	subscribeToEvents()
 
 	log.debug "updated (version $atomicState.version)"
 }
 
 def uninstalled() {
-	unsubscribe()
-	unschedule()
 	log.debug "uninstalled (version $atomicState.version)"
 }
 
 def createBucket() {
 
 	if (!atomicState.bucketName) {
-    	atomicState.bucketName = atomicState.bucketKey
+    	atomicState.bucketName = atomicState.bucketKey;
+    }
+    if (!atomicState.accessKey) {
+    	return;
     }
 	def bucketName = "${atomicState.bucketName}"
 	def bucketKey = "${atomicState.bucketKey}"

--- a/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
+++ b/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
@@ -280,7 +280,7 @@ def createBucket() {
 
 	try {
 		// Create a bucket on Initial State so the data has a logical grouping
-		httpPostJson(bucketCreatePost) { resp =>
+		httpPostJson(bucketCreatePost) { resp ->
 			log.debug "bucket posted"
 			if (resp.status >= 400) {
 				log.error "bucket not created successfully"
@@ -353,7 +353,7 @@ def shipEvents() {
 
 	try {
 		// post the events to initial state
-		httpPostJson(eventPost) { resp =>
+		httpPostJson(eventPost) { resp ->
 			log.debug "shipped events and got ${resp.status}"
 			if (resp.status >= 400) {
 				log.error "shipping failed... ${resp.data}"

--- a/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
+++ b/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
@@ -36,7 +36,6 @@ preferences {
         //input "cos", "capability.carbonMonoxideDetector", title: "Carbon  Monoxide Detectors", multiple: true, required: false
         //input "colors", "capability.colorControl", title: "Color Controllers", multiple: true, required: false
         input "contacts", "capability.contactSensor", title: "Contact Sensors", multiple: true, required: false
-        //input "doorsControllers", "capability.doorControl", title: "Door Controllers", multiple: true, required: false
         //input "energyMeters", "capability.energyMeter", title: "Energy Meters", multiple: true, required: false
         //input "illuminances", "capability.illuminanceMeasurement", title: "Illuminance Meters", multiple: true, required: false
         input "locks", "capability.lock", title: "Locks", multiple: true, required: false
@@ -101,9 +100,6 @@ def subscribeToEvents() {
 	if (contacts != null) {
 		subscribe(contacts, "contact", genericHandler)
 	}
-	/*if (doorsControllers != null) {
-		subscribe(doorsControllers, "door", genericHandler)
-	}*/
 	/*if (energyMeters != null) {
 		subscribe(energyMeters, "energy", genericHandler)
 	}*/

--- a/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
+++ b/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
@@ -229,7 +229,7 @@ def installed() {
 
 	atomicState.isBucketCreated = false
 	atomicState.grokerSubdomain = "groker"
-	atomicState.eventBuffer = [];
+	atomicState.eventBuffer = []
 
 	runEvery15Minutes(flushBuffer)
 
@@ -243,7 +243,7 @@ def updated() {
 		atomicState.isBucketCreated = false
 	}
 	if (atomicState.eventBuffer == null) {
-		atomicState.eventBuffer = [];
+		atomicState.eventBuffer = []
 	}
 
 	subscribeToEvents()
@@ -258,10 +258,10 @@ def uninstalled() {
 def createBucket() {
 
 	if (!atomicState.bucketName) {
-    	atomicState.bucketName = atomicState.bucketKey;
+    	atomicState.bucketName = atomicState.bucketKey
     }
     if (!atomicState.accessKey) {
-    	return;
+    	return
     }
 	def bucketName = "${atomicState.bucketName}"
 	def bucketKey = "${atomicState.bucketKey}"
@@ -321,23 +321,23 @@ def genericHandler(evt) {
 def flushBuffer() {
 	log.trace "About to flush the buffer on schedule"
 	if (atomicState.eventBuffer != null && atomicState.eventBuffer.size() > 0) {
-		shipEvents();
+		shipEvents()
 	}
 }
 
 def eventHandler(name, value) {
-	log.debug atomicState.eventBuffer;
+	log.debug atomicState.eventBuffer
 
-	def eventBuffer = atomicState.eventBuffer;
-	def epoch = now() / 1000;
+	def eventBuffer = atomicState.eventBuffer
+	def epoch = now() / 1000
 	eventBuffer << [key: "$name", value: "$value", epoch: "$epoch"]
 	
-	log.debug eventBuffer;
+	log.debug eventBuffer
 
-	atomicState.eventBuffer = eventBuffer;
+	atomicState.eventBuffer = eventBuffer
 
 	if (eventBuffer.size() >= 10) {
-		shipEvents();
+		shipEvents()
 	}
 }
 
@@ -352,7 +352,7 @@ def shipEvents() {
 			"Accept-Version": "0.0.2"
 		],
 		body: atomicState.eventBuffer
-	];
+	]
 
 	try {
 		// post the events to initial state
@@ -362,7 +362,7 @@ def shipEvents() {
 				log.error "shipping failed... ${resp.data}"
 			} else {
 				// clear the buffer
-				atomicState.eventBuffer = [];
+				atomicState.eventBuffer = []
 			}
 		}
 	} catch (e) {

--- a/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
+++ b/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
@@ -28,31 +28,31 @@ import groovy.json.JsonSlurper
 
 preferences {
 	section("Choose which devices to monitor...") {
-        //input "accelerometers", "capability.accelerationSensor", title: "Accelerometers", multiple: true, required: false
+        input "accelerometers", "capability.accelerationSensor", title: "Accelerometers", multiple: true, required: false
         input "alarms", "capability.alarm", title: "Alarms", multiple: true, required: false
-        //input "batteries", "capability.battery", title: "Batteries", multiple: true, required: false
-        //input "beacons", "capability.beacon", title: "Beacons", multiple: true, required: false
+        input "batteries", "capability.battery", title: "Batteries", multiple: true, required: false
+        input "beacons", "capability.beacon", title: "Beacons", multiple: true, required: false
         //input "buttons", "capability.button", title: "Buttons", multiple: true, required: false
-        //input "cos", "capability.carbonMonoxideDetector", title: "Carbon  Monoxide Detectors", multiple: true, required: false
-        //input "colors", "capability.colorControl", title: "Color Controllers", multiple: true, required: false
+        input "cos", "capability.carbonMonoxideDetector", title: "Carbon  Monoxide Detectors", multiple: true, required: false
+        input "colors", "capability.colorControl", title: "Color Controllers", multiple: true, required: false
         input "contacts", "capability.contactSensor", title: "Contact Sensors", multiple: true, required: false
-        //input "energyMeters", "capability.energyMeter", title: "Energy Meters", multiple: true, required: false
-        //input "illuminances", "capability.illuminanceMeasurement", title: "Illuminance Meters", multiple: true, required: false
+        input "energyMeters", "capability.energyMeter", title: "Energy Meters", multiple: true, required: false
+        input "illuminances", "capability.illuminanceMeasurement", title: "Illuminance Meters", multiple: true, required: false
         input "locks", "capability.lock", title: "Locks", multiple: true, required: false
         input "motions", "capability.motionSensor", title: "Motion Sensors", multiple: true, required: false
-        //input "musicPlayers", "capability.musicPlayer", title: "Music Players", multiple: true, required: false
-        //input "powerMeters", "capability.powerMeter", title: "Power Meters", multiple: true, required: false
+        input "musicPlayers", "capability.musicPlayer", title: "Music Players", multiple: true, required: false
+        input "powerMeters", "capability.powerMeter", title: "Power Meters", multiple: true, required: false
         input "presences", "capability.presenceSensor", title: "Presence Sensors", multiple: true, required: false
         input "humidities", "capability.relativeHumidityMeasurement", title: "Humidity Meters", multiple: true, required: false
-        //input "relaySwitches", "capability.relaySwitch", title: "Relay Switches", multiple: true, required: false
-        //input "sleepSensors", "capability.sleepSensor", title: "Sleep Sensors", multiple: true, required: false
-        //input "smokeDetectors", "capability.smokeDetector", title: "Smoke Detectors", multiple: true, required: false
-        //input "peds", "capability.stepSensor", title: "Pedometers", multiple: true, required: false
+        input "relaySwitches", "capability.relaySwitch", title: "Relay Switches", multiple: true, required: false
+        input "sleepSensors", "capability.sleepSensor", title: "Sleep Sensors", multiple: true, required: false
+        input "smokeDetectors", "capability.smokeDetector", title: "Smoke Detectors", multiple: true, required: false
+        input "peds", "capability.stepSensor", title: "Pedometers", multiple: true, required: false
         input "switches", "capability.switch", title: "Switches", multiple: true, required: false
         input "switchLevels", "capability.switchLevel", title: "Switch Levels", multiple: true, required: false
         input "temperatures", "capability.temperatureMeasurement", title: "Temperature Sensors", multiple: true, required: false
         input "thermostats", "capability.thermostat", title: "Thermostats", multiple: true, required: false
-        //input "valves", "capability.valve", title: "Valves", multiple: true, required: false
+        input "valves", "capability.valve", title: "Valves", multiple: true, required: false
         input "waterSensors", "capability.waterSensor", title: "Water Sensors", multiple: true, required: false
     }
 }
@@ -73,74 +73,74 @@ mappings {
 }
 
 def subscribeToEvents() {
-	/*if (accelerometers != null) {
+	if (accelerometers != null) {
 		subscribe(accelerometers, "acceleration", genericHandler)
-	}*/
+	}
 	if (alarms != null) {
 		subscribe(alarms, "alarm", genericHandler)
 	}
-	/*if (batteries != null) {
+	if (batteries != null) {
 		subscribe(batteries, "battery", genericHandler)
-	}*/
-	/*if (beacons != null) {
+	}
+	if (beacons != null) {
 		subscribe(beacons, "presence", genericHandler)
-	}*/
-	/*
-	if (buttons != null) {
+	}
+	
+	/*if (buttons != null) {
 		subscribe(buttons, "button", genericHandler)
 	}*/
-	/*if (cos != null) {
+	if (cos != null) {
 		subscribe(cos, "carbonMonoxide", genericHandler)
-	}*/
-	/*if (colors != null) {
+	}
+	if (colors != null) {
 		subscribe(colors, "hue", genericHandler)
 		subscribe(colors, "saturation", genericHandler)
 		subscribe(colors, "color", genericHandler)
-	}*/
+	}
 	if (contacts != null) {
 		subscribe(contacts, "contact", genericHandler)
 	}
-	/*if (energyMeters != null) {
+	if (energyMeters != null) {
 		subscribe(energyMeters, "energy", genericHandler)
-	}*/
-	/*if (illuminances != null) {
+	}
+	if (illuminances != null) {
 		subscribe(illuminances, "illuminance", genericHandler)
-	}*/
+	}
 	if (locks != null) {
 		subscribe(locks, "lock", genericHandler)
 	}
 	if (motions != null) {
 		subscribe(motions, "motion", genericHandler)
 	}
-	/*if (musicPlayers != null) {
+	if (musicPlayers != null) {
 		subscribe(musicPlayers, "status", genericHandler)
 		subscribe(musicPlayers, "level", genericHandler)
 		subscribe(musicPlayers, "trackDescription", genericHandler)
 		subscribe(musicPlayers, "trackData", genericHandler)
 		subscribe(musicPlayers, "mute", genericHandler)
-	}*/
-	/*if (powerMeters != null) {
+	}
+	if (powerMeters != null) {
 		subscribe(powerMeters, "power", genericHandler)
-	}*/
+	}
 	if (presences != null) {
 		subscribe(presences, "presence", genericHandler)
 	}
 	if (humidities != null) {
 		subscribe(humidities, "humidity", genericHandler)
 	}
-	/*if (relaySwitches != null) {
+	if (relaySwitches != null) {
 		subscribe(relaySwitches, "switch", genericHandler)
-	}*/
-	/*if (sleepSensors != null) {
+	}
+	if (sleepSensors != null) {
 		subscribe(sleepSensors, "sleeping", genericHandler)
-	}*/
-	/*if (smokeDetectors != null) {
+	}
+	if (smokeDetectors != null) {
 		subscribe(smokeDetectors, "smoke", genericHandler)
-	}*/
-	/*if (peds != null) {
+	}
+	if (peds != null) {
 		subscribe(peds, "steps", genericHandler)
 		subscribe(peds, "goal", genericHandler)
-	}*/
+	}
 	if (switches != null) {
 		subscribe(switches, "switch", genericHandler)
 	}
@@ -159,9 +159,9 @@ def subscribeToEvents() {
 		subscribe(thermostats, "thermostatFanMode", genericHandler)
 		subscribe(thermostats, "thermostatOperatingState", genericHandler)
 	}
-	/*if (valves != null) {
+	if (valves != null) {
 		subscribe(valves, "contact", genericHandler)
-	}*/
+	}
 	if (waterSensors != null) {
 		subscribe(waterSensors, "water", genericHandler)
 	}
@@ -208,7 +208,13 @@ def setBucketKey() {
 def setAccessKey() {
 	log.trace "set access key"
 	def newAccessKey = request.JSON?.accessKey
+	def newGrokerSubdomain = request.JSON?.grokerSubdomain
 
+	if (newGrokerSubdomain && newGrokerSubdomain != "" && newGrokerSubdomain != state.grokerSubdomain) {
+		state.grokerSubdomain = "$newGrokerSubdomain"
+		state.isBucketCreated = false
+	}
+    
 	if (newAccessKey && newAccessKey != state.accessKey) {
 		state.accessKey = "$newAccessKey"
 		state.isBucketCreated = false
@@ -220,6 +226,7 @@ def installed() {
 	subscribeToEvents()
 
 	state.isBucketCreated = false
+    state.grokerSubdomain = "groker"
 }
 
 def updated() {
@@ -244,7 +251,7 @@ def createBucket() {
 	def bucketCreateBody = new JsonSlurper().parseText("{\"bucketKey\": \"$bucketKey\", \"bucketName\": \"$bucketName\"}")
 
 	def bucketCreatePost = [
-		uri: 'https://groker.initialstate.com/api/buckets',
+		uri: "https://${state.grokerSubdomain}.initialstate.com/api/buckets",
 		headers: [
 			"Content-Type": "application/json",
 			"X-IS-AccessKey": accessKey
@@ -284,7 +291,7 @@ def eventHandler(name, value) {
 
 	def eventBody = new JsonSlurper().parseText("[{\"key\": \"$name\", \"value\": \"$value\"}]")
 	def eventPost = [
-		uri: 'https://groker.initialstate.com/api/events',
+		uri: "https://${state.grokerSubdomain}.initialstate.com/api/events",
 		headers: [
 			"Content-Type": "application/json",
 			"X-IS-BucketKey": "${state.bucketKey}",

--- a/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
+++ b/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
@@ -265,9 +265,10 @@ def tryCreateBucket() {
 	
 	// can't ship events if there is no grokerSubdomain
 	if (atomicState.grokerSubdomain == null || atomicState.grokerSubdomain == "") {
+		log.error "streaming url is currently null"
 		return
 	}
-	
+
 	// if the bucket has already been created, no need to continue
 	if (atomicState.isBucketCreated) {
 		return
@@ -356,6 +357,7 @@ def tryShipEvents() {
 
 	// can't ship events if there is no grokerSubdomain
 	if (atomicState.grokerSubdomain == null || atomicState.grokerSubdomain == "") {
+		log.error "streaming url is currently null"
 		return
 	}
 	// can't ship if access key and bucket key are null, so finish trying

--- a/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
+++ b/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
@@ -226,7 +226,7 @@ def setAccessKey() {
 }
 
 def installed() {
-	atomicState.version = "1.0.17"
+	atomicState.version = "1.0.18"
 	subscribeToEvents()
 
 	atomicState.isBucketCreated = false

--- a/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
+++ b/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
@@ -248,6 +248,9 @@ def updated() {
 	if (atomicState.eventBuffer == null) {
 		atomicState.eventBuffer = []
 	}
+	if (atomicState.grokerSubdomain == null || atomicState.grokerSubdomain == "") {
+		atomicState.grokerSubdomain = "groker"
+	}
 
 	subscribeToEvents()
 
@@ -259,6 +262,11 @@ def uninstalled() {
 }
 
 def tryCreateBucket() {
+	
+	// can't ship events if there is no grokerSubdomain
+	if (atomicState.grokerSubdomain == null || atomicState.grokerSubdomain == "") {
+		return
+	}
 	
 	// if the bucket has already been created, no need to continue
 	if (atomicState.isBucketCreated) {
@@ -346,6 +354,10 @@ def eventHandler(name, value) {
 // a helper function for shipping the atomicState.eventBuffer to Initial State
 def tryShipEvents() {
 
+	// can't ship events if there is no grokerSubdomain
+	if (atomicState.grokerSubdomain == null || atomicState.grokerSubdomain == "") {
+		return
+	}
 	// can't ship if access key and bucket key are null, so finish trying
 	if (atomicState.accessKey == null || atomicState.bucketKey == null) {
 		return


### PR DESCRIPTION
This pull request contains major enhancements to the Initial State Event Streamer.
Enhancements regarding ST's request for less network resource usage:
- Events are now buffered using `atomicState`
- When there are 10 or more events in the `atomicState` buffer, the buffer is flushed and the events are sent to Initial State
- Every 15 minutes a schedule task is triggered to flush the buffer as long as the buffer is not empty. This solves for the case where very few events are being triggered.

Enhancements based on User's feedback and demand:
- Now allows users to subscribe to `capability.energyMeter` and `capability.powerMeter` among many other new capabilities a user can subscribe to

Other Enhancements:
- Switched all uses of `state` to `atomicState` since buffering was required
- Added link to Initial State's terms of service in comments
- Added ability to define the Initial State streaming service's subdomain for better testing
- Added a version to the `atomicState` to help troubleshoot the SmartApp in both logs and state view.
