### PR TITLE
Fixed a potential bug if a InitialState SmartApp hasn't been updated

### DIFF
--- a/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
+++ b/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
@@ -341,6 +341,13 @@ def eventHandler(name, value) {
 
 	def eventBuffer = atomicState.eventBuffer
 	def epoch = now() / 1000
+	
+	// if for some reason this code block is being run
+	// but the SmartApp wasn't propery setup during install
+	// we need to set initialize the eventBuffer.
+	if (!atomicState.eventBuffer) {
+		atomicState.eventBuffer = []
+	}
 	eventBuffer << [key: "$name", value: "$value", epoch: "$epoch"]
 	
 	log.debug eventBuffer


### PR DESCRIPTION
Added a line to check if `atomicState.eventBuffer` is not initialized and if so, initialize it with an empty array before appending to the array in the eventHandler. This is to mitigate an error being thrown in some scenarios where the `atomicState.eventBuffer` is somehow not properly initialized.
