### PR TITLE
Turns off is value switch = off

### DIFF
--- a/smartapps/smartthings/hue-connect.src/hue-connect.groovy
+++ b/smartapps/smartthings/hue-connect.src/hue-connect.groovy
@@ -679,6 +679,11 @@ def setColor(childDevice, huesettings) {
 
 	log.debug "sending command $value"
 	put("lights/${getId(childDevice)}/state", value)
+
+    if (huesettings.switch == "off")
+		put("lights/${getId(childDevice)}/state", [on: false])
+
+    return "Bulb changed color"
 }
 
 def nextLevel(childDevice) {


### PR DESCRIPTION
After turning color the bulb turns off is value switch = off. This is used by Smart Home Monitor to restore bulb to the values before Notification with light was activated.

cc @larsfinander 
