### PR TITLE
CREX-2981 Update the background image for arrival devices

### DIFF
--- a/devicetypes/smartthings/arrival-sensor.src/arrival-sensor.groovy
+++ b/devicetypes/smartthings/arrival-sensor.src/arrival-sensor.groovy
@@ -43,7 +43,7 @@ metadata {
 	tiles {
 		standardTile("presence", "device.presence", width: 2, height: 2, canChangeBackground: true) {
 			state "present", labelIcon:"st.presence.tile.present", backgroundColor:"#53a7c0"
-			state "not present", labelIcon:"st.presence.tile.not-present", backgroundColor:"#ffffff"
+			state "not present", labelIcon:"st.presence.tile.not-present", backgroundColor:"#ebeef2"
 		}
 		standardTile("beep", "device.beep", decoration: "flat") {
 			state "beep", label:'', action:"tone.beep", icon:"st.secondary.beep", backgroundColor:"#ffffff"

--- a/devicetypes/smartthings/mobile-presence.src/mobile-presence.groovy
+++ b/devicetypes/smartthings/mobile-presence.src/mobile-presence.groovy
@@ -25,7 +25,7 @@ metadata {
 	tiles {
 		standardTile("presence", "device.presence", width: 2, height: 2, canChangeBackground: true) {
 			state("present", labelIcon:"st.presence.tile.mobile-present", backgroundColor:"#53a7c0")
-			state("not present", labelIcon:"st.presence.tile.mobile-not-present", backgroundColor:"#ffffff")
+			state("not present", labelIcon:"st.presence.tile.mobile-not-present", backgroundColor:"#ebeef2")
 		}
 		main "presence"
 		details "presence"


### PR DESCRIPTION
Currently the white circle background on a white tile makes it look empty. This will make the circle gray. This will be redesigned at some point, but for now at least it won't look like an empty tile.

<img src="http://cloud.mattnohr.com/image/2d331q3e022o/Simulator%20Screen%20Shot%20Oct%2014,%202015,%2011.09.18%20AM.png" width="300px" />
