### PR TITLE
Add capability sensor to SS Open/Closed

### DIFF
--- a/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
@@ -22,6 +22,7 @@ metadata {
 		capability "Refresh"
 		capability "Temperature Measurement"
 		capability "Health Check"
+		capability "Sensor"
 
 		command "enrollResponse"
 


### PR DESCRIPTION
There are some integrations out there using the "Actuator" and "Sensor" Capabilities and this doesn't show up for them.

cc @workingmonk 
