### PR TITLE
DPROT-2: Update DTHs to use ZigBee library ZoneStatus

### DIFF
--- a/devicetypes/smartthings/nyce-motion-sensor.src/nyce-motion-sensor.groovy
+++ b/devicetypes/smartthings/nyce-motion-sensor.src/nyce-motion-sensor.groovy
@@ -13,6 +13,7 @@
  *  for the specific language governing permissions and limitations under the License.
  *
  */
+import physicalgraph.zigbee.clusters.iaszone.ZoneStatus
 
 metadata {
 	definition (name: "NYCE Motion Sensor", namespace: "smartthings", author: "SmartThings") {
@@ -143,51 +144,14 @@ private Map parseReportAttributeMessage(String description) {
  
 
 private Map parseIasMessage(String description) {
-    List parsedMsg = description.split(' ')
-    String msgCode = parsedMsg[2]
-    
-    Map resultMap = [:]
-    switch(msgCode) {
-        case '0x0030': // Closed/No Motion/Dry
-            log.debug 'no motion'
-            resultMap.name = 'motion'
-            resultMap.value = 'inactive'
-            break
+	ZoneStatus zs = zigbee.parseZoneStatus(description)
+	Map resultMap = [:]
 
-        case '0x0032': // Open/Motion/Wet
-            log.debug 'motion'
-            resultMap.name = 'motion'
-            resultMap.value = 'active'
-            break
+	result.name = 'motion'
+	result.value = zs.isAlarm2Set() ? 'active' : 'inactive'
+	log.debug(zs.isAlarm2Set() ? 'motion' : 'no motion')
 
-        case '0x0032': // Tamper Alarm
-        	log.debug 'motion with tamper alarm'
-            resultMap.name = 'motion'
-            resultMap.value = 'active'
-            break
-
-        case '0x0033': // Battery Alarm
-            break
-
-        case '0x0034': // Supervision Report
-        	log.debug 'no motion with tamper alarm'
-            resultMap.name = 'motion'
-            resultMap.value = 'inactive'
-            break
-
-        case '0x0035': // Restore Report
-            break
-
-        case '0x0036': // Trouble/Failure
-        	log.debug 'motion with failure alarm'
-            resultMap.name = 'motion'
-            resultMap.value = 'active'
-            break
-
-        case '0x0038': // Test Mode
-            break
-    }
-    return resultMap
+	return resultMap
 }
 
 def refresh()

--- a/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
@@ -13,6 +13,8 @@
  *  License for the specific language governing permissions and limitations
  *  under the License.
  */
+import physicalgraph.zigbee.clusters.iaszone.ZoneStatus
+
 
 metadata {
 	definition (name: "SmartSense Moisture Sensor",namespace: "smartthings", author: "SmartThings", category: "C2") {
@@ -169,42 +171,9 @@ private Map parseCustomMessage(String description) {
 }
 
 private Map parseIasMessage(String description) {
-	List parsedMsg = description.split(' ')
-	String msgCode = parsedMsg[2]
+	ZoneStatus zs = zigbee.parseZoneStatus(description)
 
-	Map resultMap = [:]
-	switch(msgCode) {
-		case '0x0020': // Closed/No Motion/Dry
-			resultMap = getMoistureResult('dry')
-			break
-
-		case '0x0021': // Open/Motion/Wet
-			resultMap = getMoistureResult('wet')
-			break
-
-		case '0x0022': // Tamper Alarm
-			break
-
-		case '0x0023': // Battery Alarm
-			break
-
-		case '0x0024': // Supervision Report
-			 log.debug 'dry with tamper alarm'
-			resultMap = getMoistureResult('dry')
-			break
-
-		case '0x0025': // Restore Report
-			log.debug 'water with tamper alarm'
-			resultMap = getMoistureResult('wet')
-			break
-
-		case '0x0026': // Trouble/Failure
-			break
-
-		case '0x0028': // Test Mode
-			break
-	}
-	return resultMap
+	return zs.isAlarm1Set() ? getMoistureResult('wet') : getMoistureResult('dry')
 }
 
 def getTemperature(value) {

--- a/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
@@ -13,6 +13,8 @@
  *  License for the specific language governing permissions and limitations
  *  under the License.
  */
+import physicalgraph.zigbee.clusters.iaszone.ZoneStatus
+
 
 metadata {
 	definition (name: "SmartSense Motion Sensor", namespace: "smartthings", author: "SmartThings", category: "C2") {
@@ -182,44 +184,10 @@ private Map parseCustomMessage(String description) {
 }
 
 private Map parseIasMessage(String description) {
-	List parsedMsg = description.split(' ')
-	String msgCode = parsedMsg[2]
+	ZoneStatus zs = zigbee.parseZoneStatus(description)
 
-	Map resultMap = [:]
-	switch(msgCode) {
-		case '0x0020': // Closed/No Motion/Dry
-			resultMap = getMotionResult('inactive')
-			break
-
-		case '0x0021': // Open/Motion/Wet
-			resultMap = getMotionResult('active')
-			break
-
-		case '0x0022': // Tamper Alarm
-			log.debug 'motion with tamper alarm'
-			resultMap = getMotionResult('active')
-			break
-
-		case '0x0023': // Battery Alarm
-			break
-
-		case '0x0024': // Supervision Report
-			log.debug 'no motion with tamper alarm'
-			resultMap = getMotionResult('inactive')
-			break
-
-		case '0x0025': // Restore Report
-			break
-
-		case '0x0026': // Trouble/Failure
-			log.debug 'motion with failure alarm'
-			resultMap = getMotionResult('active')
-			break
-
-		case '0x0028': // Test Mode
-			break
-	}
-	return resultMap
+	// Some sensor models that use this DTH use alarm1 and some use alarm2 to signify motion
+	return (zs.isAlarm1Set() || zs.isAlarm2Set()) ? getMotionResult('active') : getMotionResult('inactive')
 }
 
 def getTemperature(value) {

--- a/devicetypes/smartthings/smartsense-motion-temp-sensor.src/smartsense-motion-temp-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-temp-sensor.src/smartsense-motion-temp-sensor.groovy
@@ -15,6 +15,7 @@
  */
 
 //DEPRECATED - Using the smartsense-motion-sensor.groovy DTH for this device. Users need to be moved before deleting this DTH
+import physicalgraph.zigbee.clusters.iaszone.ZoneStatus
 
 metadata {
 	definition (name: "SmartSense Motion/Temp Sensor", namespace: "smartthings", author: "SmartThings") {
@@ -168,44 +169,8 @@ private Map parseCustomMessage(String description) {
 }
 
 private Map parseIasMessage(String description) {
-    List parsedMsg = description.split(' ')
-    String msgCode = parsedMsg[2]
-
-    Map resultMap = [:]
-    switch(msgCode) {
-        case '0x0020': // Closed/No Motion/Dry
-        	resultMap = getMotionResult('inactive')
-            break
-
-        case '0x0021': // Open/Motion/Wet
-        	resultMap = getMotionResult('active')
-            break
-
-        case '0x0022': // Tamper Alarm
-        	log.debug 'motion with tamper alarm'
-        	resultMap = getMotionResult('active')
-            break
-
-        case '0x0023': // Battery Alarm
-            break
-
-        case '0x0024': // Supervision Report
-        	log.debug 'no motion with tamper alarm'
-        	resultMap = getMotionResult('inactive')
-            break
-
-        case '0x0025': // Restore Report
-            break
-
-        case '0x0026': // Trouble/Failure
-        	log.debug 'motion with failure alarm'
-        	resultMap = getMotionResult('active')
-            break
-
-        case '0x0028': // Test Mode
-            break
-    }
-    return resultMap
+	ZoneStatus zs = zigbee.parseZoneStatus(description)
+	return zs.isAlarm1Set() ? getMotionResult('active') : getMotionResult('inactive')
 }
 
 def getTemperature(value) {

--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -13,6 +13,7 @@
  *  License for the specific language governing permissions and limitations
  *  under the License.
  */
+import physicalgraph.zigbee.clusters.iaszone.ZoneStatus
 
 metadata {
 	definition (name: "SmartSense Multi Sensor", namespace: "smartthings", author: "SmartThings", category: "C2") {
@@ -224,47 +225,13 @@ private Map parseCustomMessage(String description) {
 }
 
 private Map parseIasMessage(String description) {
-	List parsedMsg = description.split(' ')
-	String msgCode = parsedMsg[2]
-
+	ZoneStatus zs = zigbee.parseZoneStatus(description)
 	Map resultMap = [:]
-	switch(msgCode) {
-		case '0x0020': // Closed/No Motion/Dry
-			if (garageSensor != "Yes"){
-				resultMap = getContactResult('closed')
-			}
-		break
 
-		case '0x0021': // Open/Motion/Wet
-			if (garageSensor != "Yes"){
-				resultMap = getContactResult('open')
-			}
-		break
-
-		case '0x0022': // Tamper Alarm
-		break
-
-		case '0x0023': // Battery Alarm
-		break
-
-		case '0x0024': // Supervision Report
-			if (garageSensor != "Yes"){
-				resultMap = getContactResult('closed')
-			}
-		break
-
-		case '0x0025': // Restore Report
-			if (garageSensor != "Yes"){
-				resultMap = getContactResult('open')
-			}
-		break
-
-		case '0x0026': // Trouble/Failure
-		break
-
-		case '0x0028': // Test Mode
-		break
+	if(garageSensor !=  "Yes") {
+		resultMap = zs.isAlarm1Set() ? getContactResult('open') : getContactResult('closed')
 	}
+
 	return resultMap
 }
 

--- a/devicetypes/smartthings/smartsense-open-closed-accelerometer-sensor.src/smartsense-open-closed-accelerometer-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-accelerometer-sensor.src/smartsense-open-closed-accelerometer-sensor.groovy
@@ -14,6 +14,7 @@
  *
  */
 //DEPRECATED - Using the smartsense-multi-sensor.groovy DTH for this device. Users need to be moved before deleting this DTH
+import physicalgraph.zigbee.clusters.iaszone.ZoneStatus
 
  metadata {
  	definition (name: "SmartSense Open/Closed Accelerometer Sensor", namespace: "smartthings", author: "SmartThings", category: "C2") {
@@ -171,40 +172,9 @@ private Map parseCustomMessage(String description) {
 }
 
 private Map parseIasMessage(String description) {
-	List parsedMsg = description.split(' ')
-	String msgCode = parsedMsg[2]
+	ZoneStatus zs = zigbee.parseZoneStatus(description)
 
-	Map resultMap = [:]
-	switch(msgCode) {
-        case '0x0020': // Closed/No Motion/Dry
-        resultMap = getContactResult('closed')
-        break
-
-        case '0x0021': // Open/Motion/Wet
-        resultMap = getContactResult('open')
-        break
-
-        case '0x0022': // Tamper Alarm
-        break
-
-        case '0x0023': // Battery Alarm
-        break
-
-        case '0x0024': // Supervision Report
-        resultMap = getContactResult('closed')
-        break
-
-        case '0x0025': // Restore Report
-        resultMap = getContactResult('open')
-        break
-
-        case '0x0026': // Trouble/Failure
-        break
-
-        case '0x0028': // Test Mode
-        break
-    }
-    return resultMap
+	return zs.isAlarm1Set() ? getContactResult('open') : getContactResult('closed')
 }
 
 def getTemperature(value) {

--- a/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
@@ -13,6 +13,7 @@
  *  for the specific language governing permissions and limitations under the License.
  *
  */
+import physicalgraph.zigbee.clusters.iaszone.ZoneStatus
 
 metadata {
 	definition (name: "SmartSense Open/Closed Sensor", namespace: "smartthings", author: "SmartThings", category: "C2") {
@@ -167,40 +168,8 @@ private Map parseCustomMessage(String description) {
 }
 
 private Map parseIasMessage(String description) {
-    List parsedMsg = description.split(' ')
-    String msgCode = parsedMsg[2]
-
-    Map resultMap = [:]
-    switch(msgCode) {
-        case '0x0020': // Closed/No Motion/Dry
-        	resultMap = getContactResult('closed')
-            break
-
-        case '0x0021': // Open/Motion/Wet
-        	resultMap = getContactResult('open')
-            break
-
-        case '0x0022': // Tamper Alarm
-            break
-
-        case '0x0023': // Battery Alarm
-            break
-
-        case '0x0024': // Supervision Report
-        	resultMap = getContactResult('closed')
-            break
-
-        case '0x0025': // Restore Report
-        	resultMap = getContactResult('open')
-            break
-
-        case '0x0026': // Trouble/Failure
-            break
-
-        case '0x0028': // Test Mode
-            break
-    }
-    return resultMap
+	ZoneStatus zs = zigbee.parseZoneStatus(description)
+	return zs.isAlarm1Set() ? getContactResult('open') : getContactResult('closed')
 }
 
 def getTemperature(value) {

--- a/devicetypes/smartthings/tyco-door-window-sensor.src/tyco-door-window-sensor.groovy
+++ b/devicetypes/smartthings/tyco-door-window-sensor.src/tyco-door-window-sensor.groovy
@@ -13,6 +13,7 @@
  *  for the specific language governing permissions and limitations under the License.
  *
  */
+import physicalgraph.zigbee.clusters.iaszone.ZoneStatus
 
 metadata {
 	definition (name: "Tyco Door/Window Sensor", namespace: "smartthings", author: "SmartThings") {
@@ -161,40 +162,9 @@ private Map parseCustomMessage(String description) {
 }
 
 private Map parseIasMessage(String description) {
-    List parsedMsg = description.split(' ')
-    String msgCode = parsedMsg[2]
+	ZoneStatus zs = zigbee.parseZoneStatus(description)
 
-    Map resultMap = [:]
-    switch(msgCode) {
-        case '0x0020': // Closed/No Motion/Dry
-        	resultMap = getContactResult('closed')
-            break
-
-        case '0x0021': // Open/Motion/Wet
-        	resultMap = getContactResult('open')
-            break
-
-        case '0x0022': // Tamper Alarm
-            break
-
-        case '0x0023': // Battery Alarm
-            break
-
-        case '0x0024': // Supervision Report
-        	resultMap = getContactResult('closed')
-            break
-
-        case '0x0025': // Restore Report
-        	resultMap = getContactResult('open')
-            break
-
-        case '0x0026': // Trouble/Failure
-            break
-
-        case '0x0028': // Test Mode
-            break
-    }
-    return resultMap
+	return zs.isAlarm1Set() ? getContactResult('open') : getContactResult('closed')
 }
 
 def getTemperature(value) {


### PR DESCRIPTION
This makes use of a new class exposed from the ZigBee library to
automatically parse the ZoneStatus attribute bit map and expose
the individual values in a simple way.  This fixes a lot of
unhandled cases in the previous copy-pasted switch statements,
as well as allowing for a simpler interface with less copy/pasted
code.

@tpmanley @workingmonk 
