### PR TITLE
[CHF-363] Set HealthCheck interval to 12 min

### DIFF
--- a/devicetypes/smartthings/hue-bloom.src/hue-bloom.groovy
+++ b/devicetypes/smartthings/hue-bloom.src/hue-bloom.groovy
@@ -57,7 +57,7 @@ metadata {
 }
 
 void installed() {
-	sendEvent(name: "checkInterval", value: 60 * 15, data: [protocol: "lan"], displayed: false)
+	sendEvent(name: "checkInterval", value: 60 * 12, data: [protocol: "lan"], displayed: false)
 }
 
 // parse events into attributes

--- a/devicetypes/smartthings/hue-bulb.src/hue-bulb.groovy
+++ b/devicetypes/smartthings/hue-bulb.src/hue-bulb.groovy
@@ -66,7 +66,7 @@ metadata {
 }
 
 void installed() {
-	sendEvent(name: "checkInterval", value: 60 * 15, data: [protocol: "lan"], displayed: false)
+	sendEvent(name: "checkInterval", value: 60 * 12, data: [protocol: "lan"], displayed: false)
 }
 
 // parse events into attributes

--- a/devicetypes/smartthings/hue-lux-bulb.src/hue-lux-bulb.groovy
+++ b/devicetypes/smartthings/hue-lux-bulb.src/hue-lux-bulb.groovy
@@ -50,7 +50,7 @@ metadata {
 }
 
 void installed() {
-	sendEvent(name: "checkInterval", value: 60 * 15, data: [protocol: "lan"], displayed: false)
+	sendEvent(name: "checkInterval", value: 60 * 12, data: [protocol: "lan"], displayed: false)
 }
 
 // parse events into attributes

--- a/devicetypes/smartthings/hue-white-ambiance-bulb.src/hue-white-ambiance-bulb.groovy
+++ b/devicetypes/smartthings/hue-white-ambiance-bulb.src/hue-white-ambiance-bulb.groovy
@@ -55,7 +55,7 @@ metadata {
 }
 
 void installed() {
-	sendEvent(name: "checkInterval", value: 60 * 15, data: [protocol: "lan"], displayed: false)
+	sendEvent(name: "checkInterval", value: 60 * 12, data: [protocol: "lan"], displayed: false)
 }
 
 // parse events into attributes

--- a/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
+++ b/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
@@ -128,8 +128,8 @@ def refresh() {
 }
 
 def configure() {
-	// Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
-	sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 2 check-in misses from device
+	sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
 	// OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
 	zigbee.onOffConfig(0, 300) + powerConfig() + refresh()
 }

--- a/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
@@ -292,8 +292,8 @@ def refresh() {
 }
 
 def configure() {
-	// Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
-	sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 2 check-in misses from device
+	sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
 
 	String zigbeeEui = swapEndianHex(device.hub.zigbeeEui)
 	log.debug "Configuring Reporting, IAS CIE, and Bindings."

--- a/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
@@ -303,8 +303,8 @@ def refresh() {
 }
 
 def configure() {
-	// Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
-	sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 2 check-in misses from device
+	sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
 
 	String zigbeeEui = swapEndianHex(device.hub.zigbeeEui)
 	log.debug "Configuring Reporting, IAS CIE, and Bindings."

--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -401,8 +401,8 @@ def refresh() {
 }
 
 def configure() {
-	// Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
-	sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 2 check-in misses from device
+	sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
 
 	log.debug "Configuring Reporting"
 

--- a/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
@@ -255,8 +255,8 @@ def refresh() {
 }
 
 def configure() {
-	// Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
-	sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 2 check-in misses from device
+	sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
 
 	String zigbeeEui = swapEndianHex(device.hub.zigbeeEui)
 	log.debug "Configuring Reporting, IAS CIE, and Bindings."

--- a/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
@@ -264,8 +264,8 @@ def refresh()
 }
 
 def configure() {
-	// Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
-	sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 2 check-in misses from device
+	sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
 
 	log.debug "Configuring Reporting and Bindings."
 	def humidityConfigCmds = [

--- a/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
@@ -89,8 +89,8 @@ def refresh() {
 
 def configure() {
     log.debug "Configuring Reporting and Bindings."
-    // Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
-    sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+    // Device-Watch allows 2 check-in misses from device
+    sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
     // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
     zigbee.onOffConfig(0, 300) + zigbee.levelConfig() + zigbee.onOffRefresh() + zigbee.levelRefresh()
 }

--- a/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
@@ -133,8 +133,8 @@ def refresh() {
 
 def configure() {
     log.debug "Configuring Reporting and Bindings."
-    // Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
-    sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+    // Device-Watch allows 2 check-in misses from device
+    sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
     // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
     zigbee.onOffConfig(0, 300) + zigbee.levelConfig() + zigbee.colorTemperatureConfig() + zigbee.configureReporting(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE, 0x20, 1, 3600, 0x01) + zigbee.configureReporting(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION, 0x20, 1, 3600, 0x01) + zigbee.readAttribute(0x0006, 0x00) + zigbee.readAttribute(0x0008, 0x00) + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, 0x00) + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_COLOR_TEMPERATURE) + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE) + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION)
 }

--- a/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
@@ -113,8 +113,8 @@ def refresh() {
 
 def configure() {
     log.debug "Configuring Reporting and Bindings."
-    // Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
-    sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+    // Device-Watch allows 2 check-in misses from device
+    sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
     // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
     zigbee.onOffConfig(0, 300) + zigbee.levelConfig() + zigbee.colorTemperatureConfig() + zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.colorTemperatureRefresh()
 }


### PR DESCRIPTION
Device Watch will expect 2x misses before it starts pinging. 
`5min` reporting interval if no activity. `checkInterval` changed to 12 min. Which gives us more buffer time greater than 2x5min. 

We expect Devices to go `OFFLINE` sometime between 13 min to 16 min. Within the promised 16 min VD requirement. 

@mortent @workingmonk @magnusekenheim 
