### PR TITLE
DVCSMP-1802 - Removing "motion sensor" capability from ecobee remote sensors

### DIFF
--- a/devicetypes/smartthings/ecobee-sensor.src/ecobee-sensor.groovy
+++ b/devicetypes/smartthings/ecobee-sensor.src/ecobee-sensor.groovy
@@ -18,7 +18,6 @@ metadata {
 	definition (name: "Ecobee Sensor", namespace: "smartthings", author: "SmartThings") {
 		capability "Sensor"
 		capability "Temperature Measurement"
-		capability "Motion Sensor"
 		capability "Refresh"
 	}
 


### PR DESCRIPTION
These devices aren't meant to be used as security sensors. They have
inconsistent response times, and can sometimes send events quite a bit
after they actually happen. Suggested fix is to remove
