### PR TITLE
INTL-527 Temperature Notifications Should Respect Location Temp Scale

### DIFF
--- a/smartapps/smartthings/its-too-cold.src/its-too-cold.groovy
+++ b/smartapps/smartthings/its-too-cold.src/its-too-cold.groovy
@@ -73,7 +73,8 @@ def temperatureHandler(evt) {
 			// TODO: Send "Temperature back to normal" SMS, turn switch off
 		} else {
 			log.debug "Temperature dropped below $tooCold:  sending SMS to $phone1 and activating $mySwitch"
-			send("${temperatureSensor1.displayName} is too cold, reporting a temperature of ${evt.value}${evt.unit?:"F"}")
+			def tempScale = location.temperatureScale ?: "F"
+			send("${temperatureSensor1.displayName} is too cold, reporting a temperature of ${evt.value}${evt.unit?:tempScale}")
 			switch1?.on()
 		}
 	}

--- a/smartapps/smartthings/its-too-hot.src/its-too-hot.groovy
+++ b/smartapps/smartthings/its-too-hot.src/its-too-hot.groovy
@@ -73,7 +73,8 @@ def temperatureHandler(evt) {
 			// TODO: Send "Temperature back to normal" SMS, turn switch off
 		} else {
 			log.debug "Temperature rose above $tooHot:  sending SMS to $phone1 and activating $mySwitch"
-			send("${temperatureSensor1.displayName} is too hot, reporting a temperature of ${evt.value}${evt.unit?:"F"}")
+			def tempScale = location.temperatureScale ?: "F"
+			send("${temperatureSensor1.displayName} is too hot, reporting a temperature of ${evt.value}${evt.unit?:tempScale}")
 			switch1?.on()
 		}
 	}


### PR DESCRIPTION
For SmartApps It's Too Hot/Cold the temperature in the notification was defaulting to fahrenheit even if the user's location setting was celsius. This PR makes the app check the location setting and send the correct temp scale in the notification.
