### PR TITLE
[CHF-112] Add Health Check capability to SmartThings SmartSense products

### DIFF
--- a/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
+++ b/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
@@ -31,6 +31,7 @@ metadata {
 		capability "Configuration"
 		capability "Refresh"
 		capability "Sensor"
+		capability "Health Check"
 
 		// indicates that device keeps track of heartbeat (in state.heartbeat)
 		attribute "heartbeat", "string"

--- a/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
@@ -31,6 +31,7 @@ metadata {
 		capability "Refresh"
 		capability "Temperature Measurement"
 		capability "Water Sensor"
+		capability "Health Check"
 
 		command "enrollResponse"
 

--- a/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
@@ -31,6 +31,7 @@ metadata {
 		capability "Battery"
 		capability "Temperature Measurement"
 		capability "Refresh"
+		capability "Health Check"
 
 		command "enrollResponse"
 

--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -35,6 +35,7 @@ metadata {
  		capability "Acceleration Sensor"
  		capability "Refresh"
  		capability "Temperature Measurement"
+		capability "Health Check"
 
  		command "enrollResponse"
  		fingerprint inClusters: "0000,0001,0003,0402,0500,0020,0B05,FC02", outClusters: "0019", manufacturer: "CentraLite", model: "3320"

--- a/devicetypes/smartthings/smartsense-open-closed-accelerometer-sensor.src/smartsense-open-closed-accelerometer-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-accelerometer-sensor.src/smartsense-open-closed-accelerometer-sensor.groovy
@@ -23,8 +23,9 @@
  		capability "Acceleration Sensor"
  		capability "Refresh"
  		capability "Temperature Measurement"
- 		command "enrollResponse"
+		capability "Health Check"
 
+		command "enrollResponse"
  	}
 
  	simulator {

--- a/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
@@ -20,6 +20,7 @@ metadata {
 		capability "Refresh"
 		capability "Temperature Measurement"
 		capability "Relative Humidity Measurement"
+		capability "Health Check"
 
 		fingerprint endpointId: "01", inClusters: "0001,0003,0020,0402,0B05,FC45", outClusters: "0019,0003"
 	}


### PR DESCRIPTION
By adding `capability Health Check` Device Watch will monitor Devices send `online:offline` events to the `Location`

https://smartthings.atlassian.net/browse/CHF-112
