### PR TITLE
PROB-398 Fix Homeseer Multi Instance encap parse

### DIFF
--- a/devicetypes/smartthings/homeseer-multisensor.src/homeseer-multisensor.groovy
+++ b/devicetypes/smartthings/homeseer-multisensor.src/homeseer-multisensor.groovy
@@ -80,19 +80,12 @@ def parse(String description) {
 	if (cmd) {
 		result = zwaveEvent(cmd)
 	}
-	// log.debug "Parsed ${description.inspect()} to ${result.inspect()}"
+	log.debug "Parsed ${description.inspect()} to ${result.inspect()}"
 	return result
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.multiinstancev1.MultiInstanceCmdEncap cmd) {
-	def encapsulated = null
-	if (cmd.respondsTo("encapsulatedCommand")) {
-		encapsulated = cmd.encapsulatedCommand()
-	} else {
-		def hex1 = { n -> String.format("%02X", n) }
-		def sorry = "command: ${hex1(cmd.commandClass)}${hex1(cmd.command)}, payload: " + cmd.parameter.collect{ hex1(it) }.join(" ")
-		encapsulated = zwave.parse(sorry, [0x31: 1, 0x84: 2, 0x60: 1, 0x85: 1, 0x70: 1])
-	}
+	def encapsulated = cmd.encapsulatedCommand([0x31: 1, 0x84: 2, 0x60: 1, 0x85: 1, 0x70: 1])
 	return encapsulated ? zwaveEvent(encapsulated) : null
 }
 


### PR DESCRIPTION
The call to cmd.encapsulatedCommand wasn't specifying the command class versions to use, which was breaking Lux and Temperature events.
