### PR TITLE
Changing the name for the DTH and the namespace

### DIFF
--- a/devicetypes/smartthings/zigbee-button.src/zigbee-button.groovy
+++ b/devicetypes/smartthings/zigbee-button.src/zigbee-button.groovy
@@ -15,7 +15,7 @@
  *
  */
 metadata {
-	definition (name: "Iris Smart Fob", namespace: "mitchpond", author: "Mitch Pond") {
+	definition (name: "ZigBee Button", namespace: "smartthings", author: "Mitch Pond") {
 		capability "Battery"
 		capability "Button"
         capability "Configuration"


### PR DESCRIPTION
changing the name to generic button and moving namespaces to account for code division 

cc @mitchpond 
