### PR TITLE
DOCS-284 - update tiles for best practices, add setColor to colorWheel

### DIFF
--- a/devicetypes/smartthings/tile-ux/tile-basic-colorwheel.src/tile-basic-colorwheel.groovy
+++ b/devicetypes/smartthings/tile-ux/tile-basic-colorwheel.src/tile-basic-colorwheel.groovy
@@ -22,7 +22,7 @@ metadata {
 
 	tiles(scale: 2) {
 		valueTile("currentColor", "device.color") {
-			state "default", label: '${currentValue}'
+			state "color", label: '${currentValue}', defaultState: true
 		}
 
 		controlTile("rgbSelector", "device.color", "color", height: 6, width: 6, inactiveLabel: false) {
@@ -39,6 +39,13 @@ metadata {
 // parse events into attributes
 def parse(String description) {
 	log.debug "Parsing '${description}'"
+}
+
+def setColor(value) {
+	log.debug "setting color: $value"
+    if (value.hex) { sendEvent(name: "color", value: value.hex) }
+    if (value.hue) { sendEvent(name: "hue", value: value.hue) }
+    if (value.saturation) { sendEvent(name: "saturation", value: value.saturation) }
 }
 
 def setSaturation(percent) {

--- a/devicetypes/smartthings/tile-ux/tile-basic-slider.src/tile-basic-slider.groovy
+++ b/devicetypes/smartthings/tile-ux/tile-basic-slider.src/tile-basic-slider.groovy
@@ -39,7 +39,7 @@ metadata {
 		}
 
 		valueTile("rangeValue", "device.rangedLevel", height: 2, width: 2) {
-			state "default", label:'${currentValue}'
+			state "range", label:'${currentValue}', defaultState: true
 		}
 
 		controlTile("rangeSliderConstrained", "device.rangedLevel", "slider", height: 2, width: 4, range: "(40..60)") {

--- a/devicetypes/smartthings/tile-ux/tile-basic-standard.src/tile-basic-standard.groovy
+++ b/devicetypes/smartthings/tile-ux/tile-basic-standard.src/tile-basic-standard.groovy
@@ -41,17 +41,17 @@ metadata {
 
 		// standard flat tile with only a label
 		standardTile("flatLabel", "device.switch", width: 2, height: 2, decoration: "flat") {
-			state "default", label: 'On Action', action: "switch.on", backgroundColor: "#ffffff"
+			state "label", label: 'On Action', action: "switch.on", backgroundColor: "#ffffff", defaultState: true
 		}
 
 		// standard flat tile with icon and label
 		standardTile("flatIconLabel", "device.switch", width: 2, height: 2, decoration: "flat") {
-			state "default", label: 'Off Action', action: "switch.off", icon:"st.switches.switch.off", backgroundColor: "#ffffff"
+			state "iconLabel", label: 'Off Action', action: "switch.off", icon:"st.switches.switch.off", backgroundColor: "#ffffff", defaultState: true
 		}
 
 		// standard flat tile with only icon (Refreh text is IN the icon file)
 		standardTile("flatIcon", "device.switch", width: 2, height: 2, decoration: "flat") {
-			state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
+			state "icon", action:"refresh.refresh", icon:"st.secondary.refresh", defaultState: true
 		}
 
 		// standard with defaultState = true
@@ -74,19 +74,19 @@ metadata {
 
 		// utility tiles to fill the spaces
 		standardTile("empty2x2", "null", width: 2, height: 2, decoration: "flat") {
-			state "default", label:''
+			state "emptySmall", label:'', defaultState: true
 		}
 		standardTile("empty4x2", "null", width: 4, height: 2, decoration: "flat") {
-			state "default", label:''
+			state "emptyBigger", label:'', defaultState: true
 		}
 
 		// multi-line text (explicit newlines)
 		standardTile("multiLine", "device.multiLine", width: 2, height: 2) {
-			state "default", label: '${currentValue}'
+			state "multiLine", label: '${currentValue}', defaultState: true
 		}
 
 		standardTile("multiLineWithIcon", "device.multiLine", width: 2, height: 2) {
-			state "default", label: '${currentValue}', icon: "st.switches.switch.off"
+			state "multiLineIcon", label: '${currentValue}', icon: "st.switches.switch.off", defaultState: true
 		}
 
 		main("actionRings")

--- a/devicetypes/smartthings/tile-ux/tile-basic-value.src/tile-basic-value.groovy
+++ b/devicetypes/smartthings/tile-ux/tile-basic-value.src/tile-basic-value.groovy
@@ -22,68 +22,68 @@ metadata {
 
 	tiles(scale: 2) {
 		valueTile("text", "device.text", width: 2, height: 2) {
-			state "default", label:'${currentValue}'
+			state "val", label:'${currentValue}', defaultState: true
 		}
 
 		valueTile("longText", "device.longText", width: 2, height: 2) {
-			state "default", label:'${currentValue}'
+			state "val", label:'${currentValue}', defaultState: true
 		}
 
 		valueTile("integer", "device.integer", width: 2, height: 2) {
-			state "default", label:'${currentValue}'
+			state "val", label:'${currentValue}', defaultState: true
 		}
 
 		valueTile("integerFloat", "device.integerFloat", width: 2, height: 2) {
-			state "default", label:'${currentValue}'
+			state "val", label:'${currentValue}', defaultState: true
 		}
 
 		valueTile("pi", "device.pi", width: 2, height: 2) {
-			state "default", label:'${currentValue}'
+			state "val", label:'${currentValue}', defaultState: true
 		}
 
 		valueTile("floatAsText", "device.floatAsText", width: 2, height: 2) {
-			state "default", label:'${currentValue}'
+			state "val", label:'${currentValue}', defaultState: true
 		}
 
 		valueTile("bgColor", "device.integer", width: 2, height: 2) {
-			state "default", label:'${currentValue}', backgroundColor: "#e86d13"
+			state "val", label:'${currentValue}', backgroundColor: "#e86d13", defaultState: true
 		}
 
 		valueTile("bgColorRange", "device.integer", width: 2, height: 2) {
-			state "default", label:'${currentValue}', backgroundColors: [
+			state "val", label:'${currentValue}', defaultState: true, backgroundColors: [
 				[value: 10, color: "#ff0000"],
 				[value: 90, color: "#0000ff"]
 			]
 		}
 
 		valueTile("bgColorRangeSingleItem", "device.integer", width: 2, height: 2) {
-			state "default", label:'${currentValue}', backgroundColors: [
+			state "val", label:'${currentValue}', defaultState: true, backgroundColors: [
 				[value: 10, color: "#333333"]
 			]
 		}
 
 		valueTile("bgColorRangeConflict", "device.integer", width: 2, height: 2) {
-			state "default", label:'${currentValue}', backgroundColors: [
+			state "valWithConflict", label:'${currentValue}', defaultState: true, backgroundColors: [
 				[value: 10, color: "#990000"],
 				[value: 10, color: "#000099"]
 			]
 		}
 
 		valueTile("noValue", "device.nada", width: 4, height: 2) {
-			state "default", label:'${currentValue}'
+			state "noval", label:'${currentValue}', defaultState: true
 		}
 
 		valueTile("multiLine", "device.multiLine", width: 3, height: 2) {
-			state "default", label: '${currentValue}'
+			state "val", label: '${currentValue}', defaultState: true
 		}
 
 		valueTile("multiLineWithIcon", "device.multiLine", width: 3, height: 2) {
-			state "default", label: '${currentValue}', icon: "st.switches.switch.off"
+			state "val", label: '${currentValue}', icon: "st.switches.switch.off", defaultState: true
 		}
 
 		main("text")
 		details([
-			"text", "longText", "integer", 
+			"text", "longText", "integer",
             "integerFloat", "pi", "floatAsText",
             "bgColor", "bgColorRange", "bgColorRangeSingleItem",
             "bgColorRangeConflict", "noValue",

--- a/devicetypes/smartthings/tile-ux/tile-multiattribute-generic.src/tile-multiattribute-generic.groovy
+++ b/devicetypes/smartthings/tile-ux/tile-multiattribute-generic.src/tile-multiattribute-generic.groovy
@@ -39,15 +39,15 @@ metadata {
 				attributeState "turningOff", label:'${name}', backgroundColor:"#ffffff", nextState:"turningOn"
 			}
 			tileAttribute("device.level", key: "SECONDARY_CONTROL") {
-				attributeState "default", icon: 'st.Weather.weather1', action:"randomizeLevel"
+				attributeState "level", icon: 'st.Weather.weather1', action:"randomizeLevel", defaultState: true
 			}
 			tileAttribute("device.level", key: "SLIDER_CONTROL") {
-				attributeState "default", action:"switch level.setLevel"
+				attributeState "level", action:"switch level.setLevel", defaultState: true
 			}
 		}
 		multiAttributeTile(name:"valueTile", type:"generic", width:6, height:4) {
 			tileAttribute("device.level", key: "PRIMARY_CONTROL") {
-				attributeState "default", label:'${currentValue}', backgroundColors:[
+				attributeState "level", label:'${currentValue}', defaultState: true, backgroundColors:[
 					[value: 0, color: "#ff0000"],
 					[value: 20, color: "#ffff00"],
 					[value: 40, color: "#00ff00"],
@@ -69,34 +69,34 @@ metadata {
 		}
 		multiAttributeTile(name:"lengthyTile", type:"generic", width:6, height:4) {
 			tileAttribute("device.lengthyText", key: "PRIMARY_CONTROL") {
-				attributeState "default", label:'The value of this tile is long and should wrap to two lines', backgroundColor:"#79b821"
+				attributeState "lengthyText", label:'The value of this tile is long and should wrap to two lines', backgroundColor:"#79b821", defaultState: true
 			}
 			tileAttribute("device.lengthyText", key: "SECONDARY_CONTROL") {
-				attributeState "default", label:'The value of this tile is long and should wrap to two lines', backgroundColor:"#79b821"
+				attributeState "lengthyText", label:'The value of this tile is long and should wrap to two lines', backgroundColor:"#79b821", defaultState: true
 			}
 		}
 		multiAttributeTile(name:"multilineTile", type:"generic", width:6, height:4) {
 			tileAttribute("device.multilineText", key: "PRIMARY_CONTROL") {
-				attributeState "default", label:'Line 1 YES\nLine 2 YES\nLine 3 NO', backgroundColor:"#79b821"
+				attributeState "multiLineText", label:'Line 1 YES\nLine 2 YES\nLine 3 NO', backgroundColor:"#79b821", defaultState: true
 			}
 			tileAttribute("device.multilineText", key: "SECONDARY_CONTROL") {
-				attributeState "default", label:'Line 1 YES\nLine 2 YES\nLine 3 NO', backgroundColor:"#79b821"
+				attributeState "multiLineText", label:'Line 1 YES\nLine 2 YES\nLine 3 NO', backgroundColor:"#79b821", defaultState: true
 			}
 		}
 		multiAttributeTile(name:"lengthyTileWithIcon", type:"generic", width:6, height:4) {
 			tileAttribute("device.lengthyText", key: "PRIMARY_CONTROL") {
-				attributeState "default", label:'The value of this tile is long and should wrap to two lines', backgroundColor:"#79b821", icon: "st.switches.switch.on"
+				attributeState "lengthyText", label:'The value of this tile is long and should wrap to two lines', backgroundColor:"#79b821", icon: "st.switches.switch.on", defaultState: true
 			}
 			tileAttribute("device.lengthyText", key: "SECONDARY_CONTROL") {
-				attributeState "default", label:'The value of this tile is long and should wrap to two lines', backgroundColor:"#79b821", icon: "st.switches.switch.on"
+				attributeState "lengthyText", label:'The value of this tile is long and should wrap to two lines', backgroundColor:"#79b821", icon: "st.switches.switch.on", defaultState: true
 			}
 		}
 		multiAttributeTile(name:"multilineTileWithIcon", type:"generic", width:6, height:4) {
 			tileAttribute("device.multilineText", key: "PRIMARY_CONTROL") {
-				attributeState "default", label:'Line 1 YES\nLine 2 YES\nLine 3 NO', backgroundColor:"#79b821", icon: "st.switches.switch.on"
+				attributeState "multilineText", label:'Line 1 YES\nLine 2 YES\nLine 3 NO', backgroundColor:"#79b821", icon: "st.switches.switch.on", defaultState: true
 			}
 			tileAttribute("device.multilineText", key: "SECONDARY_CONTROL") {
-				attributeState "default", label:'Line 1 YES\nLine 2 YES\nLine 3 NO', backgroundColor:"#79b821", icon: "st.switches.switch.on"
+				attributeState "multilineText", label:'Line 1 YES\nLine 2 YES\nLine 3 NO', backgroundColor:"#79b821", icon: "st.switches.switch.on", defaultState: true
 			}
 		}
 

--- a/devicetypes/smartthings/tile-ux/tile-multiattribute-lighting.src/tile-multiattribute-lighting.groovy
+++ b/devicetypes/smartthings/tile-ux/tile-multiattribute-lighting.src/tile-multiattribute-lighting.groovy
@@ -96,10 +96,10 @@ metadata {
 		}
 
 		standardTile("reset", "device.reset", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
-			state "default", label:"Reset Color", action:"reset", icon:"st.lights.philips.hue-single"
+			state "reset", label:"Reset Color", action:"reset", icon:"st.lights.philips.hue-single", defaultState: true
 		}
 		standardTile("refresh", "device.switch", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
-			state "default", label:"", action:"refresh.refresh", icon:"st.secondary.refresh"
+			state "refresh", label:"", action:"refresh.refresh", icon:"st.secondary.refresh", defaultState: true
 		}
 
 		main(["switch"])
@@ -173,7 +173,6 @@ def setColor(value) {
 def reset() {
 	log.debug "Executing 'reset'"
 	setAdjustedColor([level:100, hex:"#90C638", saturation:56, hue:23])
-	//parent.poll()
 }
 
 def setAdjustedColor(value) {
@@ -189,7 +188,6 @@ def setAdjustedColor(value) {
 
 def refresh() {
 	log.debug "Executing 'refresh'"
-	//parent.manualRefresh()
 }
 
 def adjustOutgoingHue(percent) {
@@ -208,4 +206,3 @@ def adjustOutgoingHue(percent) {
 	log.info "percent: $percent, adjusted: $adjusted"
 	adjusted
 }
-

--- a/devicetypes/smartthings/tile-ux/tile-multiattribute-mediaplayer.src/tile-multiattribute-mediaplayer.groovy
+++ b/devicetypes/smartthings/tile-ux/tile-multiattribute-mediaplayer.src/tile-multiattribute-mediaplayer.groovy
@@ -37,10 +37,10 @@ metadata {
 				attributeState("stopped", label:"Stopped", action:"music Player.play", nextState: "playing")
 			}
 			tileAttribute("device.status", key: "PREVIOUS_TRACK") {
-				attributeState("default", action:"music Player.previousTrack")
+				attributeState("status", action:"music Player.previousTrack", defaultState: true)
 			}
 			tileAttribute("device.status", key: "NEXT_TRACK") {
-				attributeState("default", action:"music Player.nextTrack")
+				attributeState("status", action:"music Player.nextTrack", defaultState: true)
 			}
 			tileAttribute ("device.level", key: "SLIDER_CONTROL") {
 				attributeState("level", action:"music Player.setLevel")
@@ -50,7 +50,7 @@ metadata {
 				attributeState("muted", action:"music Player.unmute", nextState: "unmuted")
 			}
 			tileAttribute("device.trackDescription", key: "MARQUEE") {
-				attributeState("default", label:"${currentValue}")
+				attributeState("trackDescription", label:"${currentValue}", defaultState: true)
 			}
 		}
 

--- a/devicetypes/smartthings/tile-ux/tile-multiattribute-thermostat.src/tile-multiattribute-thermostat.groovy
+++ b/devicetypes/smartthings/tile-ux/tile-multiattribute-thermostat.src/tile-multiattribute-thermostat.groovy
@@ -32,14 +32,14 @@ metadata {
 	tiles(scale: 2) {
 		multiAttributeTile(name:"thermostatFull", type:"thermostat", width:6, height:4) {
 			tileAttribute("device.temperature", key: "PRIMARY_CONTROL") {
-				attributeState("default", label:'${currentValue}', unit:"dF")
+				attributeState("temp", label:'${currentValue}', unit:"dF", defaultState: true)
 			}
 			tileAttribute("device.temperature", key: "VALUE_CONTROL") {
 				attributeState("VALUE_UP", action: "tempUp")
 				attributeState("VALUE_DOWN", action: "tempDown")
 			}
 			tileAttribute("device.humidity", key: "SECONDARY_CONTROL") {
-				attributeState("default", label:'${currentValue}%', unit:"%")
+				attributeState("humidity", label:'${currentValue}%', unit:"%", defaultState: true)
 			}
 			tileAttribute("device.thermostatOperatingState", key: "OPERATING_STATE") {
 				attributeState("idle", backgroundColor:"#44b621")
@@ -53,15 +53,16 @@ metadata {
 				attributeState("auto", label:'${name}')
 			}
 			tileAttribute("device.heatingSetpoint", key: "HEATING_SETPOINT") {
-				attributeState("default", label:'${currentValue}', unit:"dF")
+				attributeState("heatingSetpoint", label:'${currentValue}', unit:"dF", defaultState: true)
 			}
 			tileAttribute("device.coolingSetpoint", key: "COOLING_SETPOINT") {
-				attributeState("default", label:'${currentValue}', unit:"dF")
+				attributeState("coolingSetpoint", label:'${currentValue}', unit:"dF", defaultState: true)
 			}
 		}
 		multiAttributeTile(name:"thermostatNoHumidity", type:"thermostat", width:6, height:4) {
 			tileAttribute("device.temperature", key: "PRIMARY_CONTROL") {
-				attributeState("default", label:'${currentValue}', unit:"dF")
+                attributeState("coolingSetpoint", label:'${currentValue}', unit:"dF", defaultState: true)
+				attributeState("temp", label:'${currentValue}', unit:"dF")
 			}
 			tileAttribute("device.temperature", key: "VALUE_CONTROL") {
 				attributeState("VALUE_UP", action: "tempUp")
@@ -79,15 +80,16 @@ metadata {
 				attributeState("auto", label:'${name}')
 			}
 			tileAttribute("device.heatingSetpoint", key: "HEATING_SETPOINT") {
-				attributeState("default", label:'${currentValue}', unit:"dF")
+                attributeState("coolingSetpoint", label:'${currentValue}', unit:"dF", defaultState: true)
+				attributeState("heatingSetpoint", label:'${currentValue}', unit:"dF")
 			}
 			tileAttribute("device.coolingSetpoint", key: "COOLING_SETPOINT") {
-				attributeState("default", label:'${currentValue}', unit:"dF")
+				attributeState("coolingSetpoint", label:'${currentValue}', unit:"dF", defaultState: true)
 			}
 		}
 		multiAttributeTile(name:"thermostatBasic", type:"thermostat", width:6, height:4) {
 			tileAttribute("device.temperature", key: "PRIMARY_CONTROL") {
-				attributeState("default", label:'${currentValue}', unit:"dF",
+				attributeState("temp", label:'${currentValue}', unit:"dF", defaultState: true,
 				backgroundColors:[
 					[value: 31, color: "#153591"],
 					[value: 44, color: "#1e9cbb"],
@@ -118,30 +120,30 @@ metadata {
 			)
 		}
 		standardTile("tempDown", "device.temperature", width: 2, height: 2, inactiveLabel: false, decoration: "flat") {
-			state "default", label:'down', action:"tempDown"
+			state "tempDown", label:'down', action:"tempDown", defaultState: true
 		}
 		standardTile("tempUp", "device.temperature", width: 2, height: 2, inactiveLabel: false, decoration: "flat") {
-			state "default", label:'up', action:"tempUp"
+			state "tempUp", label:'up', action:"tempUp", defaultState: true
 		}
 
 		valueTile("heatingSetpoint", "device.heatingSetpoint", width: 2, height: 2, inactiveLabel: false, decoration: "flat") {
 			state "heat", label:'${currentValue} heat', unit: "F", backgroundColor:"#ffffff"
 		}
 		standardTile("heatDown", "device.temperature", width: 2, height: 2, inactiveLabel: false, decoration: "flat") {
-			state "default", label:'down', action:"heatDown"
+			state "heatDown", label:'down', action:"heatDown", defaultState: true
 		}
 		standardTile("heatUp", "device.temperature", width: 2, height: 2, inactiveLabel: false, decoration: "flat") {
-			state "default", label:'up', action:"heatUp"
+			state "heatUp", label:'up', action:"heatUp", defaultState: true
 		}
 
 		valueTile("coolingSetpoint", "device.coolingSetpoint", width: 2, height: 2, inactiveLabel: false, decoration: "flat") {
 			state "cool", label:'${currentValue} cool', unit:"F", backgroundColor:"#ffffff"
 		}
 		standardTile("coolDown", "device.temperature", width: 2, height: 2, inactiveLabel: false, decoration: "flat") {
-			state "default", label:'down', action:"coolDown"
+			state "coolDown", label:'down', action:"coolDown", defaultState: true
 		}
 		standardTile("coolUp", "device.temperature", width: 2, height: 2, inactiveLabel: false, decoration: "flat") {
-			state "default", label:'up', action:"coolUp"
+			state "coolUp", label:'up', action:"coolUp", defaultState: true
 		}
 
 		standardTile("mode", "device.thermostatMode", width: 2, height: 2, inactiveLabel: false, decoration: "flat") {


### PR DESCRIPTION
Updating state and attributeState to use `defaultState: true` instead of `"default"` name per best practices.

Also added `setColor()` command to the color wheel device tile.

@KyleLeneau or @pennig one of you should review.
