### PR TITLE
DVCSMP-1716 Remove heartbeat from device types

### DIFF
--- a/devicetypes/smartthings/osram-lightify-led-tunable-white-60w.src/osram-lightify-led-tunable-white-60w.groovy
+++ b/devicetypes/smartthings/osram-lightify-led-tunable-white-60w.src/osram-lightify-led-tunable-white-60w.groovy
@@ -19,11 +19,6 @@ metadata {
         capability "Sensor"
 
         attribute "colorName", "string"
-
-        // indicates that device keeps track of heartbeat (in state.heartbeat)
-        attribute "heartbeat", "string"
-        
-
     }
 
     // simulator metadata
@@ -74,9 +69,6 @@ metadata {
 // Parse incoming device messages to generate events
 def parse(String description) {
     //log.trace description
-
-    // save heartbeat (i.e. last time we got a message from device)
-    state.heartbeat = Calendar.getInstance().getTimeInMillis()
 
     if (description?.startsWith("catchall:")) {
         if(description?.endsWith("0100") ||description?.endsWith("1001") || description?.matches("on/off\\s*:\\s*1"))
@@ -132,7 +124,6 @@ def off() {
 }
 
 def refresh() {
-    sendEvent(name: "heartbeat", value: "alive", displayed:false)
     [
             "st rattr 0x${device.deviceNetworkId} ${endpointId} 6 0", "delay 500",
             "st rattr 0x${device.deviceNetworkId} ${endpointId} 8 0", "delay 500",

--- a/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
+++ b/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
@@ -25,9 +25,6 @@ metadata {
 		capability "Sensor"
 		capability "Health Check"
 
-		// indicates that device keeps track of heartbeat (in state.heartbeat)
-		attribute "heartbeat", "string"
-
 		fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0B04,0B05", outClusters: "0019", manufacturer: "CentraLite",  model: "3200", deviceJoinName: "Outlet"
 		fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0B04,0B05", outClusters: "0019", manufacturer: "CentraLite",  model: "3200-Sgb", deviceJoinName: "Outlet"
 		fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0B04,0B05", outClusters: "0019", manufacturer: "CentraLite",  model: "4257050-RZHAC", deviceJoinName: "Outlet"
@@ -81,9 +78,6 @@ metadata {
 def parse(String description) {
 	log.debug "description is $description"
 
-	// save heartbeat (i.e. last time we got a message from device)
-	state.heartbeat = Calendar.getInstance().getTimeInMillis()
-
 	def finalResult = zigbee.getKnownDescription(description)
 
 	//TODO: Remove this after getKnownDescription can parse it automatically
@@ -124,7 +118,6 @@ def on() {
 }
 
 def refresh() {
-	sendEvent(name: "heartbeat", value: "alive", displayed:false)
 	zigbee.onOffRefresh() + zigbee.refreshData("0x0B04", "0x050B")
 }
 


### PR DESCRIPTION
-Remove heartbeat from OSRAM white bulb and Smartpower Outlet
-Heartbeat was a hack previously used for Amazon Echo
