### PR TITLE
To Bose Soundtouch DTH, added Capability "Actuator" and "Sensor"

### DIFF
--- a/devicetypes/smartthings/bose-soundtouch.src/bose-soundtouch.groovy
+++ b/devicetypes/smartthings/bose-soundtouch.src/bose-soundtouch.groovy
@@ -28,6 +28,8 @@ metadata {
         capability "Refresh"
         capability "Music Player"
         capability "Polling"
+		capability "Actuator"
+		capability "Sensor"
 
         /**
          * Define all commands, ie, if you have a custom action not


### PR DESCRIPTION
There are some SmartApps out there using the "Actuator" and "Sensor" Capabilities and this Device doesn't show up for them (e.g., SmartTiles V6).
- Ref Docs: http://docs.smartthings.com/en/latest/device-type-developers-guide/overview.html?highlight=sensor%20actuator#actuator-and-sensor
- Ref @tslagle13 for more info regarding SmartTiles V6's use of these standard Capabilities as device authorization input filters.

**CC**: @tylerlange , @workingmonk

**_Thank-you!_**
