### PR TITLE
PROB-1373: hue: fix HTTP request headers

### DIFF
--- a/smartapps/smartthings/hue-connect.src/hue-connect.groovy
+++ b/smartapps/smartthings/hue-connect.src/hue-connect.groovy
@@ -1175,9 +1175,8 @@ private poll() {
 	def host = getBridgeIP()
 	def uri = "/api/${state.username}/lights/"
 	log.debug "GET: $host$uri"
-	sendHubCommand(new physicalgraph.device.HubAction("""GET ${uri} HTTP/1.1
-HOST: ${host}
-""", physicalgraph.device.Protocol.LAN, selectedHue))
+	sendHubCommand(new physicalgraph.device.HubAction("GET ${uri} HTTP/1.1\r\n" +
+		"HOST: ${host}\r\n\r\n", physicalgraph.device.Protocol.LAN, selectedHue))
 }
 
 private isOnline(id) {
@@ -1193,13 +1192,11 @@ private put(path, body) {
 	log.debug "PUT:  $host$uri"
 	log.debug "BODY: ${bodyJSON}"
 
-	sendHubCommand(new physicalgraph.device.HubAction("""PUT $uri HTTP/1.1
-HOST: ${host}
-Content-Length: ${length}
-
-${bodyJSON}
-""", physicalgraph.device.Protocol.LAN, "${selectedHue}"))
-
+	sendHubCommand(new physicalgraph.device.HubAction("PUT $uri HTTP/1.1\r\n" +
+		"HOST: ${host}\r\n" +
+		"Content-Length: ${length}\r\n" +
+		"\r\n" +
+		"${bodyJSON}", physicalgraph.device.Protocol.LAN, "${selectedHue}"))
 }
 
 /*


### PR DESCRIPTION
Previously, the whitespace characters from the file were used for
newlines in HTTP headers.  In order for the HTTP headers sent to
the hue to be valid, line separators must always be \r\n.  Oddly, the
hue seemed to accept and respond to requests with the invalid header
that was being sent but it would cause increased latency for all
other API clients.

In addition to the missing carriage returns, the GET request was also
missing the required blank line which marks the end of the request
headers.

https://smartthings.atlassian.net/browse/PROB-1366
http://status.smartthings.com/incidents/13j8g8g2w7ly
https://community.smartthings.com/t/new-hue-delay/57569

@larsfinander @tpmanley @juano2310 
