### PR TITLE
DEVTOOLS-659: Bumping executable-deployment-scripts version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'smartthings-slack'
 
 buildscript {
     dependencies {
-        classpath "com.smartthings.deployment:executable-deployment-scripts:1.0.8"
+        classpath "com.smartthings.deployment:executable-deployment-scripts:1.0.9"
     }
     repositories {
         mavenLocal()


### PR DESCRIPTION
see https://smartthings.atlassian.net/browse/DEVTOOLS-659 and https://github.com/PhysicalGraph/executable-deployment-scripts/pull/16
