### PR TITLE
Use runHourly in SmartweatherStation DH

### DIFF
--- a/devicetypes/smartthings/smartweather-station-tile.src/smartweather-station-tile.groovy
+++ b/devicetypes/smartthings/smartweather-station-tile.src/smartweather-station-tile.groovy
@@ -158,7 +158,11 @@ def parse(String description) {
 }
 
 def installed() {
-	runPeriodically(3600, poll)
+	runHourly(new Date(now()+5000), poll)
+}
+
+def updated() {
+	runHourly(new Date(now()+5000), poll)
 }
 
 def uninstalled() {


### PR DESCRIPTION
Use runHourly rather than the (no longer available) runPeriodically in Smart Weather Station
