### PR TITLE
PRP-172 Fix Hue Connect parse errors on newer versions of Groovy

### DIFF
--- a/smartapps/smartthings/hue-connect.src/hue-connect.groovy
+++ b/smartapps/smartthings/hue-connect.src/hue-connect.groovy
@@ -689,7 +689,7 @@ def parse(childDevice, description) {
             	log.warn "Parsing Body failed - trying again..."
                 poll()
             }
-            if (body instanceof java.util.HashMap) {
+			if (body instanceof java.util.HashMap || body instanceof groovy.json.internal.LazyMap) {
             	//poll response
                 def bulbs = getChildDevices()
                 for (bulb in body) {
@@ -830,22 +830,22 @@ def setColorTemperature(childDevice, huesettings) {
 
 def setColor(childDevice, huesettings) {
     log.debug "Executing 'setColor($huesettings)'"
-    
+
     def value = [:]
     def hue = null
     def sat = null
     def xy = null
-    
+
     if (huesettings.hex != null) {
         value.xy = getHextoXY(huesettings.hex)
     } else {
         if (huesettings.hue != null)
             value.hue = Math.min(Math.round(huesettings.hue * 65535 / 100), 65535)
-        if (huesettings.saturation != null)   
+        if (huesettings.saturation != null)
             value.sat = Math.min(Math.round(huesettings.saturation * 255 / 100), 255)
     }
-    
-    // Default behavior is to turn light on 
+
+    // Default behavior is to turn light on
     value.on = true
 
     if (huesettings.level != null) {
@@ -853,7 +853,7 @@ def setColor(childDevice, huesettings) {
             value.on = false
         else if (huesettings.level == 1)
             value.bri = 1
-        else 
+        else
             value.bri = Math.min(Math.round(huesettings.level * 255 / 100), 255)
     }
     value.alert = huesettings.alert ? huesettings.alert : "none"


### PR DESCRIPTION
In Grails 2.3.11 `new groovy.json.JsonSlurper().parseText(bodyString)` returns a `java.util.HashMap`, but in Grails 2.5.4 it returns a `groovy.json.internal.LazyMap`.  This change modifies the `instanceof` check after parsing the body to look for both so that we can match on dni properly. By modifying to check for both we can future proof the SA for when we actually roll out the upgrade.

It's also worth noting that with the current version of Grails when iterating over the `java.util.HashMap` we get objects of type `java.util.HashMap$Entry` where when looping over `groovy.json.internal.LazyMap` we get objects of type `java.util.TreeMap$Entry` in case there is any logic that actually relies on those types downstream from the parse.
