### PR TITLE
LiFX: update oauth/callback url, use getApiServerUrl() for proxying to corresponding shard

### DIFF
--- a/devicetypes/smartthings/lifx-white-bulb.src/lifx-white-bulb.groovy
+++ b/devicetypes/smartthings/lifx-white-bulb.src/lifx-white-bulb.groovy
@@ -16,41 +16,44 @@ metadata {
 	}
 
 	simulator {
-		// TODO: define status and reply messages here
+
 	}
 
-	tiles {
-		standardTile("switch", "device.switch", width: 2, height: 2, canChangeIcon: true) {
-			state "on", label:'${name}', action:"switch.off", icon:"st.switches.light.on", backgroundColor:"#79b821", nextState:"turningOff"
-			state "off", label:'${name}', action:"switch.on", icon:"st.switches.light.off", backgroundColor:"#ffffff", nextState:"turningOn"
-			state "turningOn", label:'Turning on', action:"switch.off", icon:"st.switches.light.on", backgroundColor:"#79b821", nextState:"turningOff"
-			state "turningOff", label:'Turning off', action:"switch.on", icon:"st.switches.light.off", backgroundColor:"#ffffff", nextState:"turningOn"
-			state "unreachable", label: "?", action:"refresh.refresh", icon:"st.switches.light.off", backgroundColor:"#666666"
+	tiles(scale: 2) {
+		multiAttributeTile(name:"switch", type: "lighting", width: 6, height: 4, canChangeIcon: true){
+			tileAttribute ("device.switch", key: "PRIMARY_CONTROL") {
+				attributeState "unreachable", label: "?", action:"refresh.refresh", icon:"http://hosted.lifx.co/smartthings/v1/196xUnreachable.png", backgroundColor:"#666666"
+				attributeState "on", label:'${name}', action:"switch.off", icon:"http://hosted.lifx.co/smartthings/v1/196xOn.png", backgroundColor:"#79b821", nextState:"turningOff"
+				attributeState "off", label:'${name}', action:"switch.on", icon:"http://hosted.lifx.co/smartthings/v1/196xOff.png", backgroundColor:"#ffffff", nextState:"turningOn"
+				attributeState "turningOn", label:'Turning on', action:"switch.off", icon:"http://hosted.lifx.co/smartthings/v1/196xOn.png", backgroundColor:"#79b821", nextState:"turningOff"
+				attributeState "turningOff", label:'Turning off', action:"switch.on", icon:"http://hosted.lifx.co/smartthings/v1/196xOff.png", backgroundColor:"#ffffff", nextState:"turningOn"
+
+			}
+			tileAttribute ("device.level", key: "SLIDER_CONTROL") {
+				attributeState "level", action:"switch level.setLevel"
+			}
 		}
-		standardTile("refresh", "device.switch", inactiveLabel: false, decoration: "flat") {
+
+		standardTile("refresh", "device.switch", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
 			state "default", label:"", action:"refresh.refresh", icon:"st.secondary.refresh"
 		}
+
 		valueTile("null", "device.switch", inactiveLabel: false, decoration: "flat") {
 			state "default", label:''
 		}
 
-		controlTile("levelSliderControl", "device.level", "slider", height: 1, width: 3, inactiveLabel: false, range:"(0..100)") {
-			state "level", action:"switch level.setLevel"
-		}
-		valueTile("level", "device.level", inactiveLabel: false, icon: "st.illuminance.illuminance.light", decoration: "flat") {
-			state "level", label: '${currentValue}%'
-		}
-
-		controlTile("colorTempSliderControl", "device.colorTemperature", "slider", height: 1, width: 2, inactiveLabel: false, range:"(2700..6500)") {
+		controlTile("colorTempSliderControl", "device.colorTemperature", "slider", height: 2, width: 4, inactiveLabel: false, range:"(2700..9000)") {
 			state "colorTemp", action:"color temperature.setColorTemperature"
 		}
-		valueTile("colorTemp", "device.colorTemperature", inactiveLabel: false, decoration: "flat") {
+
+		valueTile("colorTemp", "device.colorTemperature", inactiveLabel: false, decoration: "flat", height: 2, width: 2) {
 			state "colorTemp", label: '${currentValue}K'
 		}
 
-		main(["switch"])
-		details(["switch", "refresh", "level", "levelSliderControl", "colorTempSliderControl", "colorTemp"])
+		main "switch"
+		details(["switch", "colorTempSliderControl", "colorTemp", "refresh"])
 	}
+
 }
 
 // parse events into attributes
@@ -72,9 +75,10 @@ def setLevel(percentage) {
 		return off() // if the brightness is set to 0, just turn it off
 	}
 	parent.logErrors(logObject:log) {
-		def resp = parent.apiPUT("/lights/${device.deviceNetworkId}/color", ["color": "brightness:${percentage / 100}"])
+		def resp = parent.apiPUT("/lights/${selector()}/state", [brightness: percentage / 100, power: "on"])
 		if (resp.status < 300) {
 			sendEvent(name: "level", value: percentage)
+			sendEvent(name: "switch.setLevel", value: percentage)
 			sendEvent(name: "switch", value: "on")
 		} else {
 			log.error("Bad setLevel result: [${resp.status}] ${resp.data}")
@@ -85,7 +89,7 @@ def setLevel(percentage) {
 def setColorTemperature(kelvin) {
 	log.debug "Executing 'setColorTemperature' to ${kelvin}"
 	parent.logErrors() {
-		def resp = parent.apiPUT("/lights/${device.deviceNetworkId}/color", [color: "kelvin:${kelvin}"])
+		def resp = parent.apiPUT("/lights/${selector()}/state", [color: "kelvin:${kelvin}", power: "on"])
 		if (resp.status < 300) {
 			sendEvent(name: "colorTemperature", value: kelvin)
 			sendEvent(name: "color", value: "#ffffff")
@@ -100,7 +104,7 @@ def setColorTemperature(kelvin) {
 def on() {
 	log.debug "Device setOn"
 	parent.logErrors() {
-		if (parent.apiPUT("/lights/${device.deviceNetworkId}/power", [state: "on"]) != null) {
+		if (parent.apiPUT("/lights/${selector()}/state", [power: "on"]) != null) {
 			sendEvent(name: "switch", value: "on")
 		}
 	}
@@ -109,7 +113,7 @@ def on() {
 def off() {
 	log.debug "Device setOff"
 	parent.logErrors() {
-		if (parent.apiPUT("/lights/${device.deviceNetworkId}/power", [state: "off"]) != null) {
+		if (parent.apiPUT("/lights/${selector()}/state", [power: "off"]) != null) {
 			sendEvent(name: "switch", value: "off")
 		}
 	}
@@ -117,16 +121,22 @@ def off() {
 
 def poll() {
 	log.debug "Executing 'poll' for ${device} ${this} ${device.deviceNetworkId}"
-	def resp = parent.apiGET("/lights/${device.deviceNetworkId}")
-	if (resp.status != 200) {
+	def resp = parent.apiGET("/lights/${selector()}")
+	if (resp.status == 404) {
+		sendEvent(name: "switch", value: "unreachable")
+		return []
+	} else if (resp.status != 200) {
 		log.error("Unexpected result in poll(): [${resp.status}] ${resp.data}")
 		return []
 	}
-	def data = resp.data
+	def data = resp.data[0]
 
-	sendEvent(name: "level", value: sprintf("%f", (data.brightness ?: 1) * 100))
+	sendEvent(name: "label", value: data.label)
+	sendEvent(name: "level", value: Math.round((data.brightness ?: 1) * 100))
+	sendEvent(name: "switch.setLevel", value: Math.round((data.brightness ?: 1) * 100))
 	sendEvent(name: "switch", value: data.connected ? data.power : "unreachable")
 	sendEvent(name: "colorTemperature", value: data.color.kelvin)
+	sendEvent(name: "model", value: data.product.name)
 
 	return []
 }
@@ -135,3 +145,13 @@ def refresh() {
 	log.debug "Executing 'refresh'"
 	poll()
 }
+
+def selector() {
+	if (device.deviceNetworkId.contains(":")) {
+		return device.deviceNetworkId
+	} else {
+		return "id:${device.deviceNetworkId}"
+	}
+}
+
+

--- a/smartapps/smartthings/lifx-connect.src/lifx-connect.groovy
+++ b/smartapps/smartthings/lifx-connect.src/lifx-connect.groovy
@@ -5,22 +5,23 @@
  *
  */
 definition(
-	name: "LIFX (Connect)",
-	namespace: "smartthings",
-	author: "LIFX",
-	description: "Allows you to use LIFX smart light bulbs with SmartThings.",
-	category: "Convenience",
-	iconUrl: "https://cloud.lifx.com/images/lifx.png",
-	iconX2Url: "https://cloud.lifx.com/images/lifx.png",
-	iconX3Url: "https://cloud.lifx.com/images/lifx.png",
-	oauth: true) {
-		appSetting "clientId"
-		appSetting "clientSecret"
-	}
+		name: "LIFX (Connect)",
+		namespace: "smartthings",
+		author: "LIFX",
+		description: "Allows you to use LIFX smart light bulbs with SmartThings.",
+		category: "Convenience",
+		iconUrl: "https://cloud.lifx.com/images/lifx.png",
+		iconX2Url: "https://cloud.lifx.com/images/lifx.png",
+		iconX3Url: "https://cloud.lifx.com/images/lifx.png",
+		oauth: true,
+		singleInstance: true) {
+	appSetting "clientId"
+	appSetting "clientSecret"
+}
 
 
 preferences {
-	page(name: "Credentials", title: "LIFX", content: "authPage", install: false)
+	page(name: "Credentials", title: "LIFX", content: "authPage", install: true)
 }
 
 mappings {
@@ -32,11 +33,16 @@ mappings {
 	path("/test") { action: [ GET: "oauthSuccess" ] }
 }
 
-def getServerUrl() { return "https://graph.api.smartthings.com" }
-def apiURL(path = '/') { return "https://api.lifx.com/v1beta1${path}" }
+def getServerUrl()               { return "https://graph.api.smartthings.com" }
+def getShardUrl()                { return getApiServerUrl() }
+def getCallbackUrl()             { return "https://graph.api.smartthings.com/oauth/callback"}
+def apiURL(path = '/') 			 { return "https://api.lifx.com/v1${path}" }
 def buildRedirectUrl(page) {
 	return "${serverUrl}/api/token/${state.accessToken}/smartapps/installations/${app.id}/${page}"
 }
+def getSecretKey()               { return appSettings.secretKey }
+def getClientId()                { return appSettings.clientId }
+
 
 def authPage() {
 	log.debug "authPage"
@@ -45,16 +51,15 @@ def authPage() {
 		// This is the SmartThings access token
 		if (!state.accessToken) {
 			log.debug "no access token, create access token"
-			createAccessToken() // predefined method
+			state.accessToken = createAccessToken() // predefined method
 		}
 		def description = "Tap to enter LIFX credentials"
-		def redirectUrl = "${serverUrl}/oauth/initialize?appId=${app.id}&access_token=${state.accessToken}" // this triggers oauthInit() below
+		def redirectUrl = "${serverUrl}/oauth/initialize?appId=${app.id}&access_token=${state.accessToken}&apiServerUrl=${shardUrl}" // this triggers oauthInit() below
 		log.debug "app id: ${app.id}"
 		log.debug "redirect url: ${redirectUrl}"
-		return dynamicPage(name: "Credentials", title: "Connect to LIFX", nextPage: null, uninstall: true, install:false) {
+		return dynamicPage(name: "Credentials", title: "Connect to LIFX", nextPage: null, uninstall: true, install:true) {
 			section {
 				href(url:redirectUrl, required:true, title:"Connect to LIFX", description:"Tap here to connect your LIFX account")
-				// href(url:buildRedirectUrl("test"), title: "Message test")
 			}
 		}
 	} else {
@@ -62,11 +67,10 @@ def authPage() {
 
 		def options = locationOptions() ?: []
 		def count = options.size()
-        def refreshInterval = 3
 
-		return dynamicPage(name:"Credentials", title:"Select devices...", nextPage:"", refreshInterval:refreshInterval, install:true, uninstall: true) {
+		return dynamicPage(name:"Credentials", title:"", nextPage:"", install:true, uninstall: true) {
 			section("Select your location") {
-				input "selectedLocationId", "enum", required:true, title:"Select location (${count} found)", multiple:false, options:options
+				input "selectedLocationId", "enum", required:true, title:"Select location (${count} found)", multiple:false, options:options, submitOnChange: true
 			}
 		}
 	}
@@ -111,7 +115,7 @@ def oauthCallback() {
 }
 
 def oauthReceiveToken(redirectUrl = null) {
-
+	// Not sure what redirectUrl is for
 	log.debug "receiveToken - params: ${params}"
 	def oauthParams = [ client_id: "${appSettings.clientId}", client_secret: "${appSettings.clientSecret}", grant_type: "authorization_code", code: params.code, scope: params.scope ] // how is params.code valid here?
 	def params = [
@@ -134,25 +138,25 @@ def oauthReceiveToken(redirectUrl = null) {
 
 def oauthSuccess() {
 	def message = """
-        <p>Your LIFX Account is now connected to SmartThings!</p>
-        <p>Click 'Done' to finish setup.</p>
-    """
+		<p>Your LIFX Account is now connected to SmartThings!</p>
+		<p>Click 'Done' to finish setup.</p>
+	"""
 	oauthConnectionStatus(message)
 }
 
 def oauthFailure() {
 	def message = """
-        <p>The connection could not be established!</p>
-        <p>Click 'Done' to return to the menu.</p>
-    """
+		<p>The connection could not be established!</p>
+		<p>Click 'Done' to return to the menu.</p>
+	"""
 	oauthConnectionStatus(message)
 }
 
 def oauthReceivedToken() {
 	def message = """
-        <p>Your LIFX Account is already connected to SmartThings!</p>
-        <p>Click 'Done' to finish setup.</p>
-    """
+		<p>Your LIFX Account is already connected to SmartThings!</p>
+		<p>Click 'Done' to finish setup.</p>
+	"""
 	oauthConnectionStatus(message)
 }
 
@@ -160,74 +164,74 @@ def oauthConnectionStatus(message, redirectUrl = null) {
 	def redirectHtml = ""
 	if (redirectUrl) {
 		redirectHtml = """
-            <meta http-equiv="refresh" content="3; url=${redirectUrl}" />
-        """
+			<meta http-equiv="refresh" content="3; url=${redirectUrl}" />
+		"""
 	}
 
 	def html = """
-        <!DOCTYPE html>
-        <html>
-        <head>
-        <meta name="viewport" content="width=device-width">
-        <title>SmartThings Connection</title>
-        <style type="text/css">
-            @font-face {
-                font-family: 'Swiss 721 W01 Thin';
-                src: url('https://s3.amazonaws.com/smartapp-icons/Partner/fonts/swiss-721-thin-webfont.eot');
-                src: url('https://s3.amazonaws.com/smartapp-icons/Partner/fonts/swiss-721-thin-webfont.eot?#iefix') format('embedded-opentype'),
-                     url('https://s3.amazonaws.com/smartapp-icons/Partner/fonts/swiss-721-thin-webfont.woff') format('woff'),
-                     url('https://s3.amazonaws.com/smartapp-icons/Partner/fonts/swiss-721-thin-webfont.ttf') format('truetype'),
-                     url('https://s3.amazonaws.com/smartapp-icons/Partner/fonts/swiss-721-thin-webfont.svg#swis721_th_btthin') format('svg');
-                font-weight: normal;
-                font-style: normal;
-            }
-            @font-face {
-                font-family: 'Swiss 721 W01 Light';
-                src: url('https://s3.amazonaws.com/smartapp-icons/Partner/fonts/swiss-721-light-webfont.eot');
-                src: url('https://s3.amazonaws.com/smartapp-icons/Partner/fonts/swiss-721-light-webfont.eot?#iefix') format('embedded-opentype'),
-                     url('https://s3.amazonaws.com/smartapp-icons/Partner/fonts/swiss-721-light-webfont.woff') format('woff'),
-                     url('https://s3.amazonaws.com/smartapp-icons/Partner/fonts/swiss-721-light-webfont.ttf') format('truetype'),
-                     url('https://s3.amazonaws.com/smartapp-icons/Partner/fonts/swiss-721-light-webfont.svg#swis721_lt_btlight') format('svg');
-                font-weight: normal;
-                font-style: normal;
-            }
-            .container {
-                width: 280;
-                padding: 20px;
-                text-align: center;
-            }
-            img {
-                vertical-align: middle;
-            }
-            img:nth-child(2) {
-                margin: 0 15px;
-            }
-            p {
-                font-size: 1.2em;
-                font-family: 'Swiss 721 W01 Thin';
-                text-align: center;
-                color: #666666;
-                padding: 0 20px;
-                margin-bottom: 0;
-            }
-            span {
-                font-family: 'Swiss 721 W01 Light';
-            }
-        </style>
-        ${redirectHtml}
-        </head>
-        <body>
-            <div class="container">
-                <img src='https://cloud.lifx.com/images/lifx.png' alt='LIFX icon' width='100'/>
-                <img src='https://s3.amazonaws.com/smartapp-icons/Partner/support/connected-device-icn%402x.png' alt='connected device icon' width="40"/>
-                <img src='https://s3.amazonaws.com/smartapp-icons/Partner/support/st-logo%402x.png' alt='SmartThings logo' width="100"/>
-                <p>
-                    ${message}
-                </p>
-            </div>
-        </body>
-        </html>
-    """
+		<!DOCTYPE html>
+		<html>
+		<head>
+		<meta name="viewport" content="width=device-width">
+		<title>SmartThings Connection</title>
+		<style type="text/css">
+			@font-face {
+				font-family: 'Swiss 721 W01 Thin';
+				src: url('https://s3.amazonaws.com/smartapp-icons/Partner/fonts/swiss-721-thin-webfont.eot');
+				src: url('https://s3.amazonaws.com/smartapp-icons/Partner/fonts/swiss-721-thin-webfont.eot?#iefix') format('embedded-opentype'),
+					 url('https://s3.amazonaws.com/smartapp-icons/Partner/fonts/swiss-721-thin-webfont.woff') format('woff'),
+					 url('https://s3.amazonaws.com/smartapp-icons/Partner/fonts/swiss-721-thin-webfont.ttf') format('truetype'),
+					 url('https://s3.amazonaws.com/smartapp-icons/Partner/fonts/swiss-721-thin-webfont.svg#swis721_th_btthin') format('svg');
+				font-weight: normal;
+				font-style: normal;
+			}
+			@font-face {
+				font-family: 'Swiss 721 W01 Light';
+				src: url('https://s3.amazonaws.com/smartapp-icons/Partner/fonts/swiss-721-light-webfont.eot');
+				src: url('https://s3.amazonaws.com/smartapp-icons/Partner/fonts/swiss-721-light-webfont.eot?#iefix') format('embedded-opentype'),
+					 url('https://s3.amazonaws.com/smartapp-icons/Partner/fonts/swiss-721-light-webfont.woff') format('woff'),
+					 url('https://s3.amazonaws.com/smartapp-icons/Partner/fonts/swiss-721-light-webfont.ttf') format('truetype'),
+					 url('https://s3.amazonaws.com/smartapp-icons/Partner/fonts/swiss-721-light-webfont.svg#swis721_lt_btlight') format('svg');
+				font-weight: normal;
+				font-style: normal;
+			}
+			.container {
+				width: 280;
+				padding: 20px;
+				text-align: center;
+			}
+			img {
+				vertical-align: middle;
+			}
+			img:nth-child(2) {
+				margin: 0 15px;
+			}
+			p {
+				font-size: 1.2em;
+				font-family: 'Swiss 721 W01 Thin';
+				text-align: center;
+				color: #666666;
+				padding: 0 20px;
+				margin-bottom: 0;
+			}
+			span {
+				font-family: 'Swiss 721 W01 Light';
+			}
+		</style>
+		${redirectHtml}
+		</head>
+		<body>
+			<div class="container">
+				<img src='https://cloud.lifx.com/images/lifx.png' alt='LIFX icon' width='100'/>
+				<img src='https://s3.amazonaws.com/smartapp-icons/Partner/support/connected-device-icn%402x.png' alt='connected device icon' width="40"/>
+				<img src='https://s3.amazonaws.com/smartapp-icons/Partner/support/st-logo%402x.png' alt='SmartThings logo' width="100"/>
+				<p>
+					${message}
+				</p>
+			</div>
+		</body>
+		</html>
+	"""
 	render contentType: 'text/html', data: html
 }
 
@@ -238,7 +242,6 @@ String toQueryString(Map m) {
 // App lifecycle hooks
 
 def installed() {
-	enableCallback() // wtf does this do?
 	if (!state.accessToken) {
 		createAccessToken()
 	} else {
@@ -250,7 +253,6 @@ def installed() {
 
 // called after settings are changed
 def updated() {
-	enableCallback() // not sure what this does
 	if (!state.accessToken) {
 		createAccessToken()
 	} else {
@@ -304,27 +306,36 @@ def logErrors(options = [errorReturn: null, logObject: log], Closure c) {
 			state.remove("lifxAccessToken")
 			options.logObject.warn "Access token is not valid"
 		}
-		return options.errerReturn
+		return options.errorReturn
 	} catch (java.net.SocketTimeoutException e) {
 		options.logObject.warn "Connection timed out, not much we can do here"
-		return options.errerReturn
+		return options.errorReturn
 	}
 }
 
 def apiGET(path) {
-	httpGet(uri: apiURL(path), headers: apiRequestHeaders()) {response ->
-		logResponse(response)
-		return response
+	try {
+		httpGet(uri: apiURL(path), headers: apiRequestHeaders()) {response ->
+			logResponse(response)
+			return response
+		}
+	} catch (groovyx.net.http.HttpResponseException e) {
+		logResponse(e.response)
+		return e.response
 	}
 }
 
 def apiPUT(path, body = [:]) {
-	log.debug("Beginning API PUT: ${path}, ${body}")
-	httpPutJson(uri: apiURL(path), body: new groovy.json.JsonBuilder(body).toString(), headers: apiRequestHeaders(), ) {response ->
-		logResponse(response)
-		return response
-	}
-}
+	try {
+		log.debug("Beginning API PUT: ${path}, ${body}")
+		httpPutJson(uri: apiURL(path), body: new groovy.json.JsonBuilder(body).toString(), headers: apiRequestHeaders(), ) {response ->
+			logResponse(response)
+			return response
+		}
+	} catch (groovyx.net.http.HttpResponseException e) {
+		logResponse(e.response)
+		return e.response
+	}}
 
 def devicesList(selector = '') {
 	logErrors([]) {
@@ -339,12 +350,12 @@ def devicesList(selector = '') {
 }
 
 Map locationOptions() {
-
 	def options = [:]
 	def devices = devicesList()
 	devices.each { device ->
 		options[device.location.id] = device.location.name
 	}
+	log.debug("Locations: ${options}")
 	return options
 }
 
@@ -358,28 +369,32 @@ def updateDevices() {
 		state.devices = [:]
 	}
 	def devices = devicesInLocation()
-	def deviceIds = devices*.id
+	def selectors = []
+
+	log.debug("All selectors: ${selectors}")
+
 	devices.each { device ->
 		def childDevice = getChildDevice(device.id)
+		selectors.add("${device.id}")
 		if (!childDevice) {
-			log.info("Adding device ${device.id}: ${device.capabilities}")
+			log.info("Adding device ${device.id}: ${device.product}")
 			def data = [
 					label: device.label,
-					level: sprintf("%f", (device.brightness ?: 1) * 100),
+					level: Math.round((device.brightness ?: 1) * 100),
 					switch: device.connected ? device.power : "unreachable",
 					colorTemperature: device.color.kelvin
 			]
-			if (device.capabilities.has_color) {
+			if (device.product.capabilities.has_color) {
 				data["color"] = colorUtil.hslToHex((device.color.hue / 3.6) as int, (device.color.saturation * 100) as int)
 				data["hue"] = device.color.hue / 3.6
 				data["saturation"] = device.color.saturation * 100
-				childDevice = addChildDevice("smartthings", "LIFX Color Bulb", device.id, null, data)
+				childDevice = addChildDevice(app.namespace, "LIFX Color Bulb", device.id, null, data)
 			} else {
-				childDevice = addChildDevice("smartthings", "LIFX White Bulb", device.id, null, data)
+				childDevice = addChildDevice(app.namespace, "LIFX White Bulb", device.id, null, data)
 			}
 		}
 	}
-	getChildDevices().findAll { !deviceIds.contains(it.deviceNetworkId) }.each {
+	getChildDevices().findAll { !selectors.contains("${it.deviceNetworkId}") }.each {
 		log.info("Deleting ${it.deviceNetworkId}")
 		deleteChildDevice(it.deviceNetworkId)
 	}


### PR DESCRIPTION
@juano2310 and @workingmonk  Can you review this?

This update is based on the [PR#207](https://github.com/SmartThingsCommunity/SmartThingsPublic/pull/207) LIFX SmartApp Update.

The [PR#1605](https://github.com/PhysicalGraph/data-management/pull/1605) "cross shard proxy logic for /oauth/callback" allows 3rd party OAuth flow to the correct shard by proxying the oauth/callback request after user authorization process. 

P.S. This change has not been tested in prod as it has to wait for the PR#1605 to get deployed in prod on  11/02/2015.
