### PR TITLE
DVCSMP-2020: smart-security app contains invalid code

### DIFF
--- a/smartapps/smartthings/smart-security.src/smart-security.groovy
+++ b/smartapps/smartthings/smart-security.src/smart-security.groovy
@@ -156,7 +156,7 @@ def residentMotion(evt)
 	//    	startReArmSequence()
 	//    }
 	//}
-  unsubscribe(‘residentMotion’)
+  unsubscribe(residentMotions)
 }
 
 def contact(evt)


### PR DESCRIPTION
This bug was introduced by DVCSMP-1959 (https://github.com/SmartThingsCommunity/SmartThingsPublic/pull/1215).

The main problem is that the character ‘ is not valid Groovy code so fails compilation. The secondary problem is that `residentMotion` doesn't appear to be the intended setting name, so I changed it to `residentMotions`.

/cc @AndrewBresee @juano2310 @jterhune 

For reference, the error is:

```
script14733454045851958565383.groovy: 159: Invalid variable name. Must start with a letter but was: ‘residentMotion’
. At [159:15]  @ line 159, column 15.
     unsubscribe(‘residentMotion’)
                 ^

1 error
```
