### PR TITLE
[CHF-404] [CHF-422] Health check for Leviton DZPA1 Plug-in Appliance Module and GE Plug-In Outdoor Smart Switch (GE 12720) (Z-Wave)

### DIFF
--- a/devicetypes/smartthings/zwave-switch-generic.src/.st-ignore
+++ b/devicetypes/smartthings/zwave-switch-generic.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/zwave-switch-generic.src/README.md
+++ b/devicetypes/smartthings/zwave-switch-generic.src/README.md
@@ -1,0 +1,39 @@
+# Z-wave Switch
+
+
+
+Works with: 
+
+* [Leviton Appliance Module (DZPA1-1LW)](https://support.smartthings.com/hc/en-us/articles/205881176-Leviton-Appliance-Module-DZPA1-1LW-)
+* [GE Plug-In Outdoor Smart Switch (GE 12720) (Z-Wave)](https://support.smartthings.com/hc/en-us/articles/200903080-GE-Plug-In-Outdoor-Smart-Switch-GE-12720-Z-Wave-)
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+
+## Capabilities
+
+* **Actuator** - represents that a Device has commands
+* **Health Check** - indicates ability to get device health notifications
+* **Switch** - can detect state (possible values: on/off)
+* **Polling** - represents that poll() can be implemented for the device
+* **Refresh** - _refresh()_ command for status updates
+* **Sensor** - detects sensor events
+
+## Device Health
+
+A Category C5 Leviton Appliance Module (DZPA1-1LW) and GE Plug-In Outdoor Smart Switch (GE 12720) (Z-Wave) polled by the hub.
+As of hubCore version 0.14.38 the hub sends up reports every 15 minutes regardless of whether the state changed.
+Device-Watch allows 2 check-in misses from device plus some lag time. So Check-in interval = (2*15 + 2)mins = 32 mins.
+Not to mention after going OFFLINE when the device is plugged back in, it might take a considerable amount of time for
+the device to appear as ONLINE again. This is because if this listening device does not respond to two poll requests in a row,
+it is not polled for 5 minutes by the hub. This can delay up the process of being marked ONLINE by quite some time.
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
+Pairing needs to be tried again by placing the device closer to the hub.
+Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following link:
+* [Leviton Appliance Module (DZPA1-1LW) Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/205881176-Leviton-Appliance-Module-DZPA1-1LW-)
+* [GE Plug-In Outdoor Smart Switch (GE 12720) (Z-Wave) Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/200903080-GE-Plug-In-Outdoor-Smart-Switch-GE-12720-Z-Wave-)

--- a/devicetypes/smartthings/zwave-switch-generic.src/zwave-switch-generic.groovy
+++ b/devicetypes/smartthings/zwave-switch-generic.src/zwave-switch-generic.groovy
@@ -14,12 +14,15 @@
 metadata {
 	definition (name: "Z-Wave Switch Generic", namespace: "smartthings", author: "SmartThings") {
 		capability "Actuator"
+		capability "Health Check"
  		capability "Switch"
 		capability "Polling"
 		capability "Refresh"
 		capability "Sensor"
 
 		fingerprint inClusters: "0x25", deviceJoinName: "Z-Wave Switch"
+		fingerprint mfr:"001D", prod:"1A02", deviceJoinName: "Z-Wave Switch"
+		fingerprint mfr:"0063", prod:"4F50", deviceJoinName: "Z-Wave Switch"
 	}
 
 	// simulator metadata
@@ -48,6 +51,11 @@ metadata {
 		main "switch"
 		details(["switch","refresh"])
 	}
+}
+
+def updated(){
+// Device-Watch simply pings if no device events received for checkInterval duration of 32min = 2 * 15min + 2min lag time
+	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 }
 
 def parse(String description) {
@@ -124,6 +132,13 @@ def poll() {
 		zwave.switchBinaryV1.switchBinaryGet().format(),
 		zwave.manufacturerSpecificV1.manufacturerSpecificGet().format()
 	])
+}
+
+/**
+ * PING is used by Device-Watch in attempt to reach the Device
+ * */
+def ping() {
+	refresh()
 }
 
 def refresh() {


### PR DESCRIPTION
1. Added health check for Leviton DZPA1 Plug-in Appliance Module and GE Plug-In Outdoor Smart Switch (GE 12720) (Z-Wave).
2. 'checkInterval' is kept at 32min.
3. Ping is implemented using refresh().
4. Added the fingerprint of the Leviton DZPA1 Plug-in Appliance Module and GE Plug-In Outdoor Smart Switch (GE 12720) (Z-Wave) with the manufacturer and product code obtained from the raw description after pairing.
5. We've tested the checkInterval duration and the devices are marked OFFLINE within the stipulated time.
6. Added the README.md file.

@jackchi @ShunmugaSundar Please check and merge the changes.
