### PR TITLE
Bugfixes for codeReports and AlarmReport

### DIFF
--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -275,6 +275,7 @@ def zwaveEvent(physicalgraph.zwave.commands.alarmv2.AlarmReport cmd) {
 		case 32:
 			map = [ name: "codeChanged", value: "all", descriptionText: "$device.displayName: all user codes deleted", isStateChange: true ]
 			allCodesDeleted()
+			break
 		case 33:
 			map = [ name: "codeReport", value: cmd.alarmLevel, data: [ code: "" ], isStateChange: true ]
 			map.descriptionText = "$device.displayName code $cmd.alarmLevel was deleted"
@@ -341,14 +342,14 @@ def zwaveEvent(UserCodeReport cmd) {
 			map = [ name: "codeReport", value: cmd.userIdentifier, data: [ code: code ] ]
 			map.descriptionText = "$device.displayName code $cmd.userIdentifier is set"
 			map.displayed = (cmd.userIdentifier != state.requestCode && cmd.userIdentifier != state.pollCode)
-			map.isStateChange = (code != decrypt(state[name]))
+			map.isStateChange = true
 		}
 		result << createEvent(map)
 	} else {
 		map = [ name: "codeReport", value: cmd.userIdentifier, data: [ code: "" ] ]
 		if (state.blankcodes && state["reset$name"]) {  // we deleted this code so we can tell that our new code gets set
 			map.descriptionText = "$device.displayName code $cmd.userIdentifier was reset"
-			map.displayed = map.isStateChange = false
+			map.displayed = map.isStateChange = true
 			result << createEvent(map)
 			state["set$name"] = state["reset$name"]
 			result << response(setCode(cmd.userIdentifier, state["reset$name"]))
@@ -360,7 +361,7 @@ def zwaveEvent(UserCodeReport cmd) {
 				map.descriptionText = "$device.displayName code $cmd.userIdentifier is not set"
 			}
 			map.displayed = (cmd.userIdentifier != state.requestCode && cmd.userIdentifier != state.pollCode)
-			map.isStateChange = state[name] as Boolean
+			map.isStateChange = true
 			result << createEvent(map)
 		}
 		code = ""


### PR DESCRIPTION
1. Missing break in case 32 for AlarmReport
2. Bugfix - Not reporting all codes programmed into the lock causing SmartApps to fail while awaiting a codeReport notification (once a code is programmed into a lock it should be notified because there is no way to read back codes from the lock, apps awaiting a codeReport will go into an infinite programming loop to trying to update the codes and awaiting a codeReport notification indicating a successful programming)
