### PR TITLE
Correct departed logging on Simulated Presence

### DIFF
--- a/devicetypes/smartthings/testing/simulated-presence-sensor.src/simulated-presence-sensor.groovy
+++ b/devicetypes/smartthings/testing/simulated-presence-sensor.src/simulated-presence-sensor.groovy
@@ -48,6 +48,6 @@ def arrived() {
 
 
 def departed() {
-	log.trace "Executing 'arrived'"
+	log.trace "Executing 'departed'"
 	sendEvent(name: "presence", value: "not present")
 }


### PR DESCRIPTION
`departed()` would log that it was `Executing 'arrived'` when it was actually `Executing 'departed'` -- corrected in this version
