### PR TITLE
Adding Polling and Refresh capbilities to allow Pollster to refresh weather

### DIFF
--- a/devicetypes/smartthings/smartweather-station-tile.src/smartweather-station-tile.groovy
+++ b/devicetypes/smartthings/smartweather-station-tile.src/smartweather-station-tile.groovy
@@ -22,6 +22,8 @@ metadata {
 		capability "Temperature Measurement"
 		capability "Relative Humidity Measurement"
 		capability "Sensor"
+		capability "Polling"
+		capability "Refresh"
 
 		attribute "localSunrise", "string"
 		attribute "localSunset", "string"


### PR DESCRIPTION
https://community.smartthings.com/t/smartweather-station-tile-device-not-updating-updated-thread-title/36675/20
As discussed above, the SmartWeather Station Tile was not updating. I wanted to use Pollster to update it, but it didn't expose Refresh or Polling.  This just adds those capabilities so that Pollster can be used.
