### PR TITLE
Fix logic for toggling off heat/cool when using a remote sensor

### DIFF
--- a/smartapps/smartthings/keep-me-cozy-ii.src/keep-me-cozy-ii.groovy
+++ b/smartapps/smartthings/keep-me-cozy-ii.src/keep-me-cozy-ii.groovy
@@ -79,7 +79,7 @@ private evaluate()
 {
 	if (sensor) {
 		def threshold = 1.0
-        def offset = 2.0
+		def offset = 2.0
 		def tm = thermostat.currentThermostatMode
 		def ct = thermostat.currentTemperature
 		def currentTemp = sensor.currentTemperature

--- a/smartapps/smartthings/keep-me-cozy-ii.src/keep-me-cozy-ii.groovy
+++ b/smartapps/smartthings/keep-me-cozy-ii.src/keep-me-cozy-ii.groovy
@@ -91,7 +91,7 @@ private evaluate()
 				thermostat.setCoolingSetpoint(ct - offset)
 				log.debug "thermostat.setCoolingSetpoint(${ct - offset}), ON"
 			}
-			else if (coolingSetpoint - currentTemp >= threshold && ct - thermostat.currentCoolingSetpoint < offset) {
+			else if (coolingSetpoint - currentTemp >= threshold && ct - thermostat.currentCoolingSetpoint <= offset) {
 				thermostat.setCoolingSetpoint(ct + offset)
 				log.debug "thermostat.setCoolingSetpoint(${ct + offset}), OFF"
 			}
@@ -102,7 +102,7 @@ private evaluate()
 				thermostat.setHeatingSetpoint(ct + offset)
 				log.debug "thermostat.setHeatingSetpoint(${ct + offset}), ON"
 			}
-			else if (currentTemp - heatingSetpoint >= threshold && thermostat.currentHeatingSetpoint - ct < offset) {
+			else if (currentTemp - heatingSetpoint >= threshold && thermostat.currentHeatingSetpoint - ct <= offset) {
 				thermostat.setHeatingSetpoint(ct - offset)
 				log.debug "thermostat.setHeatingSetpoint(${ct - offset}), OFF"
 			}

--- a/smartapps/smartthings/keep-me-cozy-ii.src/keep-me-cozy-ii.groovy
+++ b/smartapps/smartthings/keep-me-cozy-ii.src/keep-me-cozy-ii.groovy
@@ -79,6 +79,7 @@ private evaluate()
 {
 	if (sensor) {
 		def threshold = 1.0
+        def offset = 2.0
 		def tm = thermostat.currentThermostatMode
 		def ct = thermostat.currentTemperature
 		def currentTemp = sensor.currentTemperature
@@ -87,23 +88,23 @@ private evaluate()
 		if (tm in ["cool","auto"]) {
 			// air conditioner
 			if (currentTemp - coolingSetpoint >= threshold) {
-				thermostat.setCoolingSetpoint(ct - 2)
-				log.debug "thermostat.setCoolingSetpoint(${ct - 2}), ON"
+				thermostat.setCoolingSetpoint(ct - offset)
+				log.debug "thermostat.setCoolingSetpoint(${ct - offset}), ON"
 			}
-			else if (coolingSetpoint - currentTemp >= threshold && ct - thermostat.currentCoolingSetpoint >= threshold) {
-				thermostat.setCoolingSetpoint(ct + 2)
-				log.debug "thermostat.setCoolingSetpoint(${ct + 2}), OFF"
+			else if (coolingSetpoint - currentTemp >= threshold && ct - thermostat.currentCoolingSetpoint < offset) {
+				thermostat.setCoolingSetpoint(ct + offset)
+				log.debug "thermostat.setCoolingSetpoint(${ct + offset}), OFF"
 			}
 		}
 		if (tm in ["heat","emergency heat","auto"]) {
 			// heater
 			if (heatingSetpoint - currentTemp >= threshold) {
-				thermostat.setHeatingSetpoint(ct + 2)
-				log.debug "thermostat.setHeatingSetpoint(${ct + 2}), ON"
+				thermostat.setHeatingSetpoint(ct + offset)
+				log.debug "thermostat.setHeatingSetpoint(${ct + offset}), ON"
 			}
-			else if (currentTemp - heatingSetpoint >= threshold && thermostat.currentHeatingSetpoint - ct >= threshold) {
-				thermostat.setHeatingSetpoint(ct - 2)
-				log.debug "thermostat.setHeatingSetpoint(${ct - 2}), OFF"
+			else if (currentTemp - heatingSetpoint >= threshold && thermostat.currentHeatingSetpoint - ct < offset) {
+				thermostat.setHeatingSetpoint(ct - offset)
+				log.debug "thermostat.setHeatingSetpoint(${ct - offset}), OFF"
 			}
 		}
 	}


### PR DESCRIPTION
When toggling heat/cool off via setHeatingSetpoint/setCoolingSetpoint the goal should be to maintain a difference equal to the offset that is applied (+/- 2).  Because of the potential discrepancy between the remote sensor temperature and the thermostat temperature the existing logic can result excessive heating/cooling.  For example

HeatingSetpoint = 68
SensorTemperature = 69

ThermostatSetpoint = 71
ThermostatTemperature = 70.5

Since the remote sensor is reporting a temperature greater than the setpoint heating should be turned off.  However if you apply the existing logic:

SensorTemperature - HeatingSetpoint >= 1.0 && ThermostatSetpoint - ThermostatTemperature >= 1.0

You get:

70 - 68 >= 1.0 && 71 - 70.5 >= 1.0

Which doesn't evaluate to True, thus heating isn't turned off until the thermostat temperature rises, which may never happen depending upon its location relative to the remote sensor.  In my case these are on different floors.  My change makes sure that once the remote sensor has reached the appropriate setpoint the thermostat setpoint will always maintain a consistent offset relative to the thermostat's current temperature.
