### PR TITLE
Ecobee: retries to get refresh tokens if exceptions are caught 

### DIFF
--- a/devicetypes/smartthings/ecobee-thermostat.src/ecobee-thermostat.groovy
+++ b/devicetypes/smartthings/ecobee-thermostat.src/ecobee-thermostat.groovy
@@ -99,7 +99,7 @@ metadata {
 	}
 
 	preferences {
-		input "holdType", "enum", title: "Hold Type", description: "When changing temperature, use Temporary or Permanent hold", required: false, options:["Temporary", "Permanent"]
+		input "holdType", "enum", title: "Hold Type", description: "When changing temperature, use Temporary or Permanent hold (default)", required: false, options:["Temporary", "Permanent"]
 	}
 
 }


### PR DESCRIPTION
@juano2310 Can you review this PR?

In this change, before sending push and notification message to user to re-login to their Ecobee account, the service manager will make attempts 3 times each at every 5 minutes to get the access token using the stored refresh token (expire within one year). 

For the thermostat DTH, i just added (default) to holdType option so that users know which option is the default if they don't provide input. 
