### PR TITLE
CREX-1094 Delete stale device subscriptions on IFTTT app update

### DIFF
--- a/smartapps/smartthings/ifttt.src/ifttt.groovy
+++ b/smartapps/smartthings/ifttt.src/ifttt.groovy
@@ -98,6 +98,15 @@ def installed() {
 }
 
 def updated() {
+	def currentDeviceIds = settings.collect { k, devices -> devices }.flatten().collect { it.id }.unique()
+	def subscriptionDevicesToRemove = app.subscriptions*.device.findAll { device ->
+		!currentDeviceIds.contains(device.id)
+	}
+	subscriptionDevicesToRemove.each { device ->
+		log.debug "Removing $device.displayName subscription"
+		state.remove(device.id)
+		unsubscribe(device)
+	}
 	log.debug settings
 }
 


### PR DESCRIPTION
If a device is removed from the IFTTT app in the mobile client it leaves an event subscription hanging around that can prevent devices from being deleted. This change removes all orphaned event subscriptions during app update. 
