### PR TITLE
DPROT-153 Fix event map name in NYCE Motion sensor

### DIFF
--- a/devicetypes/smartthings/nyce-motion-sensor.src/nyce-motion-sensor.groovy
+++ b/devicetypes/smartthings/nyce-motion-sensor.src/nyce-motion-sensor.groovy
@@ -147,8 +147,8 @@ private Map parseIasMessage(String description) {
 	ZoneStatus zs = zigbee.parseZoneStatus(description)
 	Map resultMap = [:]
 
-	result.name = 'motion'
-	result.value = zs.isAlarm2Set() ? 'active' : 'inactive'
+	resultMap.name = 'motion'
+	resultMap.value = zs.isAlarm2Set() ? 'active' : 'inactive'
 	log.debug(zs.isAlarm2Set() ? 'motion' : 'no motion')
 
 	return resultMap


### PR DESCRIPTION
There was a null pointer as a result of using the wrong map name

This resolves: https://smartthings.atlassian.net/browse/DPROT-153

@tpmanley @workingmonk 
