### PR TITLE
DVCSMP-1262 Fix reference to Life360 User child device type

### DIFF
--- a/smartapps/smartthings/life360-connect.src/life360-connect.groovy
+++ b/smartapps/smartthings/life360-connect.src/life360-connect.groovy
@@ -592,7 +592,7 @@ def updated() {
         	// log.debug "External Id=${app.id}:${member.id}"
        
        		// create the device
-       		def childDevice = addChildDevice("smartthings", "life360-user", "${app.id}.${member.id}",null,[name:member.firstName, completedSetup: true])
+       		def childDevice = addChildDevice("smartthings", "Life360 User", "${app.id}.${member.id}",null,[name:member.firstName, completedSetup: true])
             // childDevice.setMemberId(member.id)
         
         	if (childDevice)


### PR DESCRIPTION
Fixes an issue where it attempts to create a child device on updating the Life360 (Connect) app.

```
Caught physicalgraph.app.exception.UnknownDeviceTypeException trying to execute block. Error message: Device type 'life360-user' in namespace 'smartthings' not found.
physicalgraph.app.exception.UnknownDeviceTypeException: Device type 'life360-user' in namespace 'smartthings' not found.
```
