### PR TITLE
DPROT-8 Add explicit send commands for zigbee raw

### DIFF
--- a/devicetypes/smartthings/arrival-sensor.src/arrival-sensor.groovy
+++ b/devicetypes/smartthings/arrival-sensor.src/arrival-sensor.groovy
@@ -87,16 +87,27 @@ def beep() {
 	up to this long from the time you send the message to the time you hear a sound.
 	*/
 
+	// Used source endpoint of 0x02 because we are using smartthings manufacturer specific cluster.
 	[
 		"raw 0xFC05 {15 0A 11 00 00 15 01}",
+		"delay 200",
+		"send 0x$zigbee.deviceNetworkId 0x02 0x$zigbee.endpointId",
 		"delay 7000",
 		"raw 0xFC05 {15 0A 11 00 00 15 01}",
+		"delay 200",
+		"send 0x$zigbee.deviceNetworkId 0x02 0x$zigbee.endpointId",
 		"delay 7000",
 		"raw 0xFC05 {15 0A 11 00 00 15 01}",
+		"delay 200",
+		"send 0x$zigbee.deviceNetworkId 0x02 0x$zigbee.endpointId",
 		"delay 7000",
 		"raw 0xFC05 {15 0A 11 00 00 15 01}",
+		"delay 200",
+		"send 0x$zigbee.deviceNetworkId 0x02 0x$zigbee.endpointId",
 		"delay 7000",
-		"raw 0xFC05 {15 0A 11 00 00 15 01}"
+		"raw 0xFC05 {15 0A 11 00 00 15 01}",
+		"delay 200",
+		"send 0x$zigbee.deviceNetworkId 0x02 0x$zigbee.endpointId",
 	]
 }
 

--- a/devicetypes/smartthings/centralite-dimmer.src/centralite-dimmer.groovy
+++ b/devicetypes/smartthings/centralite-dimmer.src/centralite-dimmer.groovy
@@ -105,11 +105,21 @@ def parseDescriptionAsMap(description) {
 
 // Commands to device
 def on() {
-	'zcl on-off on'
+	[
+			'zcl on-off on',
+			'delay 200',
+			"send 0x${zigbee.deviceNetworkId} 0x01 0x${zigbee.endpointId}",
+			'delay 500'
+	]
 }
 
 def off() {
-	'zcl on-off off'
+	[
+			'zcl on-off off',
+			'delay 200',
+			"send 0x${zigbee.deviceNetworkId} 0x01 0x${zigbee.endpointId}",
+			'delay 500'
+	]
 }
 
 def setLevel(value) {

--- a/devicetypes/smartthings/smartpower-outlet-v1.src/smartpower-outlet-v1.groovy
+++ b/devicetypes/smartthings/smartpower-outlet-v1.src/smartpower-outlet-v1.groovy
@@ -47,9 +47,21 @@ def parse(String description) {
 
 // Commands to device
 def on() {
-	'zcl on-off on'
+	[
+			'zcl on-off on',
+			'delay 200',
+			"send 0x${zigbee.deviceNetworkId} 0x01 0x${zigbee.endpointId}",
+			'delay 500'
+
+	]
+
 }
 
 def off() {
-	'zcl on-off off'
+	[
+			'zcl on-off off',
+			'delay 200',
+			"send 0x${zigbee.deviceNetworkId} 0x01 0x${zigbee.endpointId}",
+			'delay 500'
+	]
 }


### PR DESCRIPTION
Previously a few places depended on the dev-conn behavior of
automatically appending a send command after a raw zigbee command.  We
intend to deprecate that behavior and so we are adding explicit sends
where they were missing.

This depends on https://smartthings.atlassian.net/browse/DPROT-8

@tpmanley 
