### PR TITLE
Update simulated thermostat with new functionality and brand colors

### DIFF
--- a/devicetypes/smartthings/testing/simulated-thermostat.src/simulated-thermostat.groovy
+++ b/devicetypes/smartthings/testing/simulated-thermostat.src/simulated-thermostat.groovy
@@ -32,14 +32,15 @@ metadata {
 				attributeState("default", label:'${currentValue}', unit:"dF")
 			}
 			tileAttribute("device.temperature", key: "VALUE_CONTROL") {
-				attributeState("default", action: "setTemperature")
+				attributeState("VALUE_UP", action: "tempUp")
+				attributeState("VALUE_DOWN", action: "tempDown")
 			}
 			tileAttribute("device.humidity", key: "SECONDARY_CONTROL") {
 				attributeState("default", label:'${currentValue}%', unit:"%")
 			}
 			tileAttribute("device.thermostatOperatingState", key: "OPERATING_STATE") {
 				attributeState("idle", backgroundColor:"#44b621")
-				attributeState("heating", backgroundColor:"#ffa81e")
+				attributeState("heating", backgroundColor:"#ea5462")
 				attributeState("cooling", backgroundColor:"#269bd2")
 			}
 			tileAttribute("device.thermostatMode", key: "THERMOSTAT_MODE") {


### PR DESCRIPTION
Our mobile clients support new functionality for the VALUE_CONTROL on multi-attribute tiles (see: http://docs.smartthings.com/en/latest/device-type-developers-guide/tiles-metadata.html#a-word-on-the-value-control-attribute). Let's update our simulated thermostat to make use of the new hotness.
