### PR TITLE
Update bose-soundtouch.groovy

### DIFF
--- a/devicetypes/smartthings/bose-soundtouch.src/bose-soundtouch.groovy
+++ b/devicetypes/smartthings/bose-soundtouch.src/bose-soundtouch.groovy
@@ -28,6 +28,7 @@ metadata {
         capability "Refresh"
         capability "Music Player"
         capability "Polling"
+        capability "Actuator"
 
         /**
          * Define all commands, ie, if you have a custom action not


### PR DESCRIPTION
add capability actuator to enable use with RuleMachine Expert features (e.g., select presets)
