### PR TITLE
DVCSMP-1521 NPE in Bose (Connect)

### DIFF
--- a/smartapps/smartthings/bose-soundtouch-connect.src/bose-soundtouch-connect.groovy
+++ b/smartapps/smartthings/bose-soundtouch-connect.src/bose-soundtouch-connect.groovy
@@ -353,7 +353,7 @@ def onLocation(evt) {
     }
     else if (
         lanEvent.headers && lanEvent.body &&
-        lanEvent.headers."content-type".contains("xml")
+        lanEvent.headers."content-type"?.contains("xml")
         )
     {
         def parsers = getParsers()


### PR DESCRIPTION
-NPE would occur if parsed LAN message is missing content-type header
