### PR TITLE
DVCSMP-1667 Authentication needs to be updated for Philips Hue

### DIFF
--- a/smartapps/smartthings/hue-connect.src/hue-connect.groovy
+++ b/smartapps/smartthings/hue-connect.src/hue-connect.groovy
@@ -161,7 +161,7 @@ private sendDeveloperReq() {
 		headers: [
 			HOST: host
 		],
-		body: [devicetype: "$token-0", username: "$token-0"]], "${selectedHue}"))
+		body: [devicetype: "$token-0"]], "${selectedHue}"))
 }
 
 private discoverHueBulbs() {


### PR DESCRIPTION
-Philips updaded their API and current ST implementation will stop
working when next Hue firmware is released without this change
