### PR TITLE
Added Capability "Sensor" and/or "Actuator" per DTH standards.

### DIFF
--- a/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
@@ -22,6 +22,7 @@ metadata {
 		capability "Temperature Measurement"
 		capability "Water Sensor"
 		capability "Health Check"
+		capability "Sensor"		
 
 		command "enrollResponse"
 

--- a/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
@@ -22,6 +22,7 @@ metadata {
 		capability "Temperature Measurement"
 		capability "Refresh"
 		capability "Health Check"
+		capability "Sensor"		
 
 		command "enrollResponse"
 

--- a/devicetypes/smartthings/smartsense-open-closed-accelerometer-sensor.src/smartsense-open-closed-accelerometer-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-accelerometer-sensor.src/smartsense-open-closed-accelerometer-sensor.groovy
@@ -24,6 +24,7 @@
  		capability "Refresh"
  		capability "Temperature Measurement"
 		capability "Health Check"
+		capability "Sensor"
 
 		command "enrollResponse"
  	}

--- a/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
@@ -21,6 +21,7 @@ metadata {
 		capability "Temperature Measurement"
 		capability "Relative Humidity Measurement"
 		capability "Health Check"
+		capability "Sensor"
 
 		fingerprint endpointId: "01", inClusters: "0001,0003,0020,0402,0B05,FC45", outClusters: "0019,0003"
 	}

--- a/devicetypes/smartthings/testing/simulated-alarm.src/simulated-alarm.groovy
+++ b/devicetypes/smartthings/testing/simulated-alarm.src/simulated-alarm.groovy
@@ -16,6 +16,8 @@
 metadata {
 	definition (name: "Simulated Alarm", namespace: "smartthings/testing", author: "SmartThings") {
 		capability "Alarm"
+		capability "Sensor"
+		capability "Actuator"
 	}
 
 	simulator {

--- a/devicetypes/smartthings/testing/simulated-color-control.src/simulated-color-control.groovy
+++ b/devicetypes/smartthings/testing/simulated-color-control.src/simulated-color-control.groovy
@@ -1,6 +1,8 @@
 metadata {
 	definition (name: "Simulated Color Control", namespace: "smartthings/testing", author: "SmartThings") {
     	capability "Color Control"
+		capability "Sensor"
+		capability "Actuator"
 	}
 
 	simulator {

--- a/devicetypes/smartthings/testing/simulated-contact-sensor.src/simulated-contact-sensor.groovy
+++ b/devicetypes/smartthings/testing/simulated-contact-sensor.src/simulated-contact-sensor.groovy
@@ -15,6 +15,7 @@ metadata {
 	// Automatically generated. Make future change here.
 	definition (name: "Simulated Contact Sensor", namespace: "smartthings/testing", author: "bob") {
 		capability "Contact Sensor"
+		capability "Sensor"
 
 		command "open"
 		command "close"

--- a/devicetypes/smartthings/testing/simulated-lock.src/simulated-lock.groovy
+++ b/devicetypes/smartthings/testing/simulated-lock.src/simulated-lock.groovy
@@ -15,6 +15,8 @@ metadata {
 	// Automatically generated. Make future change here.
 	definition (name: "Simulated Lock", namespace: "smartthings/testing", author: "bob") {
 		capability "Lock"
+		capability "Sensor"
+		capability "Actuator"
 	}
 
 	// Simulated lock

--- a/devicetypes/smartthings/testing/simulated-motion-sensor.src/simulated-motion-sensor.groovy
+++ b/devicetypes/smartthings/testing/simulated-motion-sensor.src/simulated-motion-sensor.groovy
@@ -15,6 +15,7 @@ metadata {
 	// Automatically generated. Make future change here.
 	definition (name: "Simulated Motion Sensor", namespace: "smartthings/testing", author: "bob") {
 		capability "Motion Sensor"
+		capability "Sensor"
 
 		command "active"
 		command "inactive"

--- a/devicetypes/smartthings/testing/simulated-presence-sensor.src/simulated-presence-sensor.groovy
+++ b/devicetypes/smartthings/testing/simulated-presence-sensor.src/simulated-presence-sensor.groovy
@@ -15,6 +15,7 @@ metadata {
 	// Automatically generated. Make future change here.
 	definition (name: "Simulated Presence Sensor", namespace: "smartthings/testing", author: "bob") {
 		capability "Presence Sensor"
+		capability "Sensor"
 
 		command "arrived"
 		command "departed"

--- a/devicetypes/smartthings/testing/simulated-switch.src/simulated-switch.groovy
+++ b/devicetypes/smartthings/testing/simulated-switch.src/simulated-switch.groovy
@@ -16,6 +16,8 @@ metadata {
     definition (name: "Simulated Switch", namespace: "smartthings/testing", author: "bob") {
 		capability "Switch"
         capability "Relay Switch"
+		capability "Sensor"
+		capability "Actuator"
 
 		command "onPhysical"
 		command "offPhysical"

--- a/devicetypes/smartthings/testing/simulated-temperature-sensor.src/simulated-temperature-sensor.groovy
+++ b/devicetypes/smartthings/testing/simulated-temperature-sensor.src/simulated-temperature-sensor.groovy
@@ -16,6 +16,7 @@ metadata {
 	definition (name: "Simulated Temperature Sensor", namespace: "smartthings/testing", author: "SmartThings") {
 		capability "Temperature Measurement"
 		capability "Switch Level"
+		capability "Sensor"
 
 		command "up"
 		command "down"

--- a/devicetypes/smartthings/testing/simulated-thermostat.src/simulated-thermostat.groovy
+++ b/devicetypes/smartthings/testing/simulated-thermostat.src/simulated-thermostat.groovy
@@ -16,6 +16,8 @@ metadata {
 	definition (name: "Simulated Thermostat", namespace: "smartthings/testing", author: "SmartThings") {
 		capability "Thermostat"
 		capability "Relative Humidity Measurement"
+		capability "Sensor"
+		capability "Actuator"
 
 		command "tempUp"
 		command "tempDown"

--- a/devicetypes/smartthings/testing/simulated-water-sensor.src/simulated-water-sensor.groovy
+++ b/devicetypes/smartthings/testing/simulated-water-sensor.src/simulated-water-sensor.groovy
@@ -15,6 +15,7 @@ metadata {
 	// Automatically generated. Make future change here.
 	definition (name: "Simulated Water Sensor", namespace: "smartthings/testing", author: "SmartThings") {
 		capability "Water Sensor"
+		capability "Sensor"
         
         command "wet"
         command "dry"


### PR DESCRIPTION
There are some integrations out there using the "Actuator" and "Sensor" Capabilities and instances of these Devices (and perhaps more) do not show up for them. _Example_ SmartApp "SmartTiles V6 Beta".
- Ref Docs: http://docs.smartthings.com/en/latest/device-type-developers-guide/overview.html?highlight=sensor%20actuator#actuator-and-sensor
- Ref Issue #1058.
- Ref @tslagle13 for more info regarding **SmartTiles V6**'s use of these standard Capabilities as device authorization input filters.

**CC:** @tylerlange , @workingmonk 

_Thank-you!_
