### PR TITLE
multi: Fix invalid accelerometer readings during refresh

### DIFF
--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -384,20 +384,8 @@ def getTemperature(value) {
 
         "zcl mfg-code ${manufacturerCode}", "delay 200",
         "zcl global read 0xFC02 0x0010",
-        "send 0x${device.deviceNetworkId} 1 1","delay 400",
-        
-        "zcl mfg-code ${manufacturerCode}", "delay 200",
-        "zcl global read 0xFC02 0x0012",
-        "send 0x${device.deviceNetworkId} 1 1","delay 400",
-        
-        "zcl mfg-code ${manufacturerCode}", "delay 200",
-        "zcl global read 0xFC02 0x0013",
-        "send 0x${device.deviceNetworkId} 1 1","delay 400",
-        
-        "zcl mfg-code ${manufacturerCode}", "delay 200",
-        "zcl global read 0xFC02 0x0014",
-        "send 0x${device.deviceNetworkId} 1 1", "delay 400"
-		]
+        "send 0x${device.deviceNetworkId} 1 1","delay 400"
+	]
 
 		return refreshCmds + enrollResponse()
 	}


### PR DESCRIPTION
The code can only correctly handle the accelerometer readings when they
are all received in the same message. Individual reads of the attributes
results in individual read attribute responses which led to events with
incorrect values. The most straightforward fix is to not read the attributes
in the first place and rely on attribute reporting to report the values
at the appropriate time.

Resolves:
https://smartthings.atlassian.net/browse/DVCSMP-1315
