### PR TITLE
Use "emergency heat" mode per Thermostat capabilities definition

### DIFF
--- a/smartapps/smartthings/ecobee-connect.src/ecobee-connect.groovy
+++ b/smartapps/smartthings/ecobee-connect.src/ecobee-connect.groovy
@@ -420,7 +420,7 @@ def pollChildren(child = null) {
 							temperature: (stat.runtime.actualTemperature / 10),
 							heatingSetpoint: stat.runtime.desiredHeat / 10,
 							coolingSetpoint: stat.runtime.desiredCool / 10,
-							thermostatMode: stat.settings.hvacMode,
+							thermostatMode: (stat.settings.hvacMode == "auxHeatOnly") ? "emergency heat" : stat.settings.hvacMode,
 							humidity: stat.runtime.actualHumidity,
 							thermostatFanMode: stat.runtime.desiredFanMode
 					]

--- a/smartapps/smartthings/ecobee-connect.src/ecobee-connect.groovy
+++ b/smartapps/smartthings/ecobee-connect.src/ecobee-connect.groovy
@@ -513,7 +513,7 @@ def availableModes(child) {
 	if (tData.data.heatMode) modes.add("heat")
 	if (tData.data.coolMode) modes.add("cool")
 	if (tData.data.autoMode) modes.add("auto")
-	if (tData.data.auxHeatMode) modes.add("auxHeatOnly")
+	if (tData.data.auxHeatMode) modes.add("emergency heat")
 
 	modes
 


### PR DESCRIPTION
These changes align the thermostat mode for emergency heating with the capabilities definition. So references to "auxHeatOnly" are replaced with "emergency heat". Additional handling is added where needed to deal with this change.

@Yaima @tylerlange @dsainteclaire 
