### PR TITLE
EX-45: Wemo (Connect) device addition fails on update for old devices

### DIFF
--- a/smartapps/smartthings/wemo-connect.src/wemo-connect.groovy
+++ b/smartapps/smartthings/wemo-connect.src/wemo-connect.groovy
@@ -234,7 +234,7 @@ def addSwitches() {
 		def d
 		if (selectedSwitch) {
 			d = getChildDevices()?.find {
-				it.dni == selectedSwitch.value.mac || it.device.getDataValue("mac") == selectedSwitch.value.mac
+				it.deviceNetworkId == selectedSwitch.value.mac || it.device.getDataValue("mac") == selectedSwitch.value.mac
 			}
 		}
 
@@ -265,7 +265,7 @@ def addMotions() {
 		def d
 		if (selectedMotion) {
 			d = getChildDevices()?.find {
-				it.dni == selectedMotion.value.mac || it.device.getDataValue("mac") == selectedMotion.value.mac
+				it.deviceNetworkId == selectedMotion.value.mac || it.device.getDataValue("mac") == selectedMotion.value.mac
 			}
 		}
 
@@ -296,7 +296,7 @@ def addLightSwitches() {
 		def d
 		if (selectedLightSwitch) {
 			d = getChildDevices()?.find {
-				it.dni == selectedLightSwitch.value.mac || it.device.getDataValue("mac") == selectedLightSwitch.value.mac
+				it.deviceNetworkId == selectedLightSwitch.value.mac || it.device.getDataValue("mac") == selectedLightSwitch.value.mac
 			}
 		}
 


### PR DESCRIPTION
Details here:  https://smartthings.atlassian.net/browse/EX-45

Basically, the method "dni" doesn't exist, and returns nulls. Usually not a problem, but for really old devices where there is no "mac" in device data, the app fails to update.

/cc @juano2310
