### PR TITLE
MSA-1468 - To Netatmo DTHs, added Capability "Sensor"

### DIFF
--- a/devicetypes/dianoga/netatmo-additional-module.src/netatmo-additional-module.groovy
+++ b/devicetypes/dianoga/netatmo-additional-module.src/netatmo-additional-module.groovy
@@ -15,6 +15,7 @@
  */
 metadata {
 	definition (name: "Netatmo Additional Module", namespace: "dianoga", author: "Brian Steere") {
+		capability "Sensor"
 		capability "Relative Humidity Measurement"
 		capability "Temperature Measurement"
 

--- a/devicetypes/dianoga/netatmo-basestation.src/netatmo-basestation.groovy
+++ b/devicetypes/dianoga/netatmo-basestation.src/netatmo-basestation.groovy
@@ -15,6 +15,7 @@
  */
 metadata {
 	definition (name: "Netatmo Basestation", namespace: "dianoga", author: "Brian Steere") {
+		capability "Sensor"
 		capability "Relative Humidity Measurement"
 		capability "Temperature Measurement"
 

--- a/devicetypes/dianoga/netatmo-outdoor-module.src/netatmo-outdoor-module.groovy
+++ b/devicetypes/dianoga/netatmo-outdoor-module.src/netatmo-outdoor-module.groovy
@@ -15,6 +15,7 @@
  */
 metadata {
 	definition (name: "Netatmo Outdoor Module", namespace: "dianoga", author: "Brian Steere") {
+		capability "Sensor"
 		capability "Relative Humidity Measurement"
 		capability "Temperature Measurement"
 	}

--- a/devicetypes/dianoga/netatmo-rain.src/netatmo-rain.groovy
+++ b/devicetypes/dianoga/netatmo-rain.src/netatmo-rain.groovy
@@ -15,6 +15,8 @@
  */
 metadata {
 	definition (name: "Netatmo Rain", namespace: "dianoga", author: "Brian Steere") {
+		capability "Sensor"
+	
 		attribute "rain", "number"
         attribute "rainSumHour", "number"
         attribute "rainSumDay", "number"


### PR DESCRIPTION
There are some integrations / SmartApps out there using the "Actuator" and "Sensor" Capabilities and instances of these **Netatmo** Devices (and perhaps more DTHs) do not show up for them. Example SmartApp "SmartTiles V6 Beta".
- Ref Docs: http://docs.smartthings.com/en/latest/device-type-developers-guide/overview.html?highlight=sensor%20actuator#actuator-and-sensor
- Ref @tslagle13 for more info regarding SmartTiles V6's use of these standard Capabilities as device authorization input filters.

**CC**: @tylerlange , @workingmonk

**_Thank-you!_**
