### PR TITLE
DVCSMP-1999: Use proper IAS Zone alarm for triggering motion

### DIFF
--- a/devicetypes/smartthings/smartsense-motion-temp-sensor.src/smartsense-motion-temp-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-temp-sensor.src/smartsense-motion-temp-sensor.groovy
@@ -170,7 +170,7 @@ private Map parseCustomMessage(String description) {
 
 private Map parseIasMessage(String description) {
 	ZoneStatus zs = zigbee.parseZoneStatus(description)
-	return zs.isAlarm1Set() ? getMotionResult('active') : getMotionResult('inactive')
+	return (zs.isAlarm1Set() || zs.isAlarm2Set()) ? getMotionResult('active') : getMotionResult('inactive')
 }
 
 def getTemperature(value) {


### PR DESCRIPTION
Previously we were incorrectly looking at the alarm1 bit when we should
be looking at the alarm2 bit.

This resolves: https://smartthings.atlassian.net/browse/DVCSMP-1999

@tpmanley @workingmonk 
