### PR TITLE
remove segmented style input to prevent iOS crash

### DIFF
--- a/smartapps/smartthings/gentle-wake-up.src/gentle-wake-up.groovy
+++ b/smartapps/smartthings/gentle-wake-up.src/gentle-wake-up.groovy
@@ -201,8 +201,8 @@ def completionPage() {
 
 		section("Switches") {
 			input(name: "completionSwitches", type: "capability.switch", title: "Set these switches", description: null, required: false, multiple: true, submitOnChange: true)
-			if (completionSwitches || androidClient()) {
-				input(name: "completionSwitchesState", type: "enum", title: "To", description: null, required: false, multiple: false, options: ["on", "off"], style: "segmented", defaultValue: "on")
+			if (completionSwitches) {
+				input(name: "completionSwitchesState", type: "enum", title: "To", description: null, required: false, multiple: false, options: ["on", "off"], defaultValue: "on")
 				input(name: "completionSwitchesLevel", type: "number", title: "Optionally, Set Dimmer Levels To", description: null, required: false, multiple: false, range: "(0..99)")
 			}
 		}


### PR DESCRIPTION
The iOS app is currently crashing when an `input` specifies `style: "segmented"`. This removes the segmented style and I will add it back once the iOS crash has been fixed. 

It also removes the unnecessary `androidClient` check since that was added way back before the Android app supported `submitOnChange`.This has nothing to do with the fix, but I saw it and couldn't stop myself from deleting it. ¯_(ツ)_/¯
