### PR TITLE
Replace log logging personal phone number

### DIFF
--- a/smartapps/smartthings/text-me-when-it-opens.src/text-me-when-it-opens.groovy
+++ b/smartapps/smartthings/text-me-when-it-opens.src/text-me-when-it-opens.groovy
@@ -48,7 +48,8 @@ def updated()
 
 def contactOpenHandler(evt) {
 	log.trace "$evt.value: $evt, $settings"
-	log.debug "$contact1 was opened, texting $phone1"
+  log.debug "$contact1 was opened, sending text"
+	// log.debug "$contact1 was opened, texting $phone1"
     if (location.contactBookEnabled) {
         sendNotificationToContacts("Your ${contact1.label ?: contact1.name} was opened", recipients)
     }


### PR DESCRIPTION
'$phone1' contained personal phone number. This commit commented out the log, and replaced it with a similar one without the phone number. 
@juano2310 
