### PR TITLE
Adding test cases for multi-line controls in multiattribute tiles

### DIFF
--- a/devicetypes/smartthings/tile-ux/tile-basic-standard.src/tile-basic-standard.groovy
+++ b/devicetypes/smartthings/tile-ux/tile-basic-standard.src/tile-basic-standard.groovy
@@ -80,19 +80,31 @@ metadata {
 			state "default", label:''
 		}
 
-		main("standard1")
+		// multi-line text (explicit newlines)
+		standardTile("multiLine", "device.multiLine", width: 2, height: 2) {
+			state "default", label: '${currentValue}'
+		}
+
+		standardTile("multiLineWithIcon", "device.multiLine", width: 2, height: 2) {
+			state "default", label: '${currentValue}', icon: "st.switches.switch.off"
+		}
+
+		main("actionRings")
 		details([
 			"actionRings", "actionFlat", "noActionFlat",
 
 			"flatLabel", "flatIconLabel", "flatIcon",
 
 			"flatDefaultState", "flatImplicitDefaultState1", "flatImplicitDefaultState2",
+
+			"multiLine", "multiLineWithIcon"
 		])
 	}
 }
 
 def installed() {
 	sendEvent(name: "switch", value: "off")
+	sendEvent(name: "multiLine", value: "Line 1\nLine 2\nLine 3")
 }
 
 def parse(String description) {

--- a/devicetypes/smartthings/tile-ux/tile-basic-value.src/tile-basic-value.groovy
+++ b/devicetypes/smartthings/tile-ux/tile-basic-value.src/tile-basic-value.groovy
@@ -69,8 +69,16 @@ metadata {
 			]
 		}
 
-		valueTile("noValue", "device.nada", width: 2, height: 2) {
+		valueTile("noValue", "device.nada", width: 4, height: 2) {
 			state "default", label:'${currentValue}'
+		}
+
+		valueTile("multiLine", "device.multiLine", width: 3, height: 2) {
+			state "default", label: '${currentValue}'
+		}
+
+		valueTile("multiLineWithIcon", "device.multiLine", width: 3, height: 2) {
+			state "default", label: '${currentValue}', icon: "st.switches.switch.off"
 		}
 
 		main("text")
@@ -78,7 +86,8 @@ metadata {
 			"text", "longText", "integer", 
             "integerFloat", "pi", "floatAsText",
             "bgColor", "bgColorRange", "bgColorRangeSingleItem",
-            "bgColorRangeConflict", "noValue"
+            "bgColorRangeConflict", "noValue",
+            "multiLine", "multiLineWithIcon"
 		])
 	}
 }
@@ -90,6 +99,7 @@ def installed() {
 	sendEvent(name: "integerFloat", value: 47.0)
 	sendEvent(name: "pi", value: 3.14159)
 	sendEvent(name: "floatAsText", value: "3.14159")
+	sendEvent(name: "multiLine", value: "Line 1\nLine 2\nLine 3")
 }
 
 def parse(String description) {

--- a/devicetypes/smartthings/tile-ux/tile-multiattribute-generic.src/tile-multiattribute-generic.groovy
+++ b/devicetypes/smartthings/tile-ux/tile-multiattribute-generic.src/tile-multiattribute-generic.groovy
@@ -67,14 +67,47 @@ metadata {
 				attributeState "VALUE_DOWN", action: "levelDown"
 			}
 		}
+		multiAttributeTile(name:"lengthyTile", type:"generic", width:6, height:4) {
+			tileAttribute("device.lengthyText", key: "PRIMARY_CONTROL") {
+				attributeState "default", label:'The value of this tile is long and should wrap to two lines', backgroundColor:"#79b821"
+			}
+			tileAttribute("device.lengthyText", key: "SECONDARY_CONTROL") {
+				attributeState "default", label:'The value of this tile is long and should wrap to two lines', backgroundColor:"#79b821"
+			}
+		}
+		multiAttributeTile(name:"multilineTile", type:"generic", width:6, height:4) {
+			tileAttribute("device.multilineText", key: "PRIMARY_CONTROL") {
+				attributeState "default", label:'Line 1 YES\nLine 2 YES\nLine 3 NO', backgroundColor:"#79b821"
+			}
+			tileAttribute("device.multilineText", key: "SECONDARY_CONTROL") {
+				attributeState "default", label:'Line 1 YES\nLine 2 YES\nLine 3 NO', backgroundColor:"#79b821"
+			}
+		}
+		multiAttributeTile(name:"lengthyTileWithIcon", type:"generic", width:6, height:4) {
+			tileAttribute("device.lengthyText", key: "PRIMARY_CONTROL") {
+				attributeState "default", label:'The value of this tile is long and should wrap to two lines', backgroundColor:"#79b821", icon: "st.switches.switch.on"
+			}
+			tileAttribute("device.lengthyText", key: "SECONDARY_CONTROL") {
+				attributeState "default", label:'The value of this tile is long and should wrap to two lines', backgroundColor:"#79b821", icon: "st.switches.switch.on"
+			}
+		}
+		multiAttributeTile(name:"multilineTileWithIcon", type:"generic", width:6, height:4) {
+			tileAttribute("device.multilineText", key: "PRIMARY_CONTROL") {
+				attributeState "default", label:'Line 1 YES\nLine 2 YES\nLine 3 NO', backgroundColor:"#79b821", icon: "st.switches.switch.on"
+			}
+			tileAttribute("device.multilineText", key: "SECONDARY_CONTROL") {
+				attributeState "default", label:'Line 1 YES\nLine 2 YES\nLine 3 NO', backgroundColor:"#79b821", icon: "st.switches.switch.on"
+			}
+		}
 
 		main(["basicTile"])
-		details(["basicTile", "sliderTile", "valueTile"])
+		details(["basicTile", "sliderTile", "valueTile", "lengthyTile", "multilineTile", "lengthyTileWithIcon", "multilineTileWithIcon"])
 	}
 }
 
 def installed() {
-
+	sendEvent(name: "lengthyText", value: "The value of this tile is long and should wrap to two lines")
+	sendEvent(name: "multilineText", value: "Line 1 YES\nLine 2 YES\nLine 3 NO")
 }
 
 def parse() {


### PR DESCRIPTION
We'd like PRIMARY_CONTROL and SECONDARY_CONTROL to allow up to 2 lines of text. The changes within are for testing purposes for our mobile clients.
