### PR TITLE
fix parse signature for generic multiattribute example tile

### DIFF
--- a/devicetypes/smartthings/tile-ux/tile-multiattribute-generic.src/tile-multiattribute-generic.groovy
+++ b/devicetypes/smartthings/tile-ux/tile-multiattribute-generic.src/tile-multiattribute-generic.groovy
@@ -110,7 +110,7 @@ def installed() {
 	sendEvent(name: "multilineText", value: "Line 1 YES\nLine 2 YES\nLine 3 NO")
 }
 
-def parse() {
+def parse(String description) {
 	// This is a simulated device. No incoming data to parse.
 }
 


### PR DESCRIPTION
@KyleLeneau this is needed for the generic tile to install through the controller
