### PR TITLE
Added hubVerification()

### DIFF
--- a/devicetypes/smartthings/hue-bridge.src/hue-bridge.groovy
+++ b/devicetypes/smartthings/hue-bridge.src/hue-bridge.groovy
@@ -17,16 +17,13 @@ metadata {
 
 	tiles(scale: 2) {
      	multiAttributeTile(name:"rich-control"){
-			tileAttribute ("device.switch", key: "PRIMARY_CONTROL") {
+			tileAttribute ("", key: "PRIMARY_CONTROL") {
 	            attributeState "default", label: "Hue Bridge", action: "", icon: "st.Lighting.light99-hue", backgroundColor: "#F3C200"
-			}    
+			}
 	        tileAttribute ("serialNumber", key: "SECONDARY_CONTROL") {
 	            attributeState "default", label:'SN: ${currentValue}'
-			}    
-        }    
-		standardTile("icon", "icon", width: 1, height: 1, canChangeIcon: false, inactiveLabel: true, canChangeBackground: false) {
-			state "default", label: "Hue Bridge", action: "", icon: "st.Lighting.light99-hue", backgroundColor: "#FFFFFF"
-		}
+			}
+        }
 		valueTile("serialNumber", "device.serialNumber", decoration: "flat", height: 1, width: 2, inactiveLabel: false) {
 			state "default", label:'SN: ${currentValue}'
 		}
@@ -34,7 +31,7 @@ metadata {
 			state "default", label:'${currentValue}', height: 1, width: 2, inactiveLabel: false
 		}
 
-		main (["icon"])
+		main (["rich-control"])
 		details(["rich-control", "networkAddress"])
 	}
 }
@@ -75,6 +72,7 @@ def parse(description) {
 				}
 				else if (contentType?.contains("xml")) {
 					log.debug "HUE BRIDGE ALREADY PRESENT"
+                    parent.hubVerification(device.hub.id, msg.body)
 				}
 			}
 		}

--- a/smartapps/smartthings/hue-connect.src/hue-connect.groovy
+++ b/smartapps/smartthings/hue-connect.src/hue-connect.groovy
@@ -68,7 +68,7 @@ def bridgeDiscovery(params=[:])
 	}
 
 	//setup.xml request every 3 seconds except on discoveries
-	if(((bridgeRefreshCount % 1) == 0) && ((bridgeRefreshCount % 5) != 0)) {
+	if(((bridgeRefreshCount % 3) == 0) && ((bridgeRefreshCount % 5) != 0)) {
 		verifyHueBridges()
 	}
 
@@ -175,6 +175,7 @@ private discoverHueBulbs() {
 }
 
 private verifyHueBridge(String deviceNetworkId, String host) {
+	log.trace "Verify Hue Bridge $deviceNetworkId"
 	sendHubCommand(new physicalgraph.device.HubAction([
 		method: "GET",
 		path: "/description.xml",
@@ -600,6 +601,20 @@ def parse(childDevice, description) {
 		log.debug "parse - got something other than headers,body..."
 		return []
 	}
+}
+
+def hubVerification(bodytext) {
+	log.trace "Bridge sent back description.xml for verification"
+    def body = new XmlSlurper().parseText(bodytext)
+    if (body?.device?.modelName?.text().startsWith("Philips hue bridge")) {
+        def bridges = getHueBridges()
+        def bridge = bridges.find {it?.key?.contains(body?.device?.UDN?.text())}
+        if (bridge) {
+            bridge.value << [name:body?.device?.friendlyName?.text(), serialNumber:body?.device?.serialNumber?.text(), verified: true]
+        } else {
+            log.error "/description.xml returned a bridge that didn't exist"
+        }
+    }
 }
 
 def on(childDevice) {


### PR DESCRIPTION
If the hub exist as a thing parsing the response from description.xml
was lost. Now it is sent back to the parent were the device can be
marked as verified if the modelName starts with "Philips hue bridge"
