### PR TITLE
SHM-417 break out Music Player into multiple capabilities

### DIFF
--- a/devicetypes/com-obycode/obything-music.src/obything-music.groovy
+++ b/devicetypes/com-obycode/obything-music.src/obything-music.groovy
@@ -19,15 +19,9 @@ import groovy.json.JsonSlurper
 metadata {
 	definition (name: "ObyThing Music", namespace: "com.obycode", author: "obycode") {
 		capability "Music Player"
-        capability "Refresh"
+		capability "Audio Notification"
+		capability "Refresh"
         capability "Switch"
-        
-		command "playTrackAtVolume", ["string","number"]
-        command "playTrackAndResume", ["string","number","number"]
-        command "playTextAndResume", ["string","number"]
-        command "playTrackAndRestore", ["string","number","number"]
-        command "playTextAndRestore", ["string","number"]
-        command "playSoundAndTrack", ["string","number","json_object","number"]
 	}
 
 	simulator {
@@ -37,21 +31,21 @@ metadata {
 	tiles {
 		// Main
 		standardTile("main", "device.status", width: 1, height: 1, canChangeIcon: true) {
-			state "paused", label:'Paused', action:"music Player.play", icon:"st.Electronics.electronics19", nextState:"playing", backgroundColor:"#ffffff"
-			state "playing", label:'Playing', action:"music Player.pause", icon:"st.Electronics.electronics19", nextState:"paused", backgroundColor:"#79b821"
+			state "paused", label:'Paused', action:"play", icon:"st.Electronics.electronics19", nextState:"playing", backgroundColor:"#ffffff"
+			state "playing", label:'Playing', action:"pause", icon:"st.Electronics.electronics19", nextState:"paused", backgroundColor:"#79b821"
 		}
 
 		// Row 1
 		standardTile("nextTrack", "device.status", width: 1, height: 1, decoration: "flat") {
-			state "next", label:'', action:"music Player.nextTrack", icon:"st.sonos.next-btn", backgroundColor:"#ffffff"
+			state "next", label:'', action:"nextTrack", icon:"st.sonos.next-btn", backgroundColor:"#ffffff"
 		}
 		standardTile("playpause", "device.status", width: 1, height: 1, decoration: "flat") {
-			state "default", label:'', action:"music Player.play", icon:"st.sonos.play-btn", nextState:"playing", backgroundColor:"#ffffff"
-			state "playing", label:'', action:"music Player.pause", icon:"st.sonos.pause-btn", nextState:"paused", backgroundColor:"#ffffff"
-            state "paused", label:'', action:"music Player.play", icon:"st.sonos.play-btn", nextState:"playing", backgroundColor:"#ffffff"
+			state "default", label:'', action:"play", icon:"st.sonos.play-btn", nextState:"playing", backgroundColor:"#ffffff"
+			state "playing", label:'', action:"pause", icon:"st.sonos.pause-btn", nextState:"paused", backgroundColor:"#ffffff"
+            state "paused", label:'', action:"play", icon:"st.sonos.play-btn", nextState:"playing", backgroundColor:"#ffffff"
 		}
 		standardTile("previousTrack", "device.status", width: 1, height: 1, decoration: "flat") {
-			state "previous", label:'', action:"music Player.previousTrack", icon:"st.sonos.previous-btn", backgroundColor:"#ffffff"
+			state "previous", label:'', action:"previousTrack", icon:"st.sonos.previous-btn", backgroundColor:"#ffffff"
 		}
 
 		// Row 2
@@ -60,18 +54,18 @@ metadata {
 			state "off", label:'AirPlay Off', action:"switch.on", icon:"st.Electronics.electronics16", nextState:"on", backgroundColor:"#ffffff"
 		}
 		standardTile("status", "device.status", width: 1, height: 1, decoration: "flat", canChangeIcon: true) {
-			state "playing", label:'Playing', action:"music Player.pause", icon:"st.Electronics.electronics19", nextState:"paused", backgroundColor:"#ffffff"
-			state "stopped", label:'Stopped', action:"music Player.play", icon:"st.Electronics.electronics19", nextState:"playing", backgroundColor:"#ffffff"
-			state "paused", label:'Paused', action:"music Player.play", icon:"st.Electronics.electronics19", nextState:"playing", backgroundColor:"#ffffff"
+			state "playing", label:'Playing', action:"pause", icon:"st.Electronics.electronics19", nextState:"paused", backgroundColor:"#ffffff"
+			state "stopped", label:'Stopped', action:"play", icon:"st.Electronics.electronics19", nextState:"playing", backgroundColor:"#ffffff"
+			state "paused", label:'Paused', action:"play", icon:"st.Electronics.electronics19", nextState:"playing", backgroundColor:"#ffffff"
 		}
 		standardTile("mute", "device.mute", inactiveLabel: false, decoration: "flat") {
-			state "unmuted", label:"Mute", action:"music Player.mute", icon:"st.custom.sonos.unmuted", backgroundColor:"#ffffff", nextState:"muted"
-			state "muted", label:"Unmute", action:"music Player.unmute", icon:"st.custom.sonos.muted", backgroundColor:"#ffffff", nextState:"unmuted"
+			state "unmuted", label:"Mute", action:"mute", icon:"st.custom.sonos.unmuted", backgroundColor:"#ffffff", nextState:"muted"
+			state "muted", label:"Unmute", action:"unmute", icon:"st.custom.sonos.muted", backgroundColor:"#ffffff", nextState:"unmuted"
 		}
 
 		// Row 3
 		controlTile("levelSliderControl", "device.level", "slider", height: 1, width: 3, inactiveLabel: false) {
-			state "level", action:"music Player.setLevel", backgroundColor:"#ffffff"
+			state "level", action:"setLevel", backgroundColor:"#ffffff"
 		}
 
 		// Row 4 - Disable this for now until we get communication back to hub working

--- a/smartapps/michaelstruck/talking-alarm-clock.src/talking-alarm-clock.groovy
+++ b/smartapps/michaelstruck/talking-alarm-clock.src/talking-alarm-clock.groovy
@@ -90,7 +90,7 @@ def pageMain() {
 
 page(name: "pageAlarmSummary", title: "Alarm Summary Settings") {
 	section {
-       	input "summarySonos", "capability.musicPlayer", title: "Choose a Sonos speaker", required: false
+       	input "summarySonos", "capability.audioNotification", title: "Choose a Sonos speaker", required: false
         input "summaryVolume", "number", title: "Set the summary volume", description: "0-100%", required: false
         input "summaryDisabled", "bool", title: "Include disabled or unconfigured alarms in summary", defaultValue: "false"
         input "summaryMode", "mode", title: "Speak summary only during the following modes...", multiple: true, required: false
@@ -101,7 +101,7 @@ def pageSetupScenarioA() {
     dynamicPage(name: "pageSetupScenarioA") {
 		section("Alarm settings") {
         	input "ScenarioNameA", "text", title: "Scenario Name", multiple: false, required: true
-			input "A_sonos", "capability.musicPlayer", title: "Choose a Sonos speaker", required: true, submitOnChange:true
+			input "A_sonos", "capability.audioNotification", title: "Choose a Sonos speaker", required: true, submitOnChange:true
             input "A_volume", "number", title: "Alarm volume", description: "0-100%", required: false
         	input "A_timeStart", "time", title: "Time to trigger alarm", required: true
         	input "A_day", "enum", options: ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"], title: "Alarm on certain days of the week...", multiple: true, required: false
@@ -194,7 +194,7 @@ def pageSetupScenarioB() {
     dynamicPage(name: "pageSetupScenarioB") {
 		section("Alarm settings") {
         	input "ScenarioNameB", "text", title: "Scenario Name", multiple: false, required: true
-			input "B_sonos", "capability.musicPlayer", title: "Choose a Sonos speaker", required: true, submitOnChange:true
+			input "B_sonos", "capability.audioNotification", title: "Choose a Sonos speaker", required: true, submitOnChange:true
             input "B_volume", "number", title: "Alarm volume", description: "0-100%", required: false
         	input "B_timeStart", "time", title: "Time to trigger alarm", required: true
         	input "B_day", "enum", options: ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"], title: "Alarm on certain days of the week...", multiple: true, required: false
@@ -287,7 +287,7 @@ def pageSetupScenarioC() {
     dynamicPage(name: "pageSetupScenarioC") {
 		section("Alarm settings") {
         	input "ScenarioNameC", "text", title: "Scenario Name", multiple: false, required: true
-			input "C_sonos", "capability.musicPlayer", title: "Choose a Sonos speaker", required: true, submitOnChange:true
+			input "C_sonos", "capability.audioNotification", title: "Choose a Sonos speaker", required: true, submitOnChange:true
             input "C_volume", "number", title: "Alarm volume", description: "0-100%", required: false
         	input "C_timeStart", "time", title: "Time to trigger alarm", required: true
         	input "C_day", "enum", options: ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"], title: "Alarm on certain days of the week...", multiple: true, required: false
@@ -381,7 +381,7 @@ def pageSetupScenarioD() {
     dynamicPage(name: "pageSetupScenarioD") {
 		section("Alarm settings") {
         	input "ScenarioNameD", "text", title: "Scenario Name", multiple: false, required: true
-			input "D_sonos", "capability.musicPlayer", title: "Choose a Sonos speaker", required: true, submitOnChange:true
+			input "D_sonos", "capability.audioNotification", title: "Choose a Sonos speaker", required: true, submitOnChange:true
             input "D_volume", "number", title: "Alarm volume", description: "0-100%", required: false
         	input "D_timeStart", "time", title: "Time to trigger alarm", required: true
         	input "D_day", "enum", options: ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"], title: "Alarm on certain days of the week...", multiple: true, required: false

--- a/smartapps/smartthings/gentle-wake-up.src/gentle-wake-up.groovy
+++ b/smartapps/smartthings/gentle-wake-up.src/gentle-wake-up.groovy
@@ -241,7 +241,7 @@ def completionPage() {
 				input(name: "completionPhoneNumber", type: "phone", title: "Text This Number", description: "Phone number", required: false)
 				input(name: "completionPush", type: "bool", title: "Send A Push Notification", description: "Phone number", required: false)
 			}
-			input(name: "completionMusicPlayer", type: "capability.musicPlayer", title: "Speak Using This Music Player", required: false)
+			input(name: "completionMusicPlayer", type: "capability.audioNotification", title: "Speak Using This Music Player", required: false)
 			input(name: "completionMessage", type: "text", title: "With This Message", description: null, required: false)
 		}
 

--- a/smartapps/smartthings/sonos-music-modes.src/sonos-music-modes.groovy
+++ b/smartapps/smartthings/sonos-music-modes.src/sonos-music-modes.groovy
@@ -101,7 +101,7 @@ def mainPage() {
 	dynamicPage(name: "mainPage") {
 
 		section {
-			input "sonos", "capability.musicPlayer", title: "Sonos player", required: true
+			input "sonos", "capability.trackingMusicPlayer", title: "Sonos player", required: true
 		}
 		section("More options", hideable: true, hidden: true) {
 			input "volume", "number", title: "Set the volume", description: "0-100%", required: false

--- a/smartapps/smartthings/speaker-notify-with-sound.src/speaker-notify-with-sound.groovy
+++ b/smartapps/smartthings/speaker-notify-with-sound.src/speaker-notify-with-sound.groovy
@@ -92,7 +92,7 @@ def mainPage() {
 			input "message","text",title:"Play this message", required:false, multiple: false
 		}
 		section {
-			input "sonos", "capability.musicPlayer", title: "On this Speaker player", required: true
+			input "sonos", "capability.audioNotification", title: "On this Speaker player", required: true
 		}
 		section("More options", hideable: true, hidden: true) {
 			input "resumePlaying", "bool", title: "Resume currently playing music after notification", required: false, defaultValue: true

--- a/smartapps/smartthings/speaker-weather-forecast.src/speaker-weather-forecast.groovy
+++ b/smartapps/smartthings/speaker-weather-forecast.src/speaker-weather-forecast.groovy
@@ -85,7 +85,7 @@ def mainPage() {
 			)
 		}
 		section {
-			input "sonos", "capability.musicPlayer", title: "On this Speaker player", required: true
+			input "sonos", "capability.audioNotification", title: "On this Speaker player", required: true
 		}
 		section("More options", hideable: true, hidden: true) {
 			input "resumePlaying", "bool", title: "Resume currently playing music after weather report finishes", required: false, defaultValue: true

--- a/smartapps/smartthings/step-notifier.src/step-notifier.groovy
+++ b/smartapps/smartthings/step-notifier.src/step-notifier.groovy
@@ -71,7 +71,7 @@ def setupNotifications() {
         }
         
         section("Play a song on the Sonos") {
-			input "sonos", "capability.musicPlayer", title: "On this Sonos player", required: false, submitOnChange:true
+			input "sonos", "capability.audioNotification", title: "On this Sonos player", required: false, submitOnChange:true
             if (settings.sonos) {
 				input "song","enum",title:"Play this track or radio station", required:true, multiple: false, options: songOptions()  
 				input "resumePlaying", "bool", title: "Resume currently playing music after notification", required: false, defaultValue: true                

--- a/smartapps/statusbits/smart-alarm.src/smart-alarm.groovy
+++ b/smartapps/statusbits/smart-alarm.src/smart-alarm.groovy
@@ -748,7 +748,7 @@ def pageNotifications() {
 
     def inputAudioPlayers = [
         name:           "audioPlayer",
-        type:           "capability.musicPlayer",
+        type:           "capability.audioNotification",
         title:          "Which audio players?",
         multiple:       true,
         required:       false


### PR DESCRIPTION
This change accommodates the splitting out of some of the _Music Player_ capability's commands and attributes in to new _Audio Notification_ and _Tracking Music Player_ capabilities. The objective is to prevent selection of music players that don't provide the functions and attributes required by the SmartApp. The current supported music devices break out this way:

| Device Handler | Music Player | Tracking Music Player | Audio Notification |
| --- | :-: | :-: | :-: |
| Sonos | X | X | X |
| Samsung | X |  | X |
| Bose | X |  |  |
