### PR TITLE
DEVC-246: DEVC-246 "Enerwave motion doesn't always get the associationSet that the hub sends on join"

### DIFF
--- a/devicetypes/smartthings/zwave-motion-sensor.src/zwave-motion-sensor.groovy
+++ b/devicetypes/smartthings/zwave-motion-sensor.src/zwave-motion-sensor.groovy
@@ -119,6 +119,10 @@ def zwaveEvent(physicalgraph.zwave.commands.notificationv3.NotificationReport cm
 def zwaveEvent(physicalgraph.zwave.commands.wakeupv1.WakeUpNotification cmd)
 {
 	def result = [createEvent(descriptionText: "${device.displayName} woke up", isStateChange: false)]
+
+	if (msr == "011A-0601-0901") {  // Enerwave motion doesn't always get the associationSet that the hub sends on join
+		result << response(zwave.associationV1.associationSet(groupingIdentifier:1, nodeId:zwaveHubNodeId))
+	}
 	if (!state.lastbat || (new Date().time) - state.lastbat > 53*60*60*1000) {
 		result << response(zwave.batteryV1.batteryGet())
 		result << response("delay 1200")

--- a/devicetypes/smartthings/zwave-motion-sensor.src/zwave-motion-sensor.groovy
+++ b/devicetypes/smartthings/zwave-motion-sensor.src/zwave-motion-sensor.groovy
@@ -120,7 +120,7 @@ def zwaveEvent(physicalgraph.zwave.commands.wakeupv1.WakeUpNotification cmd)
 {
 	def result = [createEvent(descriptionText: "${device.displayName} woke up", isStateChange: false)]
 
-	if (msr == "011A-0601-0901") {  // Enerwave motion doesn't always get the associationSet that the hub sends on join
+	if (state.MSR == "011A-0601-0901" && device.currentState('motion') == null) {  // Enerwave motion doesn't always get the associationSet that the hub sends on join
 		result << response(zwave.associationV1.associationSet(groupingIdentifier:1, nodeId:zwaveHubNodeId))
 	}
 	if (!state.lastbat || (new Date().time) - state.lastbat > 53*60*60*1000) {


### PR DESCRIPTION
Submitting 'DEVC-246 "Enerwave motion doesn't always get the associationSet that the hub sends on join"' for publication
