### PR TITLE
Fix requirement for SMS

### DIFF
--- a/smartapps/tslagle13/routine-director.src/routine-director.groovy
+++ b/smartapps/tslagle13/routine-director.src/routine-director.groovy
@@ -50,7 +50,7 @@ preferences {
         }
         section("Send Notifications?") {
             input("recipients", "contact", title: "Send notifications to") {
-                input "phone", "phone", title: "Send an SMS to this number?"
+                input "phone", "phone", title: "Send an SMS to this number?", required:false
             }
         }
 
@@ -266,7 +266,9 @@ def sendAway(msg) {
         }
         else {
         	sendPush(msg)
-            sendSms(phone, msg)
+        	if(phone){
+            		sendSms(phone, msg)
+        	}	
         }    
     }
 
@@ -280,7 +282,9 @@ def sendHome(msg) {
         }
         else {
         	sendPush(msg)
-            sendSms(phone, msg)
+                if(phone){
+            		sendSms(phone, msg)
+        	}
         }    
     }
 


### PR DESCRIPTION
Removed requirement to provide a SMS number is the user does not have contacts. Add logic to verify a number was provided before sending SMS.
