### PR TITLE
SHARD-174: Hue (Connect) updated() calls can fail in certain situations

### DIFF
--- a/smartapps/smartthings/hue-connect.src/hue-connect.groovy
+++ b/smartapps/smartthings/hue-connect.src/hue-connect.groovy
@@ -332,8 +332,7 @@ private addChildBulb(dni, hueType, name, hub, update=false, device = null) {
 
 	if (deviceType) {
 		return addChildDevice("smartthings", deviceType, dni, hub, ["label": name])
-	}
-	else {
+	} else {
 		log.warn "Device type $hueType not supported"
 		return null
 	}
@@ -349,8 +348,10 @@ def addBulbs() {
 				newHueBulb = bulbs.find { (app.id + "/" + it.value.id) == dni }
                 if (newHueBulb != null) {
                     d = addChildBulb(dni, newHueBulb?.value?.type, newHueBulb?.value?.name, newHueBulb?.value?.hub)
-                    log.debug "created ${d.displayName} with id $dni"
-                    d.refresh()
+					if (d) {
+						log.debug "created ${d.displayName} with id $dni"
+						d.refresh()
+					}
                 } else {
                 	log.debug "$dni in not longer paired to the Hue Bridge or ID changed"
                 }
@@ -358,7 +359,7 @@ def addBulbs() {
             	//backwards compatable
 				newHueBulb = bulbs.find { (app.id + "/" + it.id) == dni }
 				d = addChildBulb(dni, "Extended Color Light", newHueBulb?.value?.name, newHueBulb?.value?.hub)
-                d.refresh()
+				d?.refresh()
 			}
 		} else {
 			log.debug "found ${d.displayName} with id $dni already exists, type: '$d.typeName'"


### PR DESCRIPTION
If a Hue Bulb has previously been discovered and persisted in the app state of Hue (Connect), and it doesn't have "type" information in state, and doesn't get updated due to the hub being offline (or other situations), the update will fail with a NullPointerException.
