### PR TITLE
Missing labels for motion states, changed colours

### DIFF
--- a/devicetypes/fibargroup/fibaro-motion-sensor-zw5.src/fibaro-motion-sensor-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-motion-sensor-zw5.src/fibaro-motion-sensor-zw5.groovy
@@ -33,8 +33,8 @@ metadata {
     tiles(scale: 2) {
     	multiAttributeTile(name:"FGMS", type:"lighting", width:6, height:4) {//with generic type secondary control text is not displayed in Android app
         	tileAttribute("device.motion", key:"PRIMARY_CONTROL") {
-            	attributeState("inactive", icon:"st.motion.motion.inactive", backgroundColor:"#79b821")
-            	attributeState("active", icon:"st.motion.motion.active", backgroundColor:"#ffa81e")   
+            	attributeState("inactive", label: 'no motion', icon:"st.motion.motion.inactive", backgroundColor:"#ffffff")
+            	attributeState("active", label: 'motion', icon:"st.motion.motion.active", backgroundColor:"#53a7c0")   
             }
             
             tileAttribute("device.tamper", key:"SECONDARY_CONTROL") {


### PR DESCRIPTION
The labels for motion states are missing in original device handler, also colours of the tile are not in line with smartthings scheme (gray for no motion, blue for motion).
