### PR TITLE
Z-Wave Motion Sensor: fix MissingMethodException on NotificationReport

### DIFF
--- a/devicetypes/smartthings/zwave-motion-sensor.src/zwave-motion-sensor.groovy
+++ b/devicetypes/smartthings/zwave-motion-sensor.src/zwave-motion-sensor.groovy
@@ -57,7 +57,7 @@ def parse(String description) {
 	return result
 }
 
-def sensorValueEvent(Short value) {
+def sensorValueEvent(value) {
 	if (value) {
 		createEvent(name: "motion", value: "active", descriptionText: "$device.displayName detected motion")
 	} else {
@@ -94,24 +94,24 @@ def zwaveEvent(physicalgraph.zwave.commands.notificationv3.NotificationReport cm
 {
 	def result = []
 	if (cmd.notificationType == 0x07) {
-		if (cmd.event == 0x01 || cmd.event == 0x02) {
+		if (cmd.v1AlarmType == 0x07) {  // special case for nonstandard messages from Monoprice ensors
+			result << sensorValueEvent(cmd.v1AlarmLevel)
+		} else if (cmd.event == 0x01 || cmd.event == 0x02 || cmd.event == 0x07 || cmd.event == 0x08) {
 			result << sensorValueEvent(1)
+		} else if (cmd.event == 0x00) {
+			result << sensorValueEvent(0)
 		} else if (cmd.event == 0x03) {
-			result << createEvent(descriptionText: "$device.displayName covering was removed", isStateChange: true)
-			result << response(zwave.wakeUpV1.wakeUpIntervalSet(seconds:4*3600, nodeid:zwaveHubNodeId))
-			if(!state.MSR) result << response(zwave.manufacturerSpecificV2.manufacturerSpecificGet())
+			result << createEvent(name: "tamper", value: "detected", descriptionText: "$device.displayName covering was removed", isStateChange: true)
+			result << response(zwave.batteryV1.batteryGet())
 		} else if (cmd.event == 0x05 || cmd.event == 0x06) {
 			result << createEvent(descriptionText: "$device.displayName detected glass breakage", isStateChange: true)
-		} else if (cmd.event == 0x07) {
-			if(!state.MSR) result << response(zwave.manufacturerSpecificV2.manufacturerSpecificGet())
-			result << sensorValueEvent(1)
 		}
 	} else if (cmd.notificationType) {
 		def text = "Notification $cmd.notificationType: event ${([cmd.event] + cmd.eventParameter).join(", ")}"
-		result << createEvent(name: "notification$cmd.notificationType", value: "$cmd.event", descriptionText: text, displayed: false)
+		result << createEvent(name: "notification$cmd.notificationType", value: "$cmd.event", descriptionText: text, isStateChange: true, displayed: false)
 	} else {
 		def value = cmd.v1AlarmLevel == 255 ? "active" : cmd.v1AlarmLevel ?: "inactive"
-		result << createEvent(name: "alarm $cmd.v1AlarmType", value: value, displayed: false)
+		result << createEvent(name: "alarm $cmd.v1AlarmType", value: value, isStateChange: true, displayed: false)
 	}
 	result
 }


### PR DESCRIPTION
The sensorValueEvent method was defined as taking a Short for its argument but it was being called with a static int

Also fixes some of the NotificationReport handling.

DVCSMP-1438
