### PR TITLE
Restrict colorTemperature to valid values

### DIFF
--- a/devicetypes/smartthings/osram-lightify-led-tunable-white-60w.src/osram-lightify-led-tunable-white-60w.groovy
+++ b/devicetypes/smartthings/osram-lightify-led-tunable-white-60w.src/osram-lightify-led-tunable-white-60w.groovy
@@ -169,8 +169,11 @@ def levelConfig() {
 }
 
 def setColorTemperature(value) {
-    if(value<101){
-        value = (value*38) + 2700		//Calculation of mapping 0-100 to 2700-6500
+    if(value < 2700){
+        value = 2700
+    }
+    if(value > 6500){
+        value = 6500
     }
 
     def tempInMired = Math.round(1000000/value)


### PR DESCRIPTION
Removed the hacky 0-100 method and added  a restriction on color temperature.  If the bulb gets a color temperature outside of its nominal range, the bulb will turn off.
