### PR TITLE
PROB-870 - Harmony fails to save credentials

### DIFF
--- a/smartapps/smartthings/logitech-harmony-connect.src/logitech-harmony-connect.groovy
+++ b/smartapps/smartthings/logitech-harmony-connect.src/logitech-harmony-connect.groovy
@@ -419,9 +419,11 @@ def addDevice() {
         def d = getChildDevice(dni)
         if(!d) {
             def newAction = state.HarmonyActivities.find { it.key == dni }
-            d = addChildDevice("smartthings", "Harmony Activity", dni, null, [label:"${newAction.value} [Harmony Activity]"])
-            log.trace "created ${d.displayName} with id $dni"
-            poll()
+            if (newAction) {
+	            d = addChildDevice("smartthings", "Harmony Activity", dni, null, [label:"${newAction.value} [Harmony Activity]"])
+	            log.trace "created ${d.displayName} with id $dni"
+	            poll()
+            }
         } else {
             log.trace "found ${d.displayName} with id $dni already exists"
         }


### PR DESCRIPTION
It seams like the user removed some activities on Harmony side without removing them from SmartThings. This is causing an issue when adding new activities. This fix checks if the activity still exists before creating a new device.

@Yaima 
