### PR TITLE
DVCSMP-1738 Philips HUE: Detail page showing the Brightness level twice

### DIFF
--- a/devicetypes/smartthings/hue-bloom.src/hue-bloom.groovy
+++ b/devicetypes/smartthings/hue-bloom.src/hue-bloom.groovy
@@ -37,9 +37,6 @@ metadata {
 			tileAttribute ("device.level", key: "SLIDER_CONTROL") {
 				attributeState "level", action:"switch level.setLevel", range:"(0..100)"
             }
-            tileAttribute ("device.level", key: "SECONDARY_CONTROL") {
-	            attributeState "level", label: 'Level ${currentValue}%'
-			}
 			tileAttribute ("device.color", key: "COLOR_CONTROL") {
 				attributeState "color", action:"setAdjustedColor"
 			}

--- a/devicetypes/smartthings/hue-bulb.src/hue-bulb.groovy
+++ b/devicetypes/smartthings/hue-bulb.src/hue-bulb.groovy
@@ -38,9 +38,6 @@ metadata {
 			tileAttribute ("device.level", key: "SLIDER_CONTROL") {
 				attributeState "level", action:"switch level.setLevel", range:"(0..100)"
             }
-            tileAttribute ("device.level", key: "SECONDARY_CONTROL") {
-	            attributeState "level", label: 'Level ${currentValue}%'
-			}
 			tileAttribute ("device.color", key: "COLOR_CONTROL") {
 				attributeState "color", action:"setAdjustedColor"
 			}

--- a/devicetypes/smartthings/hue-lux-bulb.src/hue-lux-bulb.groovy
+++ b/devicetypes/smartthings/hue-lux-bulb.src/hue-lux-bulb.groovy
@@ -33,9 +33,6 @@ metadata {
             tileAttribute ("device.level", key: "SLIDER_CONTROL") {
               attributeState "level", action:"switch level.setLevel", range:"(0..100)"
             }
-            tileAttribute ("device.level", key: "SECONDARY_CONTROL") {
-	            attributeState "level", label: 'Level ${currentValue}%'
-			}
         }
 
         controlTile("levelSliderControl", "device.level", "slider", height: 1, width: 2, inactiveLabel: false, range:"(0..100)") {


### PR DESCRIPTION
-Removed secondary control from all Hue DTH
