### PR TITLE
DVCSMP-1505 LIFX setColor() throws exception

### DIFF
--- a/devicetypes/smartthings/lifx-color-bulb.src/lifx-color-bulb.groovy
+++ b/devicetypes/smartthings/lifx-color-bulb.src/lifx-color-bulb.groovy
@@ -84,6 +84,7 @@ def setHue(percentage) {
 			log.error("Bad setHue result: [${resp.status}] ${resp.data}")
 		}
 	}
+	return []
 }
 
 def setSaturation(percentage) {
@@ -97,6 +98,7 @@ def setSaturation(percentage) {
 			log.error("Bad setSaturation result: [${resp.status}] ${resp.data}")
 		}
 	}
+	return []
 }
 
 def setColor(Map color) {
@@ -122,13 +124,15 @@ def setColor(Map color) {
 	parent.logErrors(logObject:log) {
 		def resp = parent.apiPUT("/lights/${selector()}/state", [color: attrs.join(" "), power: "on"])
 		if (resp.status < 300) {
-			sendEvent(name: "color", value: color.hex)
+			if (color.hex)
+				sendEvent(name: "color", value: color.hex)
 			sendEvent(name: "switch", value: "on")
 			events.each { sendEvent(it) }
 		} else {
 			log.error("Bad setColor result: [${resp.status}] ${resp.data}")
 		}
 	}
+	return []
 }
 
 def setLevel(percentage) {
@@ -150,6 +154,7 @@ def setLevel(percentage) {
 			log.error("Bad setLevel result: [${resp.status}] ${resp.data}")
 		}
 	}
+	return []
 }
 
 def setColorTemperature(kelvin) {
@@ -165,6 +170,7 @@ def setColorTemperature(kelvin) {
 		}
 
 	}
+	return []
 }
 
 def on() {
@@ -174,6 +180,7 @@ def on() {
 			sendEvent(name: "switch", value: "on")
 		}
 	}
+	return []
 }
 
 def off() {
@@ -183,6 +190,7 @@ def off() {
 			sendEvent(name: "switch", value: "off")
 		}
 	}
+	return []
 }
 
 def poll() {

--- a/devicetypes/smartthings/lifx-white-bulb.src/lifx-white-bulb.groovy
+++ b/devicetypes/smartthings/lifx-white-bulb.src/lifx-white-bulb.groovy
@@ -84,6 +84,7 @@ def setLevel(percentage) {
 			log.error("Bad setLevel result: [${resp.status}] ${resp.data}")
 		}
 	}
+	return []
 }
 
 def setColorTemperature(kelvin) {
@@ -99,6 +100,7 @@ def setColorTemperature(kelvin) {
 			log.error("Bad setColorTemperature result: [${resp.status}] ${resp.data}")
 		}
 	}
+	return []
 }
 
 def on() {
@@ -108,6 +110,7 @@ def on() {
 			sendEvent(name: "switch", value: "on")
 		}
 	}
+	return []
 }
 
 def off() {
@@ -117,6 +120,7 @@ def off() {
 			sendEvent(name: "switch", value: "off")
 		}
 	}
+	return []
 }
 
 def poll() {


### PR DESCRIPTION
-Added empty return to command methods since sendEvent is used
-Added null check for hex values

This is causing exceptions for anyone using Smart Lights automations with set color + LIFX bulbs. I causes around 10k exceptions a day and breaks functionality
