### PR TITLE
Make sure we persist the updated eventBuffer with the new event added back to atomicState

### DIFF
--- a/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
+++ b/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
@@ -349,6 +349,9 @@ def eventHandler(name, value) {
 		// from growing unbounded.
 		atomicState.eventBuffer = []
 		tryShipEvents(eventBuffer)
+	} else {
+		// Make sure we persist the updated eventBuffer with the new event added back to atomicState
+		atomicState.eventBuffer = eventBuffer
 	}
 	log.debug "Event added to buffer: " + eventBuffer
 }


### PR DESCRIPTION
This got missed on the last PR, but making sure to update the eventBuffer with the newly added event back to atomicState.

/cc @kris-schaller 
