### PR TITLE
callbackUrl naming conflict

### DIFF
--- a/smartapps/smartthings/logitech-harmony-connect.src/logitech-harmony-connect.groovy
+++ b/smartapps/smartthings/logitech-harmony-connect.src/logitech-harmony-connect.groovy
@@ -89,7 +89,7 @@ mappings {
 }
 
 def getServerUrl() { return "https://graph.api.smartthings.com" }
-def getCallbackUrl() { "https://graph.api.smartthings.com/oauth/callback" }
+def getServercallbackUrl() { "https://graph.api.smartthings.com/oauth/callback" }
 def getBuildRedirectUrl() { "${serverUrl}/oauth/initialize?appId=${app.id}&access_token=${state.accessToken}&apiServerUrl=${apiServerUrl}" }
 
 def authPage() {
@@ -166,7 +166,7 @@ def callback() {
 
 def init() {
 	log.debug "Requesting Code"
-	def oauthParams = [client_id: "${appSettings.clientId}", scope: "remote", response_type: "code", redirect_uri: "${callbackUrl}" ]
+	def oauthParams = [client_id: "${appSettings.clientId}", scope: "remote", response_type: "code", redirect_uri: "${servercallbackUrl}" ]
 	redirect(location: "https://home.myharmony.com/oauth2/authorize?${toQueryString(oauthParams)}")
 }
 


### PR DESCRIPTION
With the changes we introduced in the new authentication flow we added the function 
def getCallbackUrl() { "https://graph.api.smartthings.com/oauth/callback" }
By Groovy magic you can invoke this function by calling callbackUrl as a variable.
Later we define a variable with the same name in the function that it is currently not working. 
def addSubscription() {
    def data = request.JSON
    def attribute = data.attributeName
    def callbackUrl = data.callbackUrl
generating a conflict on naming. This commit renames getCallbackUrl() and the only place that it is called from. 

@Yaima @workingmonk 
