### PR TITLE
[DEVC-231] Moving re-certified device to generic zigbee DTH.

### DIFF
--- a/devicetypes/smartthings/ge-link-bulb.src/ge-link-bulb.groovy
+++ b/devicetypes/smartthings/ge-link-bulb.src/ge-link-bulb.groovy
@@ -50,7 +50,7 @@ metadata {
 		capability "Switch Level"
         capability "Polling"
 
-		fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0008,1000", outClusters: "0019"
+        fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0008,1000", outClusters: "0019", manufacturer: "GE_Appliances", model: "ZLL Light", deviceJoinName: "GE Link Bulb"
 	}
 
 	// UI tile definitions

--- a/devicetypes/smartthings/ge-zigbee-dimmer.src/ge-zigbee-dimmer.groovy
+++ b/devicetypes/smartthings/ge-zigbee-dimmer.src/ge-zigbee-dimmer.groovy
@@ -26,8 +26,6 @@ metadata {
 		capability "Actuator"
 		capability "Sensor"
 
-		fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0008,0B05,0702", outClusters: "000A,0019", manufacturer: "Jasco Products", model: "45852"
-		fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0008,0B05,0702", outClusters: "000A,0019", manufacturer: "Jasco Products", model: "45857"
 	}
 
 	// simulator metadata

--- a/devicetypes/smartthings/ge-zigbee-switch.src/ge-zigbee-switch.groovy
+++ b/devicetypes/smartthings/ge-zigbee-switch.src/ge-zigbee-switch.groovy
@@ -26,8 +26,6 @@ metadata {
 		capability "Actuator"
 		capability "Sensor"
 
-		fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0B05,0702", outClusters: "0003, 000A,0019", manufacturer: "Jasco Products", model: "45853"
-		fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0B05,0702", outClusters: "000A,0019", manufacturer: "Jasco Products", model: "45856"
 	}
 
 	// simulator metadata

--- a/devicetypes/smartthings/sylvania-ultra-iq.src/sylvania-ultra-iq.groovy
+++ b/devicetypes/smartthings/sylvania-ultra-iq.src/sylvania-ultra-iq.groovy
@@ -11,6 +11,9 @@
  *  for the specific language governing permissions and limitations under the License.
  *
  */
+
+//DEPRECATED - Using the generic DTH for this device. Users need to be moved before deleting this DTH
+
 metadata {
 	definition (name: "Sylvania Ultra iQ", namespace:"smartthings", author: "SmartThings") {
 		capability "Switch Level"

--- a/devicetypes/smartthings/wemo-bulb.src/wemo-bulb.groovy
+++ b/devicetypes/smartthings/wemo-bulb.src/wemo-bulb.groovy
@@ -15,6 +15,8 @@
  *  Thanks to Chad Monroe @cmonroe and Patrick Stuart @pstuart
  *
  */
+//DEPRECATED - Using the generic DTH for this device. Users need to be moved before deleting this DTH
+
 metadata {
 	definition (name: "WeMo Bulb", namespace: "smartthings", author: "SmartThings") {
 	
@@ -25,7 +27,6 @@ metadata {
         capability "Switch"
 		capability "Switch Level"
 
-		fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0008,FF00", outClusters: "0019"
 	}
 
 	// simulator metadata

--- a/devicetypes/smartthings/zigbee-dimmer-power.src/zigbee-dimmer-power.groovy
+++ b/devicetypes/smartthings/zigbee-dimmer-power.src/zigbee-dimmer-power.groovy
@@ -25,6 +25,8 @@ metadata {
         fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 0B04"
         fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 0702"
         fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 0702, 0B05", outClusters: "0019", manufacturer: "sengled", model: "Z01-CIA19NAE26", deviceJoinName: "Sengled Element touch"
+        fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0008,0B05,0702", outClusters: "000A,0019", manufacturer: "Jasco Products", model: "45852", deviceJoinName: "GE Zigbee Plug-In Dimmer"
+        fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0008,0B05,0702", outClusters: "000A,0019", manufacturer: "Jasco Products", model: "45857", deviceJoinName: "GE Zigbee In-Wall Dimmer"
     }
 
     tiles(scale: 2) {

--- a/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
@@ -24,6 +24,8 @@ metadata {
 
         fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0008"
         fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 0B04, FC0F", outClusters: "0019", manufacturer: "OSRAM", model: "LIGHTIFY A19 ON/OFF/DIM", deviceJoinName: "OSRAM LIGHTIFY LED Smart Connected Light"
+        fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0008,FF00", outClusters: "0019", manufacturer: "MRVL", model: "MZ100", deviceJoinName: "Wemo Bulb"
+        fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0008,0B05", outClusters: "0019", manufacturer: "OSRAM SYLVANIA", model: "iQBR30", deviceJoinName: "Sylvania Ultra iQ"
     }
 
     tiles(scale: 2) {

--- a/devicetypes/smartthings/zigbee-switch-power.src/zigbee-switch-power.groovy
+++ b/devicetypes/smartthings/zigbee-switch-power.src/zigbee-switch-power.groovy
@@ -23,6 +23,8 @@ metadata {
 
         fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0B04"
         fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0702"
+        fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0B05,0702", outClusters: "0003, 000A,0019", manufacturer: "Jasco Products", model: "45853", deviceJoinName: "GE ZigBee Plug-In Switch"
+        fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0B05,0702", outClusters: "000A,0019", manufacturer: "Jasco Products", model: "45856", deviceJoinName: "GE ZigBee In-Wall Switch"
     }
 
     tiles(scale: 2) {


### PR DESCRIPTION
@tpmanley @dkirker 

GE Link now has the full fingerprint so that it is not considered for generic devices.
