### PR TITLE
Fix 'Low Battery Handler' exception caused by non-integer battery events

### DIFF
--- a/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
+++ b/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
@@ -139,8 +139,7 @@ private Map parseReportAttributeMessage(String description) {
     Map resultMap = [:]
     if (descMap.clusterInt == CLUSTER_POWER && descMap.attrInt == POWER_ATTR_BATTERY_PERCENTAGE_REMAINING) {
         resultMap.name = "battery"
-        // BatteryPercentageRemaining is specified in .5% increments
-        resultMap.value = Integer.parseInt(descMap.value, 16) / 2
+        resultMap.value = Math.round(Integer.parseInt(descMap.value, 16) / 2)
         log.info "parseReportAttributeMessage() --- battery: ${resultMap.value}"
     }
     else if (descMap.clusterInt == CLUSTER_DOORLOCK && descMap.attrInt == DOORLOCK_ATTR_LOCKSTATE) {


### PR DESCRIPTION
ZigBee locks report battery percentage remaining in .5% increments. However
the Low Battery Handler Smart App in Hello Home expects it to be an integer.

cc @workingmonk 
