### PR TITLE
Fixed ArrayIndexOutOfBoundsException

### DIFF
--- a/smartapps/smartthings/samsung-tv-connect.src/samsung-tv-connect.groovy
+++ b/smartapps/smartthings/samsung-tv-connect.src/samsung-tv-connect.groovy
@@ -316,60 +316,40 @@ private def parseEventMessage(String description) {
 	parts.each { part ->
 		part = part.trim()
 		if (part.startsWith('devicetype:')) {
-			def valueString = part.split(":")[1].trim()
-			event.devicetype = valueString
+			part -= "devicetype:"
+			event.devicetype = part.trim()
 		}
 		else if (part.startsWith('mac:')) {
-			def valueString = part.split(":")[1].trim()
-			if (valueString) {
-				event.mac = valueString
-			}
+			part -= "mac:"
+			event.mac = part.trim()
 		}
 		else if (part.startsWith('networkAddress:')) {
-			def valueString = part.split(":")[1].trim()
-			if (valueString) {
-				event.ip = valueString
-			}
+			part -= "networkAddress:"
+			event.ip = part.trim()
 		}
 		else if (part.startsWith('deviceAddress:')) {
-			def valueString = part.split(":")[1].trim()
-			if (valueString) {
-				event.port = valueString
-			}
+			part -= "deviceAddress:"
+			event.port = part.trim()
 		}
 		else if (part.startsWith('ssdpPath:')) {
-			def valueString = part.split(":")[1].trim()
-			if (valueString) {
-				event.ssdpPath = valueString
-			}
+			part -= "ssdpPath:"
+			event.ssdpPath = part.trim()
 		}
 		else if (part.startsWith('ssdpUSN:')) {
 			part -= "ssdpUSN:"
-			def valueString = part.trim()
-			if (valueString) {
-				event.ssdpUSN = valueString
-			}
+			event.ssdpUSN = part.trim()
 		}
 		else if (part.startsWith('ssdpTerm:')) {
 			part -= "ssdpTerm:"
-			def valueString = part.trim()
-			if (valueString) {
-				event.ssdpTerm = valueString
-			}
+			event.ssdpTerm = part.trim()
 		}
 		else if (part.startsWith('headers')) {
 			part -= "headers:"
-			def valueString = part.trim()
-			if (valueString) {
-				event.headers = valueString
-			}
+			event.headers = part.trim()
 		}
 		else if (part.startsWith('body')) {
 			part -= "body:"
-			def valueString = part.trim()
-			if (valueString) {
-				event.body = valueString
-			}
+			event.body = part.trim()
 		}
 	}
 	event

--- a/smartapps/smartthings/wemo-connect.src/wemo-connect.groovy
+++ b/smartapps/smartthings/wemo-connect.src/wemo-connect.groovy
@@ -473,68 +473,48 @@ private def parseXmlBody(def body) {
 }
 
 private def parseDiscoveryMessage(String description) {
-	def device = [:]
+	def event = [:]
 	def parts = description.split(',')
 	parts.each { part ->
 		part = part.trim()
 		if (part.startsWith('devicetype:')) {
-			def valueString = part.split(":")[1].trim()
-			device.devicetype = valueString
+			part -= "devicetype:"
+			event.devicetype = part.trim()
 		}
 		else if (part.startsWith('mac:')) {
-			def valueString = part.split(":")[1].trim()
-			if (valueString) {
-				device.mac = valueString
-			}
+			part -= "mac:"
+			event.mac = part.trim()
 		}
 		else if (part.startsWith('networkAddress:')) {
-			def valueString = part.split(":")[1].trim()
-			if (valueString) {
-				device.ip = valueString
-			}
+			part -= "networkAddress:"
+			event.ip = part.trim()
 		}
 		else if (part.startsWith('deviceAddress:')) {
-			def valueString = part.split(":")[1].trim()
-			if (valueString) {
-				device.port = valueString
-			}
+			part -= "deviceAddress:"
+			event.port = part.trim()
 		}
 		else if (part.startsWith('ssdpPath:')) {
-			def valueString = part.split(":")[1].trim()
-			if (valueString) {
-				device.ssdpPath = valueString
-			}
+			part -= "ssdpPath:"
+			event.ssdpPath = part.trim()
 		}
 		else if (part.startsWith('ssdpUSN:')) {
 			part -= "ssdpUSN:"
-			def valueString = part.trim()
-			if (valueString) {
-				device.ssdpUSN = valueString
-			}
+			event.ssdpUSN = part.trim()
 		}
 		else if (part.startsWith('ssdpTerm:')) {
 			part -= "ssdpTerm:"
-			def valueString = part.trim()
-			if (valueString) {
-				device.ssdpTerm = valueString
-			}
+			event.ssdpTerm = part.trim()
 		}
 		else if (part.startsWith('headers')) {
 			part -= "headers:"
-			def valueString = part.trim()
-			if (valueString) {
-				device.headers = valueString
-			}
+			event.headers = part.trim()
 		}
 		else if (part.startsWith('body')) {
 			part -= "body:"
-			def valueString = part.trim()
-			if (valueString) {
-				device.body = valueString
-			}
+			event.body = part.trim()
 		}
 	}
-	device
+	event
 }
 
 def doDeviceSync(){


### PR DESCRIPTION
Fixed ArrayIndexOutOfBoundsException from events that lack values to some fields.

We are seeing around 500k ArrayIndexOutOfBounds exceptions from a number of the different XXXX (Connect) SmartApps that control LAN devices. The reason is that events are received that are missing values for certain fields and that causes an exception when a non existing value is getting accessed.

Below is an example that would cause an exception when parsing the "ssdpPath:" field (.split(":")[1] fails)

devicetype:04, mac:00166C8C6901, networkAddress:00000000, deviceAddress:0000, stringCount:04, ssdpPath:, ssdpUSN:uuid:Upnp-BasicDevice-1_0-00166C8C6901::upnp:rootdevice, ssdpTerm:, ssdpNTS:ssdp:aliv

This is a fix to that problem.
