### PR TITLE
SHARD-159: Wemo (Connect) updated() fails in certain IP change scenarios

### DIFF
--- a/smartapps/smartthings/wemo-connect.src/wemo-connect.groovy
+++ b/smartapps/smartthings/wemo-connect.src/wemo-connect.groovy
@@ -236,23 +236,22 @@ def addSwitches() {
 			d = getChildDevices()?.find {
 				it.deviceNetworkId == selectedSwitch.value.mac || it.device.getDataValue("mac") == selectedSwitch.value.mac
 			}
-		}
-
-		if (!d) {
-			log.debug "Creating WeMo Switch with dni: ${selectedSwitch.value.mac}"
-			d = addChildDevice("smartthings", "Wemo Switch", selectedSwitch.value.mac, selectedSwitch?.value.hub, [
-				"label": selectedSwitch?.value?.name ?: "Wemo Switch",
-				"data": [
-					"mac": selectedSwitch.value.mac,
-					"ip": selectedSwitch.value.ip,
-					"port": selectedSwitch.value.port
-				]
-			])
-			def ipvalue = convertHexToIP(selectedSwitch.value.ip)
-			d.sendEvent(name: "currentIP", value: ipvalue, descriptionText: "IP is ${ipvalue}")
-			log.debug "Created ${d.displayName} with id: ${d.id}, dni: ${d.deviceNetworkId}"
-		} else {
-			log.debug "found ${d.displayName} with id $dni already exists"
+			if (!d) {
+				log.debug "Creating WeMo Switch with dni: ${selectedSwitch.value.mac}"
+				d = addChildDevice("smartthings", "Wemo Switch", selectedSwitch.value.mac, selectedSwitch?.value.hub, [
+					"label": selectedSwitch?.value?.name ?: "Wemo Switch",
+					"data": [
+						"mac": selectedSwitch.value.mac,
+						"ip": selectedSwitch.value.ip,
+						"port": selectedSwitch.value.port
+					]
+				])
+				def ipvalue = convertHexToIP(selectedSwitch.value.ip)
+				d.sendEvent(name: "currentIP", value: ipvalue, descriptionText: "IP is ${ipvalue}")
+				log.debug "Created ${d.displayName} with id: ${d.id}, dni: ${d.deviceNetworkId}"
+			} else {
+				log.debug "found ${d.displayName} with id $dni already exists"
+			}
 		}
 	}
 }
@@ -267,23 +266,22 @@ def addMotions() {
 			d = getChildDevices()?.find {
 				it.deviceNetworkId == selectedMotion.value.mac || it.device.getDataValue("mac") == selectedMotion.value.mac
 			}
-		}
-
-		if (!d) {
-			log.debug "Creating WeMo Motion with dni: ${selectedMotion.value.mac}"
-			d = addChildDevice("smartthings", "Wemo Motion", selectedMotion.value.mac, selectedMotion?.value.hub, [
-				"label": selectedMotion?.value?.name ?: "Wemo Motion",
-				"data": [
-					"mac": selectedMotion.value.mac,
-					"ip": selectedMotion.value.ip,
-					"port": selectedMotion.value.port
-				]
-			])
-			def ipvalue = convertHexToIP(selectedMotion.value.ip)
-			d.sendEvent(name: "currentIP", value: ipvalue, descriptionText: "IP is ${ipvalue}")
-			log.debug "Created ${d.displayName} with id: ${d.id}, dni: ${d.deviceNetworkId}"
-		} else {
-			log.debug "found ${d.displayName} with id $dni already exists"
+			if (!d) {
+				log.debug "Creating WeMo Motion with dni: ${selectedMotion.value.mac}"
+				d = addChildDevice("smartthings", "Wemo Motion", selectedMotion.value.mac, selectedMotion?.value.hub, [
+					"label": selectedMotion?.value?.name ?: "Wemo Motion",
+					"data": [
+						"mac": selectedMotion.value.mac,
+						"ip": selectedMotion.value.ip,
+						"port": selectedMotion.value.port
+					]
+				])
+				def ipvalue = convertHexToIP(selectedMotion.value.ip)
+				d.sendEvent(name: "currentIP", value: ipvalue, descriptionText: "IP is ${ipvalue}")
+				log.debug "Created ${d.displayName} with id: ${d.id}, dni: ${d.deviceNetworkId}"
+			} else {
+				log.debug "found ${d.displayName} with id $dni already exists"
+			}
 		}
 	}
 }
@@ -298,23 +296,22 @@ def addLightSwitches() {
 			d = getChildDevices()?.find {
 				it.deviceNetworkId == selectedLightSwitch.value.mac || it.device.getDataValue("mac") == selectedLightSwitch.value.mac
 			}
-		}
-
-		if (!d) {
-			log.debug "Creating WeMo Light Switch with dni: ${selectedLightSwitch.value.mac}"
-			d = addChildDevice("smartthings", "Wemo Light Switch", selectedLightSwitch.value.mac, selectedLightSwitch?.value.hub, [
-				"label": selectedLightSwitch?.value?.name ?: "Wemo Light Switch",
-				"data": [
-					"mac": selectedLightSwitch.value.mac,
-					"ip": selectedLightSwitch.value.ip,
-					"port": selectedLightSwitch.value.port
-				]
-			])
-			def ipvalue = convertHexToIP(selectedLightSwitch.value.ip)
-			d.sendEvent(name: "currentIP", value: ipvalue, descriptionText: "IP is ${ipvalue}")
-			log.debug "created ${d.displayName} with id $dni"
-		} else {
-			log.debug "found ${d.displayName} with id $dni already exists"
+			if (!d) {
+				log.debug "Creating WeMo Light Switch with dni: ${selectedLightSwitch.value.mac}"
+				d = addChildDevice("smartthings", "Wemo Light Switch", selectedLightSwitch.value.mac, selectedLightSwitch?.value.hub, [
+					"label": selectedLightSwitch?.value?.name ?: "Wemo Light Switch",
+					"data": [
+						"mac": selectedLightSwitch.value.mac,
+						"ip": selectedLightSwitch.value.ip,
+						"port": selectedLightSwitch.value.port
+					]
+				])
+				def ipvalue = convertHexToIP(selectedLightSwitch.value.ip)
+				d.sendEvent(name: "currentIP", value: ipvalue, descriptionText: "IP is ${ipvalue}")
+				log.debug "created ${d.displayName} with id $dni"
+			} else {
+				log.debug "found ${d.displayName} with id $dni already exists"
+			}
 		}
 	}
 }


### PR DESCRIPTION
There is an uncommon situation that can occur where a device is selected in Wemo (Connect) settings in the past that later does not appear in state. I'm still unsure how the app state gets into this situation for Wemo (Connect), but I do know that that this change will keep updated() calls from failing. This is directly related to SHARD-157.

/cc @bflorian @charliek @kyleboon
