### PR TITLE
multi: Fix occasional failures in sending ZigBee commands during configure

### DIFF
--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -441,28 +441,28 @@ def configure() {
 		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 500",
 
 		"zdo bind 0x${device.deviceNetworkId} ${endpointId} 1 1 {${device.zigbeeId}} {}", "delay 200",
-		"zcl global send-me-a-report 1 0x20 0x20 30 21600 {01}",		//checkin time 6 hrs
+		"zcl global send-me-a-report 1 0x20 0x20 30 21600 {01}", "delay 200",		//checkin time 6 hrs
 		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 500",
 
 		"zdo bind 0x${device.deviceNetworkId} ${endpointId} 1 0x402 {${device.zigbeeId}} {}", "delay 200",
-		"zcl global send-me-a-report 0x402 0 0x29 30 3600 {6400}",
+		"zcl global send-me-a-report 0x402 0 0x29 30 3600 {6400}", "delay 200",
 		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 500",
 
 		"zdo bind 0x${device.deviceNetworkId} ${endpointId} 1 0xFC02 {${device.zigbeeId}} {}", "delay 200",
-		"zcl mfg-code ${manufacturerCode}",
-		"zcl global send-me-a-report 0xFC02 0x0010 0x18 10 3600 {01}",
+		"zcl mfg-code ${manufacturerCode}", "delay 200",
+		"zcl global send-me-a-report 0xFC02 0x0010 0x18 10 3600 {01}", "delay 200",
 		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 500",
 
-		"zcl mfg-code ${manufacturerCode}",
-		"zcl global send-me-a-report 0xFC02 0x0012 0x29 1 3600 {01}",
+		"zcl mfg-code ${manufacturerCode}", "delay 200",
+		"zcl global send-me-a-report 0xFC02 0x0012 0x29 1 3600 {01}", "delay 200",
 		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 500",
 
-		"zcl mfg-code ${manufacturerCode}",
-		"zcl global send-me-a-report 0xFC02 0x0013 0x29 1 3600 {01}",
+		"zcl mfg-code ${manufacturerCode}", "delay 200",
+		"zcl global send-me-a-report 0xFC02 0x0013 0x29 1 3600 {01}", "delay 200",
 		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 500",
 
-		"zcl mfg-code ${manufacturerCode}",
-		"zcl global send-me-a-report 0xFC02 0x0014 0x29 1 3600 {01}",
+		"zcl mfg-code ${manufacturerCode}", "delay 200",
+		"zcl global send-me-a-report 0xFC02 0x0014 0x29 1 3600 {01}", "delay 200",
 		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 500"
 		]
 
@@ -481,7 +481,7 @@ def enrollResponse() {
 		"zcl global write 0x500 0x10 0xf0 {${zigbeeEui}}", "delay 200",
 		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 500",
 		//Enroll Response
-		"raw 0x500 {01 23 00 00 00}",
+		"raw 0x500 {01 23 00 00 00}", "delay 200",
 		"send 0x${device.deviceNetworkId} 1 1", "delay 200"
 	]
 }


### PR DESCRIPTION
The missing delay after some of the commands was sometimes causing the
ZigBee command to fail.

Resolves:
    https://smartthings.atlassian.net/browse/DVCSMP-1225
