### PR TITLE
Kelvin to Mireks

### DIFF
--- a/smartapps/smartthings/hue-connect.src/hue-connect.groovy
+++ b/smartapps/smartthings/hue-connect.src/hue-connect.groovy
@@ -650,7 +650,7 @@ def setHue(childDevice, percent) {
 
 def setColorTemperature(childDevice, huesettings) {
 	log.debug "Executing 'setColorTemperature($huesettings)'"
-	def ct = Math.round(Math.abs((huesettings / 12.96829971181556) - 654))
+	def ct = (1000000 / huesettings) as Integer
 	def value = [ct: ct, on: true]
 	log.trace "sending command $value"
 	put("lights/${getId(childDevice)}/state", value)


### PR DESCRIPTION
Per https://en.wikipedia.org/wiki/Mired

Mired = 1000000 / Kelvin

Hue bulbs support color temperatures from 2000k to 6500k, or 500 mireks to 153 mireks (http://www.developers.meethue.com/documentation/core-concepts)

Using Math.round(Math.abs((huesettings / 12.96829971181556) - 654))
   2000k = 500 mireks
   5000k = 268 mireks
   6500k = 153 mireks

Using (1000000 / huesettings) as Integer
   2000k = 500 mireks
   5000k = 200 mireks
   6500k = 153 mireks

The correct mirek equivalent for 5000k is 200, so as you can see, the previous formula only works at the ends of the range, but is not correct for middle values. 

This is all assuming that the desired behavior is to set the color temperature based on how Hue has calibrated the bulbs, and not based on a color temperature meter.
