### PR TITLE
DVCSMP-2087 changed deviceTemperatureUnit attribute to be type string

### DIFF
--- a/devicetypes/smartthings/ecobee-thermostat.src/ecobee-thermostat.groovy
+++ b/devicetypes/smartthings/ecobee-thermostat.src/ecobee-thermostat.groovy
@@ -31,13 +31,13 @@ metadata {
 		command "switchMode"
 		command "switchFanMode"
 
-		attribute "thermostatSetpoint","number"
-		attribute "thermostatStatus","string"
+		attribute "thermostatSetpoint", "number"
+		attribute "thermostatStatus", "string"
 		attribute "maxHeatingSetpoint", "number"
 		attribute "minHeatingSetpoint", "number"
 		attribute "maxCoolingSetpoint", "number"
 		attribute "minCoolingSetpoint", "number"
-		attribute "deviceTemperatureUnit", "number"
+		attribute "deviceTemperatureUnit", "string"
 	}
 
 	tiles {


### PR DESCRIPTION
It wasn't possible to read the deviceTemperatureUnit attribute because it was declared to be a number, but contained a string, which caused a number format exception to be thrown when attempting to read the value.

@larsfinander 
