### PR TITLE
[CHF-402] Removing categorization from DTH's (Core Devices)

### DIFF
--- a/devicetypes/smartthings/cree-bulb.src/README.md
+++ b/devicetypes/smartthings/cree-bulb.src/README.md
@@ -23,7 +23,7 @@ Works with:
 
 ## Device Health
 
-A Category C6 Connected Cree LED Bulb with maxReportTime of 5 mins.
+Connected Cree LED Bulb with maxReportTime of 5 mins.
 Check-in interval = 12 mins
 
 ## Troubleshooting

--- a/devicetypes/smartthings/smartpower-outlet.src/README.md
+++ b/devicetypes/smartthings/smartpower-outlet.src/README.md
@@ -23,7 +23,7 @@ Works with:
 
 ## Device Health
 
-A Category C1 smart power outlet with maxReportTime of 5 mins.
+Smart power outlet with maxReportTime of 5 mins.
 Check-in interval is double the value of maxReportTime. 
 This gives the device twice the amount of time to respond before it is marked as offline.
 Check-in interval = 12 mins

--- a/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
+++ b/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
@@ -16,7 +16,7 @@
 
 metadata {
 	// Automatically generated. Make future change here.
-	definition (name: "SmartPower Outlet", namespace: "smartthings", author: "SmartThings", category: "C1") {
+	definition (name: "SmartPower Outlet", namespace: "smartthings", author: "SmartThings") {
 		capability "Actuator"
 		capability "Switch"
 		capability "Power Meter"

--- a/devicetypes/smartthings/smartsense-moisture-sensor.src/README.md
+++ b/devicetypes/smartthings/smartsense-moisture-sensor.src/README.md
@@ -23,7 +23,7 @@ Works with:
 
 ## Device Health
 
-A Category C2 moisture sensor with maxReportTime of 5 mins.
+Moisture sensor with maxReportTime of 5 mins.
 Check-in interval is double the value of maxReportTime. 
 This gives the device twice the amount of time to respond before it is marked as offline.
 Check-in interval = 12 mins

--- a/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
@@ -17,7 +17,7 @@ import physicalgraph.zigbee.clusters.iaszone.ZoneStatus
 
 
 metadata {
-	definition (name: "SmartSense Moisture Sensor",namespace: "smartthings", author: "SmartThings", category: "C2") {
+	definition (name: "SmartSense Moisture Sensor",namespace: "smartthings", author: "SmartThings") {
 		capability "Configuration"
 		capability "Battery"
 		capability "Refresh"

--- a/devicetypes/smartthings/smartsense-motion-sensor.src/README.md
+++ b/devicetypes/smartthings/smartsense-motion-sensor.src/README.md
@@ -22,7 +22,7 @@ Works with:
 
 ## Device Health
 
-A Category C2 motion sensor with maxReportTime of 5 mins.
+Motion sensor with maxReportTime of 5 mins.
 Check-in interval is double the value of maxReportTime.
 This gives the device twice the amount of time to respond before it is marked as offline.
 Check-in interval = 12 mins

--- a/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
@@ -17,7 +17,7 @@ import physicalgraph.zigbee.clusters.iaszone.ZoneStatus
 
 
 metadata {
-	definition (name: "SmartSense Motion Sensor", namespace: "smartthings", author: "SmartThings", category: "C2") {
+	definition (name: "SmartSense Motion Sensor", namespace: "smartthings", author: "SmartThings") {
 		capability "Motion Sensor"
 		capability "Configuration"
 		capability "Battery"

--- a/devicetypes/smartthings/smartsense-multi-sensor.src/README.md
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/README.md
@@ -26,7 +26,7 @@ Works with:
 
 ## Device Health
 
-A Category C2 multi sensor with maxReportTime of 5 mins.
+Multi sensor with maxReportTime of 5 mins.
 Check-in interval is double the value of maxReportTime. 
 This gives the device twice the amount of time to respond before it is marked as offline.
 Check-in interval = 12 mins

--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -16,7 +16,7 @@
 import physicalgraph.zigbee.clusters.iaszone.ZoneStatus
 
 metadata {
-	definition (name: "SmartSense Multi Sensor", namespace: "smartthings", author: "SmartThings", category: "C2") {
+	definition (name: "SmartSense Multi Sensor", namespace: "smartthings", author: "SmartThings") {
 
 		capability "Three Axis"
 		capability "Battery"

--- a/devicetypes/smartthings/smartsense-open-closed-sensor.src/README.md
+++ b/devicetypes/smartthings/smartsense-open-closed-sensor.src/README.md
@@ -24,7 +24,7 @@ Works with:
 
 ## Device Health
 
-A Category C2 open/closed sensor with maxReportTime of 5 mins.
+Open/closed sensor with maxReportTime of 5 mins.
 Check-in interval is double the value of maxReportTime. 
 This gives the device twice the amount of time to respond before it is marked as offline.
 Check-in interval = 12 mins

--- a/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
@@ -16,7 +16,7 @@
 import physicalgraph.zigbee.clusters.iaszone.ZoneStatus
 
 metadata {
-	definition (name: "SmartSense Open/Closed Sensor", namespace: "smartthings", author: "SmartThings", category: "C2") {
+	definition (name: "SmartSense Open/Closed Sensor", namespace: "smartthings", author: "SmartThings") {
 		capability "Battery"
 		capability "Configuration"
 		capability "Contact Sensor"

--- a/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/README.md
+++ b/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/README.md
@@ -24,7 +24,7 @@ Works with:
 
 ## Device Health
 
-A Category C2 SmartSense Temp/Humidity Sensor with maxReportTime of 5 mins.
+SmartSense Temp/Humidity Sensor with maxReportTime of 5 mins.
 Check-in interval is double the value of maxReportTime. 
 This gives the device twice the amount of time to respond before it is marked as offline.
 Check-in interval = 12 mins

--- a/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
@@ -14,7 +14,7 @@
  *
  */
 metadata {
-	definition (name: "SmartSense Temp/Humidity Sensor",namespace: "smartthings", author: "SmartThings", category: "C2") {
+	definition (name: "SmartSense Temp/Humidity Sensor",namespace: "smartthings", author: "SmartThings") {
 		capability "Configuration"
 		capability "Battery"
 		capability "Refresh"

--- a/devicetypes/smartthings/zigbee-dimmer.src/README.md
+++ b/devicetypes/smartthings/zigbee-dimmer.src/README.md
@@ -23,7 +23,7 @@ Works with:
 
 ## Device Health
 
-A Category C1 Zigbee dimmer with maxReportTime of 5 mins.
+Zigbee dimmer with maxReportTime of 5 mins.
 Check-in interval is double the value of maxReportTime. 
 This gives the device twice the amount of time to respond before it is marked as offline.
 Check-in interval = 12 mins

--- a/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
@@ -13,7 +13,7 @@
  */
 
 metadata {
-    definition (name: "ZigBee Dimmer", namespace: "smartthings", author: "SmartThings", category: "C1") {
+    definition (name: "ZigBee Dimmer", namespace: "smartthings", author: "SmartThings") {
         capability "Actuator"
         capability "Configuration"
         capability "Refresh"

--- a/devicetypes/smartthings/zigbee-rgbw-bulb.src/README.md
+++ b/devicetypes/smartthings/zigbee-rgbw-bulb.src/README.md
@@ -27,7 +27,7 @@ Works with:
 
 ## Device Health
 
-A Category C6 OSRAM LIGHTIFY LED RGBW Bulb with maxReportTime of 5 mins.
+OSRAM LIGHTIFY LED RGBW Bulb with maxReportTime of 5 mins.
 Check-in interval is double the value of maxReportTime. 
 This gives the device twice the amount of time to respond before it is marked as offline.
 Check-in interval = 12 mins

--- a/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
@@ -17,7 +17,7 @@
  */
 
 metadata {
-    definition (name: "ZigBee RGBW Bulb", namespace: "smartthings", author: "SmartThings", category: "C6") {
+    definition (name: "ZigBee RGBW Bulb", namespace: "smartthings", author: "SmartThings") {
 
         capability "Actuator"
         capability "Color Control"

--- a/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/README.md
+++ b/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/README.md
@@ -24,7 +24,7 @@ Works with:
 
 ## Device Health
 
-A Category C1 OSRAM Lightify Tunable 60 White with maxReportTime of 5 mins.
+OSRAM Lightify Tunable 60 White with maxReportTime of 5 mins.
 Check-in interval is double the value of maxReportTime. 
 This gives the device twice the amount of time to respond before it is marked as offline.
 Check-in interval = 12 mins

--- a/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
@@ -17,7 +17,7 @@
  */
 
 metadata {
-    definition (name: "ZigBee White Color Temperature Bulb", namespace: "smartthings", author: "SmartThings", category: "C1") {
+    definition (name: "ZigBee White Color Temperature Bulb", namespace: "smartthings", author: "SmartThings") {
 
         capability "Actuator"
         capability "Color Temperature"


### PR DESCRIPTION
Removed categorization in DTH's and corresponding README's for the following devices:
1. SmartSense Moisture Sensor
2. SmartSense Temp/Humidity Sensor
3. SmartSense Multi Sensor
4. SmartSense Open/closed Sensor
5. SmartPower Outlet
6. Connected Cree Bulb
7. SmartSense Motion Sensor
8. OSRAM Lightify LED On/Off/Dim
9. OSRAM Lightify LED RGBW
10. OSRAM Lightify Tunable 60 White

@jackchi @ShunmugaSundar Please check and merge the changes.
