### PR TITLE
arrival: Keep 'read attr' messages from being turned into events

### DIFF
--- a/devicetypes/smartthings/arrival-sensor-ha.src/arrival-sensor-ha.groovy
+++ b/devicetypes/smartthings/arrival-sensor-ha.src/arrival-sensor-ha.groovy
@@ -76,6 +76,8 @@ def parse(String description) {
     if (description?.startsWith('read attr -')) {
         handleReportAttributeMessage(description)
     }
+
+    return []
 }
 
 private handleReportAttributeMessage(String description) {


### PR DESCRIPTION
Previously parse was returning null which causes the platform to create an event
using the message passed to parse. We don't want that to happen so return
an empty list instead.

Resolves:
    https://smartthings.atlassian.net/browse/SMJN-38
