### PR TITLE
Fix First Alert smoke alarm check-in handling

### DIFF
--- a/devicetypes/smartthings/zwave-smoke-alarm.src/zwave-smoke-alarm.groovy
+++ b/devicetypes/smartthings/zwave-smoke-alarm.src/zwave-smoke-alarm.groovy
@@ -61,37 +61,44 @@ def parse(String description) {
 			zwaveEvent(cmd, results)
 		}
 	}
-	// log.debug "\"$description\" parsed to ${results.inspect()}"
+	log.debug "'$description' parsed to ${results.inspect()}"
 	return results
 }
 
 
 def createSmokeOrCOEvents(name, results) {
 	def text = null
-	if (name == "smoke") {
-		text = "$device.displayName smoke was detected!"
-		// these are displayed:false because the composite event is the one we want to see in the app
-		results << createEvent(name: "smoke",          value: "detected", descriptionText: text, displayed: false)
-	} else if (name == "carbonMonoxide") {
-		text = "$device.displayName carbon monoxide was detected!"
-		results << createEvent(name: "carbonMonoxide", value: "detected", descriptionText: text, displayed: false)
-	} else if (name == "tested") {
-		text = "$device.displayName was tested"
-		results << createEvent(name: "smoke",          value: "tested", descriptionText: text, displayed: false)
-		results << createEvent(name: "carbonMonoxide", value: "tested", descriptionText: text, displayed: false)
-	} else if (name == "smokeClear") {
-		text = "$device.displayName smoke is clear"
-		results << createEvent(name: "smoke",          value: "clear", descriptionText: text, displayed: false)
-		name = "clear"
-	} else if (name == "carbonMonoxideClear") {
-		text = "$device.displayName carbon monoxide is clear"
-		results << createEvent(name: "carbonMonoxide", value: "clear", descriptionText: text, displayed: false)
-		name = "clear"
-	} else if (name == "testClear") {
-		text = "$device.displayName smoke is clear"
-		results << createEvent(name: "smoke",          value: "clear", descriptionText: text, displayed: false)
-		results << createEvent(name: "carbonMonoxide", value: "clear", displayed: false)
-		name = "clear"
+	switch (name) {
+		case "smoke":
+			text = "$device.displayName smoke was detected!"
+			// these are displayed:false because the composite event is the one we want to see in the app
+			results << createEvent(name: "smoke",          value: "detected", descriptionText: text, displayed: false)
+			break
+		case "carbonMonoxide":
+			text = "$device.displayName carbon monoxide was detected!"
+			results << createEvent(name: "carbonMonoxide", value: "detected", descriptionText: text, displayed: false)
+			break
+		case "tested":
+			text = "$device.displayName was tested"
+			results << createEvent(name: "smoke",          value: "tested", descriptionText: text, displayed: false)
+			results << createEvent(name: "carbonMonoxide", value: "tested", descriptionText: text, displayed: false)
+			break
+		case "smokeClear":
+			text = "$device.displayName smoke is clear"
+			results << createEvent(name: "smoke",          value: "clear", descriptionText: text, displayed: false)
+			name = "clear"
+			break
+		case "carbonMonoxideClear":
+			text = "$device.displayName carbon monoxide is clear"
+			results << createEvent(name: "carbonMonoxide", value: "clear", descriptionText: text, displayed: false)
+			name = "clear"
+			break
+		case "testClear":
+			text = "$device.displayName test cleared"
+			results << createEvent(name: "smoke",          value: "clear", descriptionText: text, displayed: false)
+			results << createEvent(name: "carbonMonoxide", value: "clear", displayed: false)
+			name = "clear"
+			break
 	}
 	// This composite event is used for updating the tile
 	results << createEvent(name: "alarmState", value: name, descriptionText: text)
@@ -117,8 +124,10 @@ def zwaveEvent(physicalgraph.zwave.commands.alarmv2.AlarmReport cmd, results) {
 			createSmokeOrCOEvents(cmd.alarmLevel ? "tested" : "testClear", results)
 			break
 		case 13:  // sent every hour -- not sure what this means, just a wake up notification?
-			if (cmd.alarmLevel != 255) {
-				results << createEvent(descriptionText: "$device.displayName code 13 is $cmd.alarmLevel", displayed: true)
+			if (cmd.alarmLevel == 255) {
+				results << createEvent(descriptionText: "$device.displayName checked in", isStateChange: false)
+			} else {
+				results << createEvent(descriptionText: "$device.displayName code 13 is $cmd.alarmLevel", isStateChange:true, displayed:false)
 			}
 			
 			// Clear smoke in case they pulled batteries and we missed the clear msg
@@ -127,9 +136,8 @@ def zwaveEvent(physicalgraph.zwave.commands.alarmv2.AlarmReport cmd, results) {
 			}
 			
 			// Check battery if we don't have a recent battery event
-			def prevBattery = device.currentState("battery")
-			if (!prevBattery || (new Date().time - prevBattery.date.time)/60000 >= 60 * 53) {
-				results << new physicalgraph.device.HubAction(zwave.batteryV1.batteryGet().format())
+			if (!state.lastbatt || (now() - state.lastbatt) >= 48*60*60*1000) {
+				results << response(zwave.batteryV1.batteryGet())
 			}
 			break
 		default:
@@ -158,12 +166,17 @@ def zwaveEvent(physicalgraph.zwave.commands.sensoralarmv1.SensorAlarmReport cmd,
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.wakeupv1.WakeUpNotification cmd, results) {
-	results << new physicalgraph.device.HubAction(zwave.wakeUpV1.wakeUpNoMoreInformation().format())
 	results << createEvent(descriptionText: "$device.displayName woke up", isStateChange: false)
+	if (!state.lastbatt || (now() - state.lastbatt) >= 56*60*60*1000) {
+		results << response(zwave.batteryV1.batteryGet(), "delay 2000", zwave.wakeUpV1.wakeUpNoMoreInformation())
+	} else {
+		results << response(zwave.wakeUpV1.wakeUpNoMoreInformation())
+	}
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.batteryv1.BatteryReport cmd, results) {
-	def map = [ name: "battery", unit: "%" ]
+	def map = [ name: "battery", unit: "%", isStateChange: true ]
+	state.lastbatt = now()
 	if (cmd.batteryLevel == 0xFF) {
 		map.value = 1
 		map.descriptionText = "$device.displayName battery is low!"


### PR DESCRIPTION
DEVFRWK-78
The Z-Wave Smoke Alarm handler hasn't been creating an event on the custom hourly check-in that the First Alert ZSMOKE and ZCOMBO send, so they're not showing the last activity time that they should be.

Also adds a battery read on wake-up in case we're not getting a response from the one sent after check-in, and sets all battery reports to isStateChange:true for peace of mind.
