### PR TITLE
fix divide by zero exception [DVCSMP-1891]

### DIFF
--- a/smartapps/smartthings/gentle-wake-up.src/gentle-wake-up.groovy
+++ b/smartapps/smartthings/gentle-wake-up.src/gentle-wake-up.groovy
@@ -720,7 +720,7 @@ def completionPercentage() {
 
 	def now = new Date().getTime()
 	def timeElapsed = now - atomicState.start
-	def totalRunTime = totalRunTimeMillis()
+	def totalRunTime = totalRunTimeMillis() ?: 1
 	def percentComplete = timeElapsed / totalRunTime * 100
 	log.debug "percentComplete: ${percentComplete}"
 


### PR DESCRIPTION
If a user enters `0` as their duration, a divide by zero exception will be thrown when calculating completionPercentage. This prevents that exception.

[DVCSMP-1891](https://smartthings.atlassian.net/browse/DVCSMP-1891)
