### PR TITLE
SSVD-2534 Set temperature unit/scale when sending temperature events

### DIFF
--- a/devicetypes/keen-home/keen-home-smart-vent.src/keen-home-smart-vent.groovy
+++ b/devicetypes/keen-home/keen-home-smart-vent.src/keen-home-smart-vent.groovy
@@ -274,6 +274,7 @@ private Map makeTemperatureResult(value) {
         name: 'temperature',
         value: "" + value,
         descriptionText: "${linkText} is ${value}°${temperatureScale}",
+        unit: temperatureScale
     ]
 }
 

--- a/devicetypes/plaidsystems/spruce-sensor.src/spruce-sensor.groovy
+++ b/devicetypes/plaidsystems/spruce-sensor.src/spruce-sensor.groovy
@@ -254,7 +254,8 @@ private Map getTemperatureResult(value) {
 	return [
 		name: 'temperature',
 		value: value,
-		descriptionText: descriptionText
+		descriptionText: descriptionText,
+		unit: temperatureScale
 	]
 }
 

--- a/devicetypes/smartthings/centralite-thermostat.src/centralite-thermostat.groovy
+++ b/devicetypes/smartthings/centralite-thermostat.src/centralite-thermostat.groovy
@@ -89,14 +89,17 @@ def parse(String description) {
 			log.debug "TEMP"
 			map.name = "temperature"
 			map.value = getTemperature(descMap.value)
+			map.unit = temperatureScale
 		} else if (descMap.cluster == "0201" && descMap.attrId == "0011") {
 			log.debug "COOLING SETPOINT"
 			map.name = "coolingSetpoint"
 			map.value = getTemperature(descMap.value)
+			map.unit = temperatureScale
 		} else if (descMap.cluster == "0201" && descMap.attrId == "0012") {
 			log.debug "HEATING SETPOINT"
 			map.name = "heatingSetpoint"
 			map.value = getTemperature(descMap.value)
+			map.unit = temperatureScale
 		} else if (descMap.cluster == "0201" && descMap.attrId == "001c") {
 			log.debug "MODE"
 			map.name = "thermostatMode"
@@ -169,7 +172,7 @@ def setHeatingSetpoint(degrees) {
 
 		def degreesInteger = Math.round(degrees)
 		log.debug "setHeatingSetpoint({$degreesInteger} ${temperatureScale})"
-		sendEvent("name": "heatingSetpoint", "value": degreesInteger)
+		sendEvent("name": "heatingSetpoint", "value": degreesInteger, "unit": temperatureScale)
 
 		def celsius = (getTemperatureScale() == "C") ? degreesInteger : (fahrenheitToCelsius(degreesInteger) as Double).round(2)
 		"st wattr 0x${device.deviceNetworkId} 1 0x201 0x12 0x29 {" + hex(celsius * 100) + "}"
@@ -180,7 +183,7 @@ def setCoolingSetpoint(degrees) {
 	if (degrees != null) {
 		def degreesInteger = Math.round(degrees)
 		log.debug "setCoolingSetpoint({$degreesInteger} ${temperatureScale})"
-		sendEvent("name": "coolingSetpoint", "value": degreesInteger)
+		sendEvent("name": "coolingSetpoint", "value": degreesInteger, "unit": temperatureScale)
 		def celsius = (getTemperatureScale() == "C") ? degreesInteger : (fahrenheitToCelsius(degreesInteger) as Double).round(2)
 		"st wattr 0x${device.deviceNetworkId} 1 0x201 0x11 0x29 {" + hex(celsius * 100) + "}"
 	}

--- a/devicetypes/smartthings/ecobee-thermostat.src/ecobee-thermostat.groovy
+++ b/devicetypes/smartthings/ecobee-thermostat.src/ecobee-thermostat.groovy
@@ -152,11 +152,11 @@ def generateEvent(Map results) {
 				sendValue =  location.temperatureScale == "C"? roundC(sendValue) : sendValue
 				isChange = isTemperatureStateChange(device, name, value.toString())
 				isDisplayed = isChange
-				event << [value: sendValue, isStateChange: isChange, displayed: isDisplayed]
+				event << [value: sendValue, unit: temperatureScale, isStateChange: isChange, displayed: isDisplayed]
 			}  else if (name=="maxCoolingSetpoint" || name=="minCoolingSetpoint" || name=="maxHeatingSetpoint" || name=="minHeatingSetpoint") {
 				def sendValue = convertTemperatureIfNeeded(value.toDouble(), "F", 1) //API return temperature value in F
 				sendValue =  location.temperatureScale == "C"? roundC(sendValue) : sendValue
-				event << [value: sendValue, displayed: false]
+				event << [value: sendValue, unit: temperatureScale, displayed: false]
 			}  else if (name=="heatMode" || name=="coolMode" || name=="autoMode" || name=="auxHeatMode"){
 				isChange = isStateChange(device, name, value.toString())
 				event << [value: value.toString(), isStateChange: isChange, displayed: false]
@@ -235,8 +235,8 @@ void setHeatingSetpoint(setpoint) {
 
 	def sendHoldType = holdType ? (holdType=="Temporary")? "nextTransition" : (holdType=="Permanent")? "indefinite" : "indefinite" : "indefinite"
 	if (parent.setHold(heatingValue, coolingValue, deviceId, sendHoldType)) {
-		sendEvent("name":"heatingSetpoint", "value":heatingSetpoint)
-		sendEvent("name":"coolingSetpoint", "value":coolingSetpoint)
+		sendEvent("name":"heatingSetpoint", "value":heatingSetpoint, "unit":location.temperatureScale)
+		sendEvent("name":"coolingSetpoint", "value":coolingSetpoint, "unit":location.temperatureScale)
 		log.debug "Done setHeatingSetpoint> coolingSetpoint: ${coolingSetpoint}, heatingSetpoint: ${heatingSetpoint}"
 		generateSetpointEvent()
 		generateStatusEvent()
@@ -272,8 +272,8 @@ void setCoolingSetpoint(setpoint) {
 
 	def sendHoldType = holdType ? (holdType=="Temporary")? "nextTransition" : (holdType=="Permanent")? "indefinite" : "indefinite" : "indefinite"
 	if (parent.setHold(heatingValue, coolingValue, deviceId, sendHoldType)) {
-		sendEvent("name":"heatingSetpoint", "value":heatingSetpoint)
-		sendEvent("name":"coolingSetpoint", "value":coolingSetpoint)
+		sendEvent("name":"heatingSetpoint", "value":heatingSetpoint, "unit":location.temperatureScale)
+		sendEvent("name":"coolingSetpoint", "value":coolingSetpoint, "unit":location.temperatureScale)
 		log.debug "Done setCoolingSetpoint>> coolingSetpoint = ${coolingSetpoint}, heatingSetpoint = ${heatingSetpoint}"
 		generateSetpointEvent()
 		generateStatusEvent()
@@ -556,12 +556,12 @@ def generateSetpointEvent() {
 
 	if (mode == "heat") {
 
-		sendEvent("name":"thermostatSetpoint", "value":heatingSetpoint )
+		sendEvent("name":"thermostatSetpoint", "value":heatingSetpoint, "unit":location.temperatureScale)
 
 	}
 	else if (mode == "cool") {
 
-		sendEvent("name":"thermostatSetpoint", "value":coolingSetpoint)
+		sendEvent("name":"thermostatSetpoint", "value":coolingSetpoint, "unit":location.temperatureScale)
 
 	} else if (mode == "auto") {
 
@@ -573,7 +573,7 @@ def generateSetpointEvent() {
 
 	} else if (mode == "auxHeatOnly") {
 
-		sendEvent("name":"thermostatSetpoint", "value":heatingSetpoint)
+		sendEvent("name":"thermostatSetpoint", "value":heatingSetpoint, "unit":location.temperatureScale)
 
 	}
 
@@ -608,7 +608,7 @@ void raiseSetpoint() {
 			targetvalue = maxCoolingSetpoint
 		}
 
-		sendEvent("name":"thermostatSetpoint", "value":targetvalue, displayed: false)
+		sendEvent("name":"thermostatSetpoint", "value":targetvalue, "unit":location.temperatureScale, displayed: false)
 		log.info "In mode $mode raiseSetpoint() to $targetvalue"
 
 		runIn(3, "alterSetpoint", [data: [value:targetvalue], overwrite: true]) //when user click button this runIn will be overwrite
@@ -644,7 +644,7 @@ void lowerSetpoint() {
 			targetvalue = minCoolingSetpoint
 		}
 
-		sendEvent("name":"thermostatSetpoint", "value":targetvalue, displayed: false)
+		sendEvent("name":"thermostatSetpoint", "value":targetvalue, "unit":location.temperatureScale, displayed: false)
 		log.info "In mode $mode lowerSetpoint() to $targetvalue"
 
 		runIn(3, "alterSetpoint", [data: [value:targetvalue], overwrite: true]) //when user click button this runIn will be overwrite
@@ -692,8 +692,8 @@ void alterSetpoint(temp) {
 
 	if (parent.setHold(heatingValue, coolingValue, deviceId, sendHoldType)) {
 		sendEvent("name": "thermostatSetpoint", "value": temp.value, displayed: false)
-		sendEvent("name": "heatingSetpoint", "value": targetHeatingSetpoint)
-		sendEvent("name": "coolingSetpoint", "value": targetCoolingSetpoint)
+		sendEvent("name": "heatingSetpoint", "value": targetHeatingSetpoint, "unit": location.temperatureScale)
+		sendEvent("name": "coolingSetpoint", "value": targetCoolingSetpoint, "unit": location.temperatureScale)
 		log.debug "alterSetpoint in mode $mode succeed change setpoint to= ${temp.value}"
 	} else {
 		log.error "Error alterSetpoint()"

--- a/devicetypes/smartthings/fidure-thermostat.src/fidure-thermostat.groovy
+++ b/devicetypes/smartthings/fidure-thermostat.src/fidure-thermostat.groovy
@@ -682,7 +682,7 @@ def setHeatingSetpoint(degrees) {
 	def temperatureScale = getTemperatureScale()
 
 	def degreesInteger = degrees as Integer
-	sendEvent("name":"heatingSetpoint", "value":degreesInteger)
+	sendEvent("name":"heatingSetpoint", "value":degreesInteger, "unit":temperatureScale)
 
 	def celsius = (getTemperatureScale() == "C") ? degreesInteger : (fahrenheitToCelsius(degreesInteger) as Double).round(2)
 	"st wattr 0x${device.deviceNetworkId} 1 0x201 0x12 0x29 {" + hex(celsius*100) + "}"
@@ -691,7 +691,7 @@ def setHeatingSetpoint(degrees) {
 
 def setCoolingSetpoint(degrees) {
 	def degreesInteger = degrees as Integer
-	sendEvent("name":"coolingSetpoint", "value":degreesInteger)
+	sendEvent("name":"coolingSetpoint", "value":degreesInteger, "unit":temperatureScale)
 	def celsius = (getTemperatureScale() == "C") ? degreesInteger : (fahrenheitToCelsius(degreesInteger) as Double).round(2)
 	"st wattr 0x${device.deviceNetworkId} 1 0x201 0x11 0x29 {" + hex(celsius*100) + "}"
 

--- a/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
@@ -259,7 +259,8 @@ private Map getTemperatureResult(value) {
 		name: 'temperature',
 		value: value,
 		descriptionText: descriptionText,
-        translatable: true
+		translatable: true,
+		unit: temperatureScale
 	]
 }
 

--- a/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
@@ -274,7 +274,8 @@ private Map getTemperatureResult(value) {
 		name: 'temperature',
 		value: value,
 		descriptionText: descriptionText,
-        translatable: true
+		translatable: true,
+		unit: temperatureScale
 	]
 }
 

--- a/devicetypes/smartthings/smartsense-motion-temp-sensor.src/smartsense-motion-temp-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-temp-sensor.src/smartsense-motion-temp-sensor.groovy
@@ -226,7 +226,8 @@ private Map getTemperatureResult(value) {
 	return [
 		name: 'temperature',
 		value: value,
-		descriptionText: descriptionText
+		descriptionText: descriptionText,
+		unit: temperatureScale
 	]
 }
 

--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -333,10 +333,11 @@ private Map getTemperatureResult(value) {
 			'{{ device.displayName }} was {{ value }}°F'
 
 	return [
-	name: 'temperature',
-	value: value,
-	descriptionText: descriptionText,
-    translatable: true
+		name: 'temperature',
+		value: value,
+		descriptionText: descriptionText,
+		translatable: true,
+		unit: temperatureScale
 	]
 }
 

--- a/devicetypes/smartthings/smartsense-open-closed-accelerometer-sensor.src/smartsense-open-closed-accelerometer-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-accelerometer-sensor.src/smartsense-open-closed-accelerometer-sensor.groovy
@@ -223,9 +223,10 @@ def getTemperature(value) {
 		}
 		def descriptionText = "${linkText} was ${value}°${temperatureScale}"
 		return [
-		name: 'temperature',
-		value: value,
-		descriptionText: descriptionText
+			name: 'temperature',
+			value: value,
+			descriptionText: descriptionText,
+			unit: temperatureScale
 		]
 	}
 

--- a/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
@@ -226,7 +226,8 @@ private Map getTemperatureResult(value) {
 	return [
 		name: 'temperature',
 		value: value,
-		descriptionText: descriptionText
+		descriptionText: descriptionText,
+		unit: temperatureScale
 	]
 }
 

--- a/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
@@ -233,7 +233,8 @@ private Map getTemperatureResult(value) {
 	return [
 		name: 'temperature',
 		value: value,
-		descriptionText: descriptionText
+		descriptionText: descriptionText,
+		unit: temperatureScale
 	]
 }
 

--- a/devicetypes/smartthings/tyco-door-window-sensor.src/tyco-door-window-sensor.groovy
+++ b/devicetypes/smartthings/tyco-door-window-sensor.src/tyco-door-window-sensor.groovy
@@ -213,7 +213,8 @@ private Map getTemperatureResult(value) {
 	return [
 		name: 'temperature',
 		value: value,
-		descriptionText: descriptionText
+		descriptionText: descriptionText,
+		unit: temperatureScale
 	]
 }
 


### PR DESCRIPTION
When sending temperature events, we need to ensure that the unit is also set. This allows us to better handle when the temperature scale is changed for a the location as we are capturing what the scale was when the event occurred.

@mrnohr made changes to update device tiles appropriately, providing the unit is capture on the events. See SSVD-2534 for related PR.
