### PR TITLE
[CHF-417] [CHF-416] Health Check devices enroll with appropriate checkInterval

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
                 username smartThingsArtifactoryUserName
                 password smartThingsArtifactoryPassword
             }
-            url "http://artifactory.smartthings.com/libs-release-local"
+            url "https://artifactory.smartthings.com/libs-release-local"
         }
     }
 }
@@ -27,9 +27,37 @@ buildscript {
 repositories {
     mavenLocal()
     jcenter()
+    maven {
+        credentials {
+            username smartThingsArtifactoryUserName
+            password smartThingsArtifactoryPassword
+        }
+        url "https://artifactory.smartthings.com/libs-release-local"
+    }
+}
+
+sourceSets {
+    devicetypes {
+        groovy {
+            srcDirs = ['devicetypes']
+        }
+    }
+    smartapps {
+        groovy {
+            srcDirs = ['smartapps']
+        }
+    }
 }
 
 dependencies {
+    devicetypesCompile 'org.codehaus.groovy:groovy-all:2.4.7'
+    devicetypesCompile 'smartthings:appengine-z-wave:0.1.2'
+    devicetypesCompile 'smartthings:appengine-zigbee:0.1.11'
+    smartappsCompile 'org.codehaus.groovy:groovy-all:2.4.7'
+    smartappsCompile 'smartthings:appengine-common:0.1.8'
+    smartappsCompile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
+    smartappsCompile 'org.grails:grails-web:2.3.11'
+    smartappsCompile 'org.json:json:20140107'
 }
 
 slackSendMessage {

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,9 @@ machine:
     version:
       oraclejdk8
 
-checkout:
+dependencies:
+  override:
+    - ./gradlew dependencies -PsmartThingsArtifactoryUserName="$ARTIFACTORY_USERNAME" -PsmartThingsArtifactoryPassword="$ARTIFACTORY_PASSWORD"
   post:
     - ./gradlew compileSmartappsGroovy compileDevicetypesGroovy -PsmartThingsArtifactoryUserName="$ARTIFACTORY_USERNAME" -PsmartThingsArtifactoryPassword="$ARTIFACTORY_PASSWORD"
 

--- a/circle.yml
+++ b/circle.yml
@@ -3,9 +3,9 @@ machine:
     version:
       oraclejdk8
 
-dependencies:
-  override:
-    - echo "Nothing to do."
+checkout:
+  post:
+    - ./gradlew compileSmartappsGroovy compileDevicetypesGroovy
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
 
 checkout:
   post:
-    - ./gradlew compileSmartappsGroovy compileDevicetypesGroovy
+    - ./gradlew compileSmartappsGroovy compileDevicetypesGroovy -PsmartThingsArtifactoryUserName="$ARTIFACTORY_USERNAME" -PsmartThingsArtifactoryPassword="$ARTIFACTORY_PASSWORD"
 
 test:
   override:

--- a/devicetypes/dianoga/netatmo-additional-module.src/netatmo-additional-module.groovy
+++ b/devicetypes/dianoga/netatmo-additional-module.src/netatmo-additional-module.groovy
@@ -15,6 +15,7 @@
  */
 metadata {
 	definition (name: "Netatmo Additional Module", namespace: "dianoga", author: "Brian Steere") {
+		capability "Sensor"
 		capability "Relative Humidity Measurement"
 		capability "Temperature Measurement"
 

--- a/devicetypes/dianoga/netatmo-basestation.src/netatmo-basestation.groovy
+++ b/devicetypes/dianoga/netatmo-basestation.src/netatmo-basestation.groovy
@@ -15,6 +15,7 @@
  */
 metadata {
 	definition (name: "Netatmo Basestation", namespace: "dianoga", author: "Brian Steere") {
+		capability "Sensor"
 		capability "Relative Humidity Measurement"
 		capability "Temperature Measurement"
 

--- a/devicetypes/dianoga/netatmo-outdoor-module.src/netatmo-outdoor-module.groovy
+++ b/devicetypes/dianoga/netatmo-outdoor-module.src/netatmo-outdoor-module.groovy
@@ -15,6 +15,7 @@
  */
 metadata {
 	definition (name: "Netatmo Outdoor Module", namespace: "dianoga", author: "Brian Steere") {
+		capability "Sensor"
 		capability "Relative Humidity Measurement"
 		capability "Temperature Measurement"
 	}

--- a/devicetypes/dianoga/netatmo-rain.src/netatmo-rain.groovy
+++ b/devicetypes/dianoga/netatmo-rain.src/netatmo-rain.groovy
@@ -15,6 +15,8 @@
  */
 metadata {
 	definition (name: "Netatmo Rain", namespace: "dianoga", author: "Brian Steere") {
+		capability "Sensor"
+	
 		attribute "rain", "number"
         attribute "rainSumHour", "number"
         attribute "rainSumDay", "number"

--- a/devicetypes/fibargroup/fibaro-motion-sensor-zw5.src/fibaro-motion-sensor-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-motion-sensor-zw5.src/fibaro-motion-sensor-zw5.groovy
@@ -33,8 +33,8 @@ metadata {
     tiles(scale: 2) {
     	multiAttributeTile(name:"FGMS", type:"lighting", width:6, height:4) {//with generic type secondary control text is not displayed in Android app
         	tileAttribute("device.motion", key:"PRIMARY_CONTROL") {
-            	attributeState("inactive", icon:"st.motion.motion.inactive", backgroundColor:"#79b821")
-            	attributeState("active", icon:"st.motion.motion.active", backgroundColor:"#ffa81e")   
+            	attributeState("inactive", label:"no motion", icon:"st.motion.motion.inactive", backgroundColor:"#79b821")
+            	attributeState("active", label:"motion", icon:"st.motion.motion.active", backgroundColor:"#ffa81e")   
             }
             
             tileAttribute("device.tamper", key:"SECONDARY_CONTROL") {

--- a/devicetypes/smartthings/cree-bulb.src/cree-bulb.groovy
+++ b/devicetypes/smartthings/cree-bulb.src/cree-bulb.groovy
@@ -19,7 +19,6 @@ metadata {
 
         capability "Actuator"
         capability "Configuration"
-        capability "Polling"
         capability "Refresh"
         capability "Switch"
         capability "Switch Level"
@@ -97,11 +96,14 @@ def refresh() {
     zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.onOffConfig() + zigbee.levelConfig()
 }
 
-def poll() {
-    zigbee.onOffRefresh() + zigbee.levelRefresh()
+def healthPoll() {
+    def cmds = zigbee.onOffRefresh() + zigbee.levelRefresh()
+    cmds.each{ sendHubCommand(new physicalgraph.device.HubAction(it))}
 }
 
 def configure() {
+    unschedule()
+    schedule("0 0/5 * * * ? *", "healthPoll")
     log.debug "Configuring Reporting and Bindings."
     // Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
     sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])

--- a/devicetypes/smartthings/cree-bulb.src/cree-bulb.groovy
+++ b/devicetypes/smartthings/cree-bulb.src/cree-bulb.groovy
@@ -103,6 +103,8 @@ def poll() {
 
 def configure() {
     log.debug "Configuring Reporting and Bindings."
-    sendEvent(name: "checkInterval", value: 1200, displayed: false, data: [protocol: "zigbee"])
-    zigbee.onOffConfig() + zigbee.levelConfig() + zigbee.onOffRefresh() + zigbee.levelRefresh()
+    // Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
+    sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+    // minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
+    zigbee.onOffConfig(0, 300) + zigbee.levelConfig() + zigbee.onOffRefresh() + zigbee.levelRefresh()
 }

--- a/devicetypes/smartthings/cree-bulb.src/cree-bulb.groovy
+++ b/devicetypes/smartthings/cree-bulb.src/cree-bulb.groovy
@@ -105,8 +105,8 @@ def configure() {
     unschedule()
     schedule("0 0/5 * * * ? *", "healthPoll")
     log.debug "Configuring Reporting and Bindings."
-    // Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
-    sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+    // Device-Watch allows 2 check-in misses from device
+    sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
     // minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
     zigbee.onOffConfig(0, 300) + zigbee.levelConfig() + zigbee.onOffRefresh() + zigbee.levelRefresh()
 }

--- a/devicetypes/smartthings/cree-bulb.src/cree-bulb.groovy
+++ b/devicetypes/smartthings/cree-bulb.src/cree-bulb.groovy
@@ -93,7 +93,7 @@ def ping() {
 }
 
 def refresh() {
-    zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.onOffConfig() + zigbee.levelConfig()
+    zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.onOffConfig(0, 300) + zigbee.levelConfig()
 }
 
 def healthPoll() {

--- a/devicetypes/smartthings/ecobee-sensor.src/ecobee-sensor.groovy
+++ b/devicetypes/smartthings/ecobee-sensor.src/ecobee-sensor.groovy
@@ -67,6 +67,6 @@ def refresh() {
 
 void poll() {
 	log.debug "Executing 'poll' using parent SmartApp"
-	parent.poll()
+	parent.pollChild()
 
 }

--- a/devicetypes/smartthings/ecobee-sensor.src/ecobee-sensor.groovy
+++ b/devicetypes/smartthings/ecobee-sensor.src/ecobee-sensor.groovy
@@ -67,6 +67,6 @@ def refresh() {
 
 void poll() {
 	log.debug "Executing 'poll' using parent SmartApp"
-	parent.pollChild()
+	parent.poll()
 
 }

--- a/devicetypes/smartthings/ecobee-thermostat.src/ecobee-thermostat.groovy
+++ b/devicetypes/smartthings/ecobee-thermostat.src/ecobee-thermostat.groovy
@@ -133,7 +133,7 @@ def refresh() {
 
 void poll() {
 	log.debug "Executing 'poll' using parent SmartApp"
-	parent.poll()
+	parent.pollChild()
 }
 
 def generateEvent(Map results) {

--- a/devicetypes/smartthings/ecobee-thermostat.src/ecobee-thermostat.groovy
+++ b/devicetypes/smartthings/ecobee-thermostat.src/ecobee-thermostat.groovy
@@ -133,7 +133,7 @@ def refresh() {
 
 void poll() {
 	log.debug "Executing 'poll' using parent SmartApp"
-	parent.pollChild()
+	parent.poll()
 }
 
 def generateEvent(Map results) {

--- a/devicetypes/smartthings/hue-bloom.src/hue-bloom.groovy
+++ b/devicetypes/smartthings/hue-bloom.src/hue-bloom.groovy
@@ -57,7 +57,7 @@ metadata {
 }
 
 void installed() {
-	sendEvent(name: "checkInterval", value: 60 * 30, data: [protocol: "lan"], displayed: false)
+	sendEvent(name: "checkInterval", value: 60 * 15, data: [protocol: "lan"], displayed: false)
 }
 
 // parse events into attributes

--- a/devicetypes/smartthings/hue-bloom.src/hue-bloom.groovy
+++ b/devicetypes/smartthings/hue-bloom.src/hue-bloom.groovy
@@ -57,7 +57,7 @@ metadata {
 }
 
 void installed() {
-	sendEvent(name: "checkInterval", value: 60 * 15, data: [protocol: "lan"], displayed: false)
+	sendEvent(name: "checkInterval", value: 60 * 12, data: [protocol: "lan"], displayed: false)
 }
 
 // parse events into attributes

--- a/devicetypes/smartthings/hue-bulb.src/hue-bulb.groovy
+++ b/devicetypes/smartthings/hue-bulb.src/hue-bulb.groovy
@@ -66,7 +66,7 @@ metadata {
 }
 
 void installed() {
-	sendEvent(name: "checkInterval", value: 60 * 30, data: [protocol: "lan"], displayed: false)
+	sendEvent(name: "checkInterval", value: 60 * 15, data: [protocol: "lan"], displayed: false)
 }
 
 // parse events into attributes

--- a/devicetypes/smartthings/hue-bulb.src/hue-bulb.groovy
+++ b/devicetypes/smartthings/hue-bulb.src/hue-bulb.groovy
@@ -66,7 +66,7 @@ metadata {
 }
 
 void installed() {
-	sendEvent(name: "checkInterval", value: 60 * 15, data: [protocol: "lan"], displayed: false)
+	sendEvent(name: "checkInterval", value: 60 * 12, data: [protocol: "lan"], displayed: false)
 }
 
 // parse events into attributes

--- a/devicetypes/smartthings/hue-lux-bulb.src/hue-lux-bulb.groovy
+++ b/devicetypes/smartthings/hue-lux-bulb.src/hue-lux-bulb.groovy
@@ -50,7 +50,7 @@ metadata {
 }
 
 void installed() {
-	sendEvent(name: "checkInterval", value: 60 * 30, data: [protocol: "lan"], displayed: false)
+	sendEvent(name: "checkInterval", value: 60 * 15, data: [protocol: "lan"], displayed: false)
 }
 
 // parse events into attributes

--- a/devicetypes/smartthings/hue-lux-bulb.src/hue-lux-bulb.groovy
+++ b/devicetypes/smartthings/hue-lux-bulb.src/hue-lux-bulb.groovy
@@ -50,7 +50,7 @@ metadata {
 }
 
 void installed() {
-	sendEvent(name: "checkInterval", value: 60 * 15, data: [protocol: "lan"], displayed: false)
+	sendEvent(name: "checkInterval", value: 60 * 12, data: [protocol: "lan"], displayed: false)
 }
 
 // parse events into attributes

--- a/devicetypes/smartthings/hue-white-ambiance-bulb.src/hue-white-ambiance-bulb.groovy
+++ b/devicetypes/smartthings/hue-white-ambiance-bulb.src/hue-white-ambiance-bulb.groovy
@@ -55,7 +55,7 @@ metadata {
 }
 
 void installed() {
-	sendEvent(name: "checkInterval", value: 60 * 15, data: [protocol: "lan"], displayed: false)
+	sendEvent(name: "checkInterval", value: 60 * 12, data: [protocol: "lan"], displayed: false)
 }
 
 // parse events into attributes

--- a/devicetypes/smartthings/hue-white-ambiance-bulb.src/hue-white-ambiance-bulb.groovy
+++ b/devicetypes/smartthings/hue-white-ambiance-bulb.src/hue-white-ambiance-bulb.groovy
@@ -55,7 +55,7 @@ metadata {
 }
 
 void installed() {
-	sendEvent(name: "checkInterval", value: 60 * 30, data: [protocol: "lan"], displayed: false)
+	sendEvent(name: "checkInterval", value: 60 * 15, data: [protocol: "lan"], displayed: false)
 }
 
 // parse events into attributes

--- a/devicetypes/smartthings/smartpower-outlet.src/README.md
+++ b/devicetypes/smartthings/smartpower-outlet.src/README.md
@@ -23,10 +23,10 @@ Works with:
 
 ## Device Health
 
-A Category C1 smart power outlet with maxReportTime of 10 min.
-Check-in interval is double the value of maxReportTime for Zigbee device. 
+A Category C1 smart power outlet with maxReportTime of 5 mins.
+Check-in interval is double the value of maxReportTime. 
 This gives the device twice the amount of time to respond before it is marked as offline.
-Check-in interval = 2*10 = 20 min
+Check-in interval = 12 mins
 
 ## Troubleshooting
 

--- a/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
+++ b/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
@@ -104,8 +104,16 @@ def parse(String description) {
 		}
 	}
 	else {
-		log.warn "DID NOT PARSE MESSAGE for description : $description"
-		log.debug zigbee.parseDescriptionAsMap(description)
+		def cluster = zigbee.parse(description)
+
+		if (cluster.clusterId == 0x0006 && cluster.command == 0x07 && cluster.data[0] == 0x00) {
+			log.debug "ON/OFF REPORTING CONFIG RESPONSE: " + cluster
+			sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
+		}
+		else {
+			log.warn "DID NOT PARSE MESSAGE for description : $description"
+			log.debug "${cluster}"
+		}
 	}
 }
 
@@ -128,8 +136,9 @@ def refresh() {
 }
 
 def configure() {
-	// Device-Watch allows 2 check-in misses from device
-	sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 3 check-in misses from device (plus 3 min lag time)
+	sendEvent(name: "checkInterval", value: 3 * 60 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee"])
+
 	// OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
 	zigbee.onOffConfig(0, 300) + powerConfig() + refresh()
 }

--- a/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
+++ b/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
@@ -128,8 +128,8 @@ def refresh() {
 }
 
 def configure() {
-	// Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
-	sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 2 check-in misses from device
+	sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
 	// OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
 	zigbee.onOffConfig(0, 300) + powerConfig() + refresh()
 }

--- a/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
+++ b/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
@@ -128,8 +128,10 @@ def refresh() {
 }
 
 def configure() {
-	sendEvent(name: "checkInterval", value: 1200, displayed: false, data: [protocol: "zigbee"])
-	zigbee.onOffConfig() + powerConfig() + refresh()
+	// Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
+	sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+	// OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
+	zigbee.onOffConfig(0, 300) + powerConfig() + refresh()
 }
 
 //power config for devices with min reporting interval as 1 seconds and reporting interval if no activity as 10min (600s)

--- a/devicetypes/smartthings/smartsense-moisture-sensor.src/README.md
+++ b/devicetypes/smartthings/smartsense-moisture-sensor.src/README.md
@@ -23,10 +23,10 @@ Works with:
 
 ## Device Health
 
-A Category C2 moisture sensor with maxReportTime of 1 hr.
-Check-in interval is double the value of maxReportTime for Zigbee device. 
+A Category C2 moisture sensor with maxReportTime of 5 mins.
+Check-in interval is double the value of maxReportTime. 
 This gives the device twice the amount of time to respond before it is marked as offline.
-Check-in interval = 2*60 = 120 min
+Check-in interval = 12 mins
 
 ## Battery Specification
 

--- a/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
@@ -292,8 +292,8 @@ def refresh() {
 }
 
 def configure() {
-	// Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
-	sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 2 check-in misses from device
+	sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
 
 	String zigbeeEui = swapEndianHex(device.hub.zigbeeEui)
 	log.debug "Configuring Reporting, IAS CIE, and Bindings."

--- a/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
@@ -122,10 +122,17 @@ private Map parseCatchAllMessage(String description) {
 				break
 
             case 0x0402:
-                // temp is last 2 data values. reverse to swap endian
-                String temp = cluster.data[-2..-1].reverse().collect { cluster.hex1(it) }.join()
-                def value = getTemperature(temp)
-                resultMap = getTemperatureResult(value)
+				if (cluster.command == 0x07 && cluster.data[0] == 0x00) // Response from temperature periodic reporting configuration
+				{
+					log.debug "TEMP REPORTING CONFIG RESPONSE" + cluster
+					sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
+				}
+				else {
+					// temp is last 2 data values. reverse to swap endian
+					String temp = cluster.data[-2..-1].reverse().collect { cluster.hex1(it) }.join()
+					def value = getTemperature(temp)
+					resultMap = getTemperatureResult(value)
+				}
                 break
         }
     }
@@ -138,7 +145,6 @@ private boolean shouldProcessMessage(cluster) {
 	// 0x07 is bind message
 	boolean ignoredMessage = cluster.profileId != 0x0104 ||
 		cluster.command == 0x0B ||
-		cluster.command == 0x07 ||
 		(cluster.data.size() > 0 && cluster.data.first() == 0x3e)
 	return !ignoredMessage
 }
@@ -292,8 +298,8 @@ def refresh() {
 }
 
 def configure() {
-	// Device-Watch allows 2 check-in misses from device
-	sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 3 check-in misses from device (plus 3 min lag time)
+	sendEvent(name: "checkInterval", value: 3 * 60 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee"])
 
 	String zigbeeEui = swapEndianHex(device.hub.zigbeeEui)
 	log.debug "Configuring Reporting, IAS CIE, and Bindings."

--- a/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
@@ -292,23 +292,19 @@ def refresh() {
 }
 
 def configure() {
-	sendEvent(name: "checkInterval", value: 14400, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
+	sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
 
 	String zigbeeEui = swapEndianHex(device.hub.zigbeeEui)
 	log.debug "Configuring Reporting, IAS CIE, and Bindings."
-	def configCmds = [
+	def enrollCmds = [
 		"zcl global write 0x500 0x10 0xf0 {${zigbeeEui}}", "delay 200",
 		"send 0x${device.deviceNetworkId} 1 1", "delay 500",
-
-		"zdo bind 0x${device.deviceNetworkId} ${endpointId} 1 1 {${device.zigbeeId}} {}", "delay 500",
-		"zcl global send-me-a-report 1 0x20 0x20 30 21600 {01}",		//checkin time 6 hrs
-		"send 0x${device.deviceNetworkId} 1 1", "delay 500",
-
-		"zdo bind 0x${device.deviceNetworkId} ${endpointId} 1 0x402 {${device.zigbeeId}} {}", "delay 500",
-		"zcl global send-me-a-report 0x402 0 0x29 30 3600 {6400}",
-		"send 0x${device.deviceNetworkId} 1 1", "delay 500"
 	]
-	return configCmds + refresh() // send refresh cmds as part of config
+
+	// temperature minReportTime 30 seconds, maxReportTime 5 min. Reporting interval if no activity
+	// battery minReport 30 seconds, maxReportTime 6 hrs by default
+	return enrollCmds + zigbee.batteryConfig() + zigbee.temperatureConfig(30, 300) + refresh() // send refresh cmds as part of config
 }
 
 def enrollResponse() {

--- a/devicetypes/smartthings/smartsense-motion-sensor.src/README.md
+++ b/devicetypes/smartthings/smartsense-motion-sensor.src/README.md
@@ -22,10 +22,10 @@ Works with:
 
 ## Device Health
 
-A Category C2 motion sensor with maxReportTime of 1 hr.
-Check-in interval is double the value of maxReportTime for Zigbee device. 
+A Category C2 motion sensor with maxReportTime of 5 mins.
+Check-in interval is double the value of maxReportTime.
 This gives the device twice the amount of time to respond before it is marked as offline.
-Check-in interval = 2*60 = 120 min
+Check-in interval = 12 mins
 
 ## Battery Specification
 

--- a/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
@@ -126,10 +126,17 @@ private Map parseCatchAllMessage(String description) {
 				break
 
 			case 0x0402:
-				// temp is last 2 data values. reverse to swap endian
-				String temp = cluster.data[-2..-1].reverse().collect { cluster.hex1(it) }.join()
-				def value = getTemperature(temp)
-				resultMap = getTemperatureResult(value)
+				if (cluster.command == 0x07 && cluster.data[0] == 0x00) // Response from temperature periodic reporting configuration
+				{
+					log.debug "TEMP REPORTING CONFIG RESPONSE" + cluster
+					sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
+				}
+				else {
+					// temp is last 2 data values. reverse to swap endian
+					String temp = cluster.data[-2..-1].reverse().collect { cluster.hex1(it) }.join()
+					def value = getTemperature(temp)
+					resultMap = getTemperatureResult(value)
+				}
 				break
 
 			case 0x0406:
@@ -147,7 +154,6 @@ private boolean shouldProcessMessage(cluster) {
 	// 0x07 is bind message
 	boolean ignoredMessage = cluster.profileId != 0x0104 ||
 		cluster.command == 0x0B ||
-		cluster.command == 0x07 ||
 		(cluster.data.size() > 0 && cluster.data.first() == 0x3e)
 	return !ignoredMessage
 }
@@ -303,8 +309,8 @@ def refresh() {
 }
 
 def configure() {
-	// Device-Watch allows 2 check-in misses from device
-	sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 3 check-in misses from device (plus 3 min lag time)
+	sendEvent(name: "checkInterval", value: 3 * 60 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee"])
 
 	String zigbeeEui = swapEndianHex(device.hub.zigbeeEui)
 	log.debug "Configuring Reporting, IAS CIE, and Bindings."

--- a/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
@@ -303,8 +303,8 @@ def refresh() {
 }
 
 def configure() {
-	// Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
-	sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 2 check-in misses from device
+	sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
 
 	String zigbeeEui = swapEndianHex(device.hub.zigbeeEui)
 	log.debug "Configuring Reporting, IAS CIE, and Bindings."

--- a/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
@@ -303,24 +303,19 @@ def refresh() {
 }
 
 def configure() {
-	sendEvent(name: "checkInterval", value: 14400, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
+	sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
 
 	String zigbeeEui = swapEndianHex(device.hub.zigbeeEui)
 	log.debug "Configuring Reporting, IAS CIE, and Bindings."
 
-	def configCmds = [
+	def enrollCmds = [
 		"zcl global write 0x500 0x10 0xf0 {${zigbeeEui}}", "delay 200",
 		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 500",
-
-		"zdo bind 0x${device.deviceNetworkId} ${endpointId} 1 1 {${device.zigbeeId}} {}", "delay 200",
-		"zcl global send-me-a-report 1 0x20 0x20 30 21600 {01}",		//checkin time 6 hrs
-		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 500",
-
-		"zdo bind 0x${device.deviceNetworkId} ${endpointId} 1 0x402 {${device.zigbeeId}} {}", "delay 200",
-		"zcl global send-me-a-report 0x402 0 0x29 300 3600 {6400}",
-		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 500"
 	]
-	return configCmds + refresh() // send refresh cmds as part of config
+	// temperature minReportTime 30 seconds, maxReportTime 5 min. Reporting interval if no activity
+	// battery minReport 30 seconds, maxReportTime 6 hrs by default
+	return enrollCmds + zigbee.batteryConfig() + zigbee.temperatureConfig(30, 300) + refresh() // send refresh cmds as part of config
 }
 
 def enrollResponse() {

--- a/devicetypes/smartthings/smartsense-multi-sensor.src/README.md
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/README.md
@@ -26,10 +26,10 @@ Works with:
 
 ## Device Health
 
-A Category C2 multi sensor with maxReportTime of 1 hr.
-Check-in interval is double the value of maxReportTime for Zigbee device. 
+A Category C2 multi sensor with maxReportTime of 5 mins.
+Check-in interval is double the value of maxReportTime. 
 This gives the device twice the amount of time to respond before it is marked as offline.
-Check-in interval = 2*60 = 120 min
+Check-in interval = 12 mins
 
 ## Battery Specification
 

--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -401,13 +401,16 @@ def refresh() {
 }
 
 def configure() {
-	sendEvent(name: "checkInterval", value: 14400, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
+	sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
 
 	log.debug "Configuring Reporting"
 
+	// temperature minReportTime 30 seconds, maxReportTime 5 min. Reporting interval if no activity
+	// battery minReport 30 seconds, maxReportTime 6 hrs by default
 	def configCmds = enrollResponse() +
 			zigbee.batteryConfig() +
-			zigbee.temperatureConfig() +
+			zigbee.temperatureConfig(30, 300) +
 			zigbee.configureReporting(0xFC02, 0x0010, 0x18, 10, 3600, 0x01, [mfgCode: manufacturerCode]) +
 			zigbee.configureReporting(0xFC02, 0x0012, 0x29, 1, 3600, 0x0001, [mfgCode: manufacturerCode]) +
 			zigbee.configureReporting(0xFC02, 0x0013, 0x29, 1, 3600, 0x0001, [mfgCode: manufacturerCode]) +

--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -155,12 +155,18 @@ private Map parseCatchAllMessage(String description) {
 			break
 
 			case 0x0402:
-			log.debug 'TEMP'
+			if (cluster.command == 0x07 && cluster.data[0] == 0x00) // Response from temperature periodic reporting configuration
+			{
+				log.debug "TEMP REPORTING CONFIG RESPONSE" + cluster
+				sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
+			}
+			else {
 				// temp is last 2 data values. reverse to swap endian
 				String temp = cluster.data[-2..-1].reverse().collect { cluster.hex1(it) }.join()
 				def value = getTemperature(temp)
 				resultMap = getTemperatureResult(value)
-				break
+			}
+			break
 		}
 	}
 
@@ -172,7 +178,6 @@ private boolean shouldProcessMessage(cluster) {
 	// 0x07 is bind message
 	boolean ignoredMessage = cluster.profileId != 0x0104 ||
 	cluster.command == 0x0B ||
-	cluster.command == 0x07 ||
 	(cluster.data.size() > 0 && cluster.data.first() == 0x3e)
 	return !ignoredMessage
 }
@@ -401,8 +406,8 @@ def refresh() {
 }
 
 def configure() {
-	// Device-Watch allows 2 check-in misses from device
-	sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 3 check-in misses from device (plus 3 min lag time)
+	sendEvent(name: "checkInterval", value: 3 * 60 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee"])
 
 	log.debug "Configuring Reporting"
 

--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -401,8 +401,8 @@ def refresh() {
 }
 
 def configure() {
-	// Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
-	sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 2 check-in misses from device
+	sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
 
 	log.debug "Configuring Reporting"
 

--- a/devicetypes/smartthings/smartsense-open-closed-sensor.src/README.md
+++ b/devicetypes/smartthings/smartsense-open-closed-sensor.src/README.md
@@ -24,10 +24,10 @@ Works with:
 
 ## Device Health
 
-A Category C2 open/closed sensor with maxReportTime of 1 hr.
-Check-in interval is double the value of maxReportTime for Zigbee device. 
+A Category C2 open/closed sensor with maxReportTime of 5 mins.
+Check-in interval is double the value of maxReportTime. 
 This gives the device twice the amount of time to respond before it is marked as offline.
-Check-in interval = 2*60 = 120 min
+Check-in interval = 12 mins
 
 ## Battery Specification
 

--- a/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
@@ -255,8 +255,8 @@ def refresh() {
 }
 
 def configure() {
-	// Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
-	sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 2 check-in misses from device
+	sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
 
 	String zigbeeEui = swapEndianHex(device.hub.zigbeeEui)
 	log.debug "Configuring Reporting, IAS CIE, and Bindings."

--- a/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/README.md
+++ b/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/README.md
@@ -24,10 +24,10 @@ Works with:
 
 ## Device Health
 
-A Category C2 SmartSense Temp/Humidity Sensor with maxReportTime of 1 hr.
-Check-in interval is double the value of maxReportTime for Zigbee device. 
+A Category C2 SmartSense Temp/Humidity Sensor with maxReportTime of 5 mins.
+Check-in interval is double the value of maxReportTime. 
 This gives the device twice the amount of time to respond before it is marked as offline.
-Check-in interval = 2*60 = 120 min
+Check-in interval = 12 mins
 
 ## Battery Specification
 

--- a/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
@@ -97,11 +97,18 @@ private Map parseCatchAllMessage(String description) {
                 break
 
             case 0x0402:
-                // temp is last 2 data values. reverse to swap endian
-                String temp = cluster.data[-2..-1].reverse().collect { cluster.hex1(it) }.join()
-                def value = getTemperature(temp)
-                resultMap = getTemperatureResult(value)
-                break
+				if (cluster.command == 0x07 && cluster.data[0] == 0x00) // Response from temperature periodic reporting configuration
+				{
+					log.debug "TEMP REPORTING CONFIG RESPONSE" + cluster
+					sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
+				}
+				else {
+					// temp is last 2 data values. reverse to swap endian
+					String temp = cluster.data[-2..-1].reverse().collect { cluster.hex1(it) }.join()
+					def value = getTemperature(temp)
+					resultMap = getTemperatureResult(value)
+				}
+				break
 
 			case 0xFC45:
                 String pctStr = cluster.data[-1, -2].collect { Integer.toHexString(it) }.join('')
@@ -119,7 +126,6 @@ private boolean shouldProcessMessage(cluster) {
     // 0x07 is bind message
     boolean ignoredMessage = cluster.profileId != 0x0104 ||
         cluster.command == 0x0B ||
-        cluster.command == 0x07 ||
         (cluster.data.size() > 0 && cluster.data.first() == 0x3e)
     return !ignoredMessage
 }
@@ -264,8 +270,8 @@ def refresh()
 }
 
 def configure() {
-	// Device-Watch allows 2 check-in misses from device
-	sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 3 check-in misses from device (plus 3 min lag time)
+	sendEvent(name: "checkInterval", value: 3 * 60 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee"])
 
 	log.debug "Configuring Reporting and Bindings."
 	def humidityConfigCmds = [

--- a/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
@@ -264,8 +264,8 @@ def refresh()
 }
 
 def configure() {
-	// Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
-	sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 2 check-in misses from device
+	sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
 
 	log.debug "Configuring Reporting and Bindings."
 	def humidityConfigCmds = [

--- a/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
@@ -264,23 +264,19 @@ def refresh()
 }
 
 def configure() {
-	sendEvent(name: "checkInterval", value: 14400, displayed: false, data: [protocol: "zigbee"])
+	// Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
+	sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
 
 	log.debug "Configuring Reporting and Bindings."
-	def configCmds = [
-		"zdo bind 0x${device.deviceNetworkId} 1 1 1 {${device.zigbeeId}} {}", "delay 500",
-		"zcl global send-me-a-report 1 0x20 0x20 30 21600 {01}",		//checkin time 6 hrs
-		"send 0x${device.deviceNetworkId} 1 1", "delay 500",
-
-		"zdo bind 0x${device.deviceNetworkId} 1 1 0x402 {${device.zigbeeId}} {}", "delay 500",
-		"zcl global send-me-a-report 0x402 0 0x29 30 3600 {6400}",
-		"send 0x${device.deviceNetworkId} 1 1", "delay 500",
-
+	def humidityConfigCmds = [
 		"zdo bind 0x${device.deviceNetworkId} 1 1 0xFC45 {${device.zigbeeId}} {}", "delay 500",
 		"zcl global send-me-a-report 0xFC45 0 0x29 30 3600 {6400}",
 		"send 0x${device.deviceNetworkId} 1 1", "delay 500"
 	]
-	return configCmds + refresh() // send refresh cmds as part of config
+
+	// temperature minReportTime 30 seconds, maxReportTime 5 min. Reporting interval if no activity
+	// battery minReport 30 seconds, maxReportTime 6 hrs by default
+	return humidityConfigCmds + zigbee.batteryConfig() + zigbee.temperatureConfig(30, 300) +  refresh() // send refresh cmds as part of config
 }
 
 private hex(value) {

--- a/devicetypes/smartthings/zigbee-dimmer.src/.st-ignore
+++ b/devicetypes/smartthings/zigbee-dimmer.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/zigbee-dimmer.src/README.md
+++ b/devicetypes/smartthings/zigbee-dimmer.src/README.md
@@ -1,21 +1,21 @@
-# Connected Cree LED Bulb
+# OSRAM Lightify LED On/Off/Dim
 
 
 
 Works with: 
 
-* [Connected Cree LED Bulb](https://support.smartthings.com/hc/en-us/articles/204258280-Cree-Connected-LED-Bulb)
+* [OSRAM Lightify LED On/Off/Dim](https://shop.smartthings.com/#!/products/osram-led-smart-bulb-on-off-dim)
 
 ## Table of contents
 
 * [Capabilities](#capabilities)
 * [Health](#device-health)
+* [Battery](#battery-specification)
 
 ## Capabilities
 
 * **Actuator** - represents that a Device has commands
 * **Configuration** - _configure()_ command called when device is installed or device preferences updated
-* **Polling** - represents that poll() can be implemented for the device
 * **Refresh** - _refresh()_ command for status updates
 * **Switch** - can detect state (possible values: on/off)
 * **Switch Level** - represents current light level, usually 0-100 in percent
@@ -23,12 +23,14 @@ Works with:
 
 ## Device Health
 
-A Category C6 Connected Cree LED Bulb with maxReportTime of 5 mins.
+A Category C1 Zigbee dimmer with maxReportTime of 5 mins.
+Check-in interval is double the value of maxReportTime. 
+This gives the device twice the amount of time to respond before it is marked as offline.
 Check-in interval = 12 mins
 
 ## Troubleshooting
 
 If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
 Pairing needs to be tried again by placing the device closer to the hub.
-Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following link:
-* [Cree Connected LED Bulb Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/204258280-Cree-Connected-LED-Bulb)
+Other troubleshooting tips are listed as follows:
+* [Troubleshooting:](https://support.smartthings.com/hc/en-us/articles/207191763-OSRAM-LIGHTIFY-LED-Smart-Connected-Light-A19-On-Off-Dim)

--- a/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
@@ -60,8 +60,16 @@ def parse(String description) {
         }
     }
     else {
-        log.warn "DID NOT PARSE MESSAGE for description : $description"
-        log.debug zigbee.parseDescriptionAsMap(description)
+        def cluster = zigbee.parse(description)
+
+        if (cluster.clusterId == 0x0006 && cluster.command == 0x07 && cluster.data[0] == 0x00) {
+            log.debug "ON/OFF REPORTING CONFIG RESPONSE: " + cluster
+            sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
+        }
+        else {
+            log.warn "DID NOT PARSE MESSAGE for description : $description"
+            log.debug "${cluster}"
+        }
     }
 }
 
@@ -84,13 +92,14 @@ def ping() {
 }
 
 def refresh() {
-    zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.onOffConfig() + zigbee.levelConfig()
+    zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.onOffConfig(0, 300) + zigbee.levelConfig()
 }
 
 def configure() {
     log.debug "Configuring Reporting and Bindings."
-    // Device-Watch allows 2 check-in misses from device
-    sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
+    // Device-Watch allows 3 check-in misses from device (plus 3 min lag time)
+    sendEvent(name: "checkInterval", value: 3 * 60 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee"])
+
     // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
     zigbee.onOffConfig(0, 300) + zigbee.levelConfig() + zigbee.onOffRefresh() + zigbee.levelRefresh()
 }

--- a/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
@@ -89,8 +89,8 @@ def refresh() {
 
 def configure() {
     log.debug "Configuring Reporting and Bindings."
-    // Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
-    sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+    // Device-Watch allows 2 check-in misses from device
+    sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
     // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
     zigbee.onOffConfig(0, 300) + zigbee.levelConfig() + zigbee.onOffRefresh() + zigbee.levelRefresh()
 }

--- a/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
@@ -89,7 +89,8 @@ def refresh() {
 
 def configure() {
     log.debug "Configuring Reporting and Bindings."
-    // Enrolls device to Device-Watch with 3 x Reporting interval 30min
-    sendEvent(name: "checkInterval", value: 1800, displayed: false, data: [protocol: "zigbee"])
-    zigbee.onOffConfig() + zigbee.levelConfig() + zigbee.onOffRefresh() + zigbee.levelRefresh()
+    // Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
+    sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+    // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
+    zigbee.onOffConfig(0, 300) + zigbee.levelConfig() + zigbee.onOffRefresh() + zigbee.levelRefresh()
 }

--- a/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
@@ -13,7 +13,7 @@
  */
 
 metadata {
-    definition (name: "ZigBee Dimmer", namespace: "smartthings", author: "SmartThings") {
+    definition (name: "ZigBee Dimmer", namespace: "smartthings", author: "SmartThings", category: "C1") {
         capability "Actuator"
         capability "Configuration"
         capability "Refresh"

--- a/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
+++ b/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
@@ -31,7 +31,8 @@
         fingerprint profileId: "0104", inClusters: "0000,0001,0003,0009,000A,0101,0020", outClusters: "000A,0019", manufacturer: "Yale", model: "YRD210 PB DB", deviceJoinName: "Yale Push Button Deadbolt Lock"
         fingerprint profileId: "0104", inClusters: "0000,0001,0003,0009,000A,0101,0020", outClusters: "000A,0019", manufacturer: "Yale", model: "YRD220/240 TSDB", deviceJoinName: "Yale Touch Screen Deadbolt Lock"
         fingerprint profileId: "0104", inClusters: "0000,0001,0003,0009,000A,0101,0020", outClusters: "000A,0019", manufacturer: "Yale", model: "YRL210 PB LL", deviceJoinName: "Yale Push Button Lever Lock"
-    }
+		fingerprint profileId: "0104", inClusters: "0000,0001,0003,0009,000A,0101,0020", outClusters: "000A,0019", manufacturer: "Yale", model: "YRD226/246 TSDB", 	deviceJoinName: "Yale Key-Free Touchscreen Deadbolt Lock"
+	}
 
     tiles(scale: 2) {
 		multiAttributeTile(name:"toggle", type:"generic", width:6, height:4){

--- a/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
+++ b/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
@@ -31,7 +31,7 @@
         fingerprint profileId: "0104", inClusters: "0000,0001,0003,0009,000A,0101,0020", outClusters: "000A,0019", manufacturer: "Yale", model: "YRD210 PB DB", deviceJoinName: "Yale Push Button Deadbolt Lock"
         fingerprint profileId: "0104", inClusters: "0000,0001,0003,0009,000A,0101,0020", outClusters: "000A,0019", manufacturer: "Yale", model: "YRD220/240 TSDB", deviceJoinName: "Yale Touch Screen Deadbolt Lock"
         fingerprint profileId: "0104", inClusters: "0000,0001,0003,0009,000A,0101,0020", outClusters: "000A,0019", manufacturer: "Yale", model: "YRL210 PB LL", deviceJoinName: "Yale Push Button Lever Lock"
-		fingerprint profileId: "0104", inClusters: "0000,0001,0003,0009,000A,0101,0020", outClusters: "000A,0019", manufacturer: "Yale", model: "YRD226/246 TSDB", 	deviceJoinName: "Yale Key-Free Touchscreen Deadbolt Lock"
+	fingerprint profileId: "0104", inClusters: "0000,0001,0003,0009,000A,0101,0020", outClusters: "000A,0019", manufacturer: "Yale", model: "YRD226/246 TSDB", deviceJoinName: "Yale Key-Free Touchscreen Deadbolt Lock"
 	}
 
     tiles(scale: 2) {

--- a/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
+++ b/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
@@ -31,7 +31,7 @@
         fingerprint profileId: "0104", inClusters: "0000,0001,0003,0009,000A,0101,0020", outClusters: "000A,0019", manufacturer: "Yale", model: "YRD210 PB DB", deviceJoinName: "Yale Push Button Deadbolt Lock"
         fingerprint profileId: "0104", inClusters: "0000,0001,0003,0009,000A,0101,0020", outClusters: "000A,0019", manufacturer: "Yale", model: "YRD220/240 TSDB", deviceJoinName: "Yale Touch Screen Deadbolt Lock"
         fingerprint profileId: "0104", inClusters: "0000,0001,0003,0009,000A,0101,0020", outClusters: "000A,0019", manufacturer: "Yale", model: "YRL210 PB LL", deviceJoinName: "Yale Push Button Lever Lock"
-	fingerprint profileId: "0104", inClusters: "0000,0001,0003,0009,000A,0101,0020", outClusters: "000A,0019", manufacturer: "Yale", model: "YRD226/246 TSDB", deviceJoinName: "Yale Key-Free Touchscreen Deadbolt Lock"
+	fingerprint profileId: "0104", inClusters: "0000,0001,0003,0009,000A,0101,0020", outClusters: "000A,0019", manufacturer: "Yale", model: "YRD226/246 TSDB", deviceJoinName: "ale Touch Screen Deadbolt Lock"
 	}
 
     tiles(scale: 2) {

--- a/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
+++ b/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
@@ -31,7 +31,7 @@
         fingerprint profileId: "0104", inClusters: "0000,0001,0003,0009,000A,0101,0020", outClusters: "000A,0019", manufacturer: "Yale", model: "YRD210 PB DB", deviceJoinName: "Yale Push Button Deadbolt Lock"
         fingerprint profileId: "0104", inClusters: "0000,0001,0003,0009,000A,0101,0020", outClusters: "000A,0019", manufacturer: "Yale", model: "YRD220/240 TSDB", deviceJoinName: "Yale Touch Screen Deadbolt Lock"
         fingerprint profileId: "0104", inClusters: "0000,0001,0003,0009,000A,0101,0020", outClusters: "000A,0019", manufacturer: "Yale", model: "YRL210 PB LL", deviceJoinName: "Yale Push Button Lever Lock"
-	fingerprint profileId: "0104", inClusters: "0000,0001,0003,0009,000A,0101,0020", outClusters: "000A,0019", manufacturer: "Yale", model: "YRD226/246 TSDB", deviceJoinName: "ale Touch Screen Deadbolt Lock"
+	fingerprint profileId: "0104", inClusters: "0000,0001,0003,0009,000A,0101,0020", outClusters: "000A,0019", manufacturer: "Yale", model: "YRD226/246 TSDB", deviceJoinName: "Yale Touch Screen Deadbolt Lock"
 	}
 
     tiles(scale: 2) {

--- a/devicetypes/smartthings/zigbee-rgbw-bulb.src/.st-ignore
+++ b/devicetypes/smartthings/zigbee-rgbw-bulb.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/zigbee-rgbw-bulb.src/README.md
+++ b/devicetypes/smartthings/zigbee-rgbw-bulb.src/README.md
@@ -1,0 +1,42 @@
+# OSRAM LIGHTIFY LED RGBW Bulb
+
+
+
+Works with: 
+
+* [OSRAM LIGHTIFY LED RGBW Bulb](https://support.smartthings.com/hc/en-us/articles/207728173-OSRAM-LIGHTIFY-LED-Smart-Connected-Light-A19-RGBW)
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+* [Battery](#battery-specification)
+
+## Capabilities
+
+* **Actuator** - It represents that a device has commands.
+* **Color Control** - It represents that the color attributes of a device can be controlled (hue, saturation, color value).
+* **Color Temperature** - It represents color temperature capability measured in degree Kelvin.
+* **Polling** - It represents that a device can be polled.
+* **Switch** - can detect state (possible values: on/off)
+* **Switch Level** - can detect current light level (0-100 in percent)
+* **Configuration** - _configure()_ command called when device is installed or device preferences updated
+* **Refresh** - _refresh()_ command for status updates
+* **Health Check** - indicates ability to get device health notifications
+
+
+## Device Health
+
+A Category C6 OSRAM LIGHTIFY LED RGBW Bulb with maxReportTime of 5 mins.
+Check-in interval is double the value of maxReportTime. 
+This gives the device twice the amount of time to respond before it is marked as offline.
+Check-in interval = 12 mins
+
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
+Pairing needs to be tried again by placing the device closer to the hub.
+It may also happen that you need to reset the device.
+Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following link:
+* [Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/207728173-OSRAM-LIGHTIFY-LED-Smart-Connected-Light-A19-RGBW)

--- a/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
@@ -133,8 +133,8 @@ def refresh() {
 
 def configure() {
     log.debug "Configuring Reporting and Bindings."
-    // Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
-    sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+    // Device-Watch allows 2 check-in misses from device
+    sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
     // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
     zigbee.onOffConfig(0, 300) + zigbee.levelConfig() + zigbee.colorTemperatureConfig() + zigbee.configureReporting(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE, 0x20, 1, 3600, 0x01) + zigbee.configureReporting(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION, 0x20, 1, 3600, 0x01) + zigbee.readAttribute(0x0006, 0x00) + zigbee.readAttribute(0x0008, 0x00) + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, 0x00) + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_COLOR_TEMPERATURE) + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE) + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION)
 }

--- a/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
@@ -17,7 +17,7 @@
  */
 
 metadata {
-    definition (name: "ZigBee RGBW Bulb", namespace: "smartthings", author: "SmartThings") {
+    definition (name: "ZigBee RGBW Bulb", namespace: "smartthings", author: "SmartThings", category: "C6") {
 
         capability "Actuator"
         capability "Color Control"

--- a/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
@@ -133,9 +133,10 @@ def refresh() {
 
 def configure() {
     log.debug "Configuring Reporting and Bindings."
-    // Enrolls device to Device-Watch with 3 x Reporting interval 30min
-    sendEvent(name: "checkInterval", value: 1800, displayed: false, data: [protocol: "zigbee"])
-    zigbee.onOffConfig() + zigbee.levelConfig() + zigbee.colorTemperatureConfig() + zigbee.configureReporting(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE, 0x20, 1, 3600, 0x01) + zigbee.configureReporting(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION, 0x20, 1, 3600, 0x01) + zigbee.readAttribute(0x0006, 0x00) + zigbee.readAttribute(0x0008, 0x00) + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, 0x00) + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_COLOR_TEMPERATURE) + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE) + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION)
+    // Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
+    sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+    // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
+    zigbee.onOffConfig(0, 300) + zigbee.levelConfig() + zigbee.colorTemperatureConfig() + zigbee.configureReporting(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE, 0x20, 1, 3600, 0x01) + zigbee.configureReporting(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION, 0x20, 1, 3600, 0x01) + zigbee.readAttribute(0x0006, 0x00) + zigbee.readAttribute(0x0008, 0x00) + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, 0x00) + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_COLOR_TEMPERATURE) + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE) + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION)
 }
 
 def setColorTemperature(value) {

--- a/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/.st-ignore
+++ b/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/README.md
+++ b/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/README.md
@@ -1,0 +1,37 @@
+# OSRAM Lightify Tunable 60 White
+
+
+
+Works with: 
+
+* [OSRAM Lightify Tunable 60 White](http://www.osram.com/osram_com/tools-and-services/tools/lightify---smart-connected-light/lightify-for-home---what-is-light-to-you/lightify-products/lightify-classic-a60-tunable-white/index.jsp)
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+* [Battery](#battery-specification)
+
+## Capabilities
+
+* **Actuator** - represents that a Device has commands
+* **Color Temperature** - represents color temperature, measured in degrees Kelvin.
+* **Configuration** - _configure()_ command called when device is installed or device preferences updated.
+* **Refresh** - _refresh()_ command for status updates
+* **Switch** - can detect state (possible values: on/off)
+* **Switch Level** - represents current light level, usually 0-100 in percent
+* **Health Check** - indicates ability to get device health notifications
+
+## Device Health
+
+A Category C1 OSRAM Lightify Tunable 60 White with maxReportTime of 5 mins.
+Check-in interval is double the value of maxReportTime. 
+This gives the device twice the amount of time to respond before it is marked as offline.
+Check-in interval = 12 mins
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
+Pairing needs to be tried again by placing the device closer to the hub.
+Other troubleshooting tips are listed as follows:
+* [Troubleshooting:](https://support.smartthings.com/hc/en-us/articles/204576454-OSRAM-LIGHTIFY-Tunable-White-60-Bulb)

--- a/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
@@ -17,7 +17,7 @@
  */
 
 metadata {
-    definition (name: "ZigBee White Color Temperature Bulb", namespace: "smartthings", author: "SmartThings") {
+    definition (name: "ZigBee White Color Temperature Bulb", namespace: "smartthings", author: "SmartThings", category: "C1") {
 
         capability "Actuator"
         capability "Color Temperature"

--- a/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
@@ -113,8 +113,8 @@ def refresh() {
 
 def configure() {
     log.debug "Configuring Reporting and Bindings."
-    // Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
-    sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+    // Device-Watch allows 2 check-in misses from device
+    sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee"])
     // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
     zigbee.onOffConfig(0, 300) + zigbee.levelConfig() + zigbee.colorTemperatureConfig() + zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.colorTemperatureRefresh()
 }

--- a/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
@@ -113,9 +113,10 @@ def refresh() {
 
 def configure() {
     log.debug "Configuring Reporting and Bindings."
-    // Enrolls device to Device-Watch with 3 x Reporting interval 30min
-    sendEvent(name: "checkInterval", value: 1800, displayed: false, data: [protocol: "zigbee"])
-    zigbee.onOffConfig() + zigbee.levelConfig() + zigbee.colorTemperatureConfig() + zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.colorTemperatureRefresh()
+    // Device-Watch allows 3 check-in misses from device. 300 seconds x 3 = 15min
+    sendEvent(name: "checkInterval", value: 900, displayed: false, data: [protocol: "zigbee"])
+    // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
+    zigbee.onOffConfig(0, 300) + zigbee.levelConfig() + zigbee.colorTemperatureConfig() + zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.colorTemperatureRefresh()
 }
 
 def setColorTemperature(value) {

--- a/smartapps/curb/curb-control.src/curb-control.groovy
+++ b/smartapps/curb/curb-control.src/curb-control.groovy
@@ -68,10 +68,10 @@ private void updateAll(devices) {
 		switch(command) {
 			case "on":
 				devices.on()
-				break;
+				break
 			case "off":
 				devices.off()
-				break;
+				break
 			default:
 				httpError(403, "Access denied. This command is not supported by current capability.")
 		}
@@ -89,10 +89,10 @@ private void update(devices) {
 			switch(command) {
 				case "on":
 					device.on()
-					break;
+					break
 				case "off":
 					device.off()
-					break;
+					break
 				default:
 					httpError(403, "Access denied. This command is not supported by current capability.")
 			}

--- a/smartapps/curb/curb-control.src/curb-control.groovy
+++ b/smartapps/curb/curb-control.src/curb-control.groovy
@@ -65,7 +65,16 @@ void updateSwitch() {
 private void updateAll(devices) {
 	def command = request.JSON?.command
 	if (command) {
-		devices."$command"()
+		switch(command) {
+			case "on":
+				devices.on()
+				break;
+			case "off":
+				devices.off()
+				break;
+			default:
+				httpError(403, "Access denied. This command is not supported by current capability.")
+		}
 	}
 }
 
@@ -77,7 +86,16 @@ private void update(devices) {
 		if (!device) {
 			httpError(404, "Device not found")
 		} else {
-			device."$command"()
+			switch(command) {
+				case "on":
+					device.on()
+					break;
+				case "off":
+					device.off()
+					break;
+				default:
+					httpError(403, "Access denied. This command is not supported by current capability.")
+			}
 		}
 	}
 }

--- a/smartapps/dianoga/netatmo-connect.src/netatmo-connect.groovy
+++ b/smartapps/dianoga/netatmo-connect.src/netatmo-connect.groovy
@@ -58,7 +58,6 @@ def authPage() {
 	if (canInstallLabs()) {
 
 		def redirectUrl = getBuildRedirectUrl()
-		log.debug "Redirect url = ${redirectUrl}"
 
 		if (state.authToken) {
 			description = "Tap 'Next' to proceed"
@@ -113,14 +112,10 @@ def oauthInitUrl() {
 		scope: "read_station"
 	]
 
-	log.debug "REDIRECT URL: ${getVendorAuthPath() + toQueryString(oauthParams)}"
-
 	redirect (location: getVendorAuthPath() + toQueryString(oauthParams))
 }
 
 def callback() {
-	log.debug "callback()>> params: $params, params.code ${params.code}"
-
 	def code = params.code
 	def oauthState = params.state
 
@@ -135,16 +130,12 @@ def callback() {
 			scope: "read_station"
 		]
 
-		log.debug "TOKEN URL: ${getVendorTokenPath() + toQueryString(tokenParams)}"
-
 		def tokenUrl = getVendorTokenPath()
 		def params = [
 			uri: tokenUrl,
 			contentType: 'application/x-www-form-urlencoded',
 			body: tokenParams
 		]
-
-		log.debug "PARAMS: ${params}"
 
 		httpPost(params) { resp ->
 
@@ -156,7 +147,6 @@ def callback() {
 				state.refreshToken = data.refresh_token
 				state.authToken = data.access_token
 				state.tokenExpires = now() + (data.expires_in * 1000)
-				log.debug "swapped token: $resp.data"
 			}
 		}
 
@@ -292,7 +282,6 @@ def refreshToken() {
 
 			response.data.each {key, value ->
 				def data = slurper.parseText(key);
-				log.debug "Data: $data"
 
 				state.refreshToken = data.refresh_token
 				state.accessToken = data.access_token

--- a/smartapps/dianoga/netatmo-connect.src/netatmo-connect.groovy
+++ b/smartapps/dianoga/netatmo-connect.src/netatmo-connect.groovy
@@ -58,6 +58,7 @@ def authPage() {
 	if (canInstallLabs()) {
 
 		def redirectUrl = getBuildRedirectUrl()
+		// log.debug "Redirect url = ${redirectUrl}"
 
 		if (state.authToken) {
 			description = "Tap 'Next' to proceed"
@@ -112,10 +113,14 @@ def oauthInitUrl() {
 		scope: "read_station"
 	]
 
+	// log.debug "REDIRECT URL: ${getVendorAuthPath() + toQueryString(oauthParams)}"
+
 	redirect (location: getVendorAuthPath() + toQueryString(oauthParams))
 }
 
 def callback() {
+	// log.debug "callback()>> params: $params, params.code ${params.code}"
+
 	def code = params.code
 	def oauthState = params.state
 
@@ -130,12 +135,16 @@ def callback() {
 			scope: "read_station"
 		]
 
+		// log.debug "TOKEN URL: ${getVendorTokenPath() + toQueryString(tokenParams)}"
+
 		def tokenUrl = getVendorTokenPath()
 		def params = [
 			uri: tokenUrl,
 			contentType: 'application/x-www-form-urlencoded',
 			body: tokenParams
 		]
+
+		// log.debug "PARAMS: ${params}"
 
 		httpPost(params) { resp ->
 
@@ -147,6 +156,7 @@ def callback() {
 				state.refreshToken = data.refresh_token
 				state.authToken = data.access_token
 				state.tokenExpires = now() + (data.expires_in * 1000)
+				// log.debug "swapped token: $resp.data"
 			}
 		}
 
@@ -282,6 +292,7 @@ def refreshToken() {
 
 			response.data.each {key, value ->
 				def data = slurper.parseText(key);
+				// log.debug "Data: $data"
 
 				state.refreshToken = data.refresh_token
 				state.accessToken = data.access_token

--- a/smartapps/gideon-api/gideon.src/gideon.groovy
+++ b/smartapps/gideon-api/gideon.src/gideon.groovy
@@ -1,0 +1,253 @@
+/**
+ *  Gideon
+ *
+ *  Copyright 2016 Nicola Russo
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ *  for the specific language governing permissions and limitations under the License.
+ *
+ */
+definition(
+    name: "Gideon",
+    namespace: "gideon.api",
+    author: "Braindrain Solutions",
+    description: "Gideon AI Smart app allows you to connect and control all of your SmartThings devices through the Gideon AI app, making your SmartThings devices even smarter.",
+    category: "Family",
+    iconUrl: "http://s33.postimg.org/t77u7y7v3/logo.png",
+    iconX2Url: "http://s33.postimg.org/t77u7y7v3/logo.png",
+    iconX3Url: "http://s33.postimg.org/t77u7y7v3/logo.png",
+    oauth: [displayName: "Gideon AI API", displayLink: "gideon.ai"])
+
+
+preferences {
+	section("Control these switches...") {
+        input "switches", "capability.switch", multiple:true
+    }
+    section("Control these motion sensors...") {
+        input "motions", "capability.motionSensor", multiple:true
+    }
+    section("Control these presence sensors...") {
+    	input "presence_sensors", "capability.presenceSensor", multiple:true
+    }
+    section("Control these outlets...") {
+    	input "outlets", "capability.switch", multiple:true
+    }
+    section("Control these locks...") {
+    	input "locks", "capability.lock", multiple:true
+    }
+    section("Control these locks...") {
+	    input "temperature_sensors", "capability.temperatureMeasurement"
+    }
+}
+
+def installed() {
+	log.debug "Installed with settings: ${settings}"
+
+	initialize()
+}
+
+def updated() {
+	log.debug "Updated with settings: ${settings}"
+
+	unsubscribe()
+	initialize()
+}
+
+def initialize() {
+	// TODO: subscribe to attributes, devices, locations, etc.
+    subscribe(outlet, "energy", outletHandler)
+  	subscribe(outlet, "switch", outletHandler)
+}
+
+// TODO: implement event handlers
+def outletHandler(evt) {
+	log.debug "$outlet.currentEnergy"
+	//TODO call G API  
+}
+
+
+private device(it, type) {
+	it ? [id: it.id, label: it.label, type: type] : null
+}
+
+//API Mapping
+mappings {
+	path("/getalldevices") {
+    action: [
+      			GET: "getAllDevices"
+    		]
+  	}
+	path("/doorlocks/:id/:command") {
+    action: [
+      GET: "updateDoorLock"
+    ]
+  }
+  	path("/doorlocks/:id") {
+    action: [
+      			GET: "getDoorLockStatus"
+    		]
+  	}
+  	path("/tempsensors/:id") {
+    action: [
+      GET: "getTempSensorsStatus"
+    ]
+  }
+  	path("/presences/:id") {
+    action: [
+      GET: "getPresenceStatus"
+    ]
+  }
+  	path("/motions/:id") {
+    action: [
+      GET: "getMotionStatus"
+    ]
+  }
+  	path("/outlets/:id") {
+    action: [
+      GET: "getOutletStatus"
+    ]
+  }
+  	path("/outlets/:id/:command") {
+    action: [
+      GET: "updateOutlet"
+    ]
+  }
+  	path("/switches/:command") {
+    action: [
+      PUT: "updateSwitch"
+    ]
+  }
+}
+
+//API Methods
+def getAllDevices() {
+	def locks_list = locks.collect{device(it,"Lock")}
+    def presences_list = presence_sensors.collect{device(it,"Presence")}
+    def motions_list = motions.collect{device(it,"Motion")}
+    def outlets_list = outlets.collect{device(it,"Outlet")}
+    def switches_list = switches.collect{device(it,"Switch")}
+    def temp_list = temperature_sensors.collect{device(it,"Temperature")}
+    return [Locks: locks_list, Presences: presences_list, Motions: motions_list, Outlets: outlets_list, Switches: switches_list, Temperatures: temp_list]
+}
+
+//LOCKS
+def getDoorLockStatus() {
+	def device = locks.find { it.id == params.id }
+    if (!device) {
+            httpError(404, "Device not found")
+        } else {
+        	return [Device_state: device.currentValue('lock')]
+        }
+}
+
+def updateDoorLock() {
+	def command = params.command
+    def device = locks.find { it.id == params.id }
+    if (command){
+        if (!device) {
+            httpError(404, "Device not found")
+        } else {
+            if(command == "toggle")
+            {
+                if(device.currentValue('lock') == "locked")
+                  device.unlock();
+                else
+                  device.lock();
+                  
+                return [Device_id: params.id, result_action: "200"]
+            }
+        }
+    }
+}
+
+//PRESENCE
+def getPresenceStatus() {
+
+	def device = presence_sensors.find { it.id == params.id }
+    if (!device) {
+            httpError(404, "Device not found")
+        } else {
+        	return [Device_state: device.currentValue('presence')]
+   }
+}
+
+//MOTION
+def getMotionStatus() {
+
+	def device = motions.find { it.id == params.id }
+    if (!device) {
+            httpError(404, "Device not found")
+        } else {
+        	return [Device_state: device.currentValue('motion')]
+   }
+}
+
+//OUTLET
+def getOutletStatus() {
+	
+    def device = outlets.find { it.id == params.id }
+   	if (!device) {
+            httpError(404, "Device not found")
+        } else {
+        	return [Device_state: device.currentSwitch, Current_watt: device.currentValue("energy")]
+  }
+}
+
+def updateOutlet() {
+	
+    def command = params.command
+    def device = outlets.find { it.id == params.id }
+    if (command){
+        if (!device) {
+            httpError(404, "Device not found")
+        } else {
+            if(command == "toggle")
+            {
+                if(device.currentSwitch == "on")
+                  device.off();
+                else
+                  device.on();
+                  
+                return [Device_id: params.id, result_action: "200"]
+            }
+        }
+    }
+}                
+
+//SWITCH
+def updateSwitch() {
+    def command = params.command
+    def device = switches.find { it.id == params.id }
+    if (command){
+        if (!device) {
+            httpError(404, "Device not found")
+        } else {
+            if(command == "toggle")
+            {
+                if(device.currentSwitch == "on")
+                  device.off();
+                else
+                  device.on();
+                  
+                return [Device_id: params.id, result_action: "200"]
+            }
+        }
+    }
+}
+
+//TEMPERATURE
+def getTempSensorsStatus() {
+	
+    def device = temperature_sensors.find { it.id == params.id }
+    if (!device) {
+            httpError(404, "Device not found")
+        } else {
+        	return [Device_state: device.currentValue('temperature')]
+   }
+}

--- a/smartapps/imbrianj/ready-for-rain.src/ready-for-rain.groovy
+++ b/smartapps/imbrianj/ready-for-rain.src/ready-for-rain.groovy
@@ -18,8 +18,13 @@ definition(
 )
 
 preferences {
-  section("Zip code?") {
-    input "zipcode", "text", title: "Zipcode?"
+
+  if (!(location.zipCode || ( location.latitude && location.longitude )) && location.channelName == 'samsungtv') {
+		section { paragraph title: "Note:", "Location is required for this SmartApp. Go to 'Location Name' settings to setup your correct location." }
+	}
+
+  if (location.channelName != 'samsungtv') {
+		section( "Set your location" ) { input "zipCode", "text", title: "Zip code" }
   }
 
   section("Things to check?") {
@@ -60,7 +65,11 @@ def scheduleCheck(evt) {
   // Only need to poll if we haven't checked in a while - and if something is left open.
   if((now() - (30 * 60 * 1000) > state.lastCheck["time"]) && open) {
     log.info("Something's open - let's check the weather.")
-    def response = getWeatherFeature("forecast", zipcode)
+    def response
+    if (location.channelName != 'samsungtv')
+      response = getWeatherFeature("forecast", zipCode)
+    else
+      response = getWeatherFeature("forecast")
     def weather  = isStormy(response)
 
     if(weather) {

--- a/smartapps/imbrianj/safe-watch.src/safe-watch.groovy
+++ b/smartapps/imbrianj/safe-watch.src/safe-watch.groovy
@@ -26,9 +26,9 @@ preferences {
   }
 
   section("Temperature monitor?") {
-    input "temp",    "capability.temperatureMeasurement", title: "Temp Sensor", required: false
-    input "maxTemp", "number",                            title: "Max Temp?",   required: false
-    input "minTemp", "number",                            title: "Min Temp?",   required: false
+    input "temp",    "capability.temperatureMeasurement", title: "Temperature Sensor", required: false
+    input "maxTemp", "number",                            title: "Max Temperature (°${location.temperatureScale})",   required: false
+    input "minTemp", "number",                            title: "Min Temperature (°${location.temperatureScale})",   required: false
   }
 
   section("When which people are away?") {

--- a/smartapps/juano2310/jawbone-up-connect.src/jawbone-up-connect.groovy
+++ b/smartapps/juano2310/jawbone-up-connect.src/jawbone-up-connect.groovy
@@ -28,7 +28,7 @@ mappings {
 	path("/receivedToken") { action: [ POST: "receivedToken", GET: "receivedToken"] }
 	path("/receiveToken") { action: [ POST: "receiveToken", GET: "receiveToken"] }
 	path("/hookCallback") { action: [ POST: "hookEventHandler", GET: "hookEventHandler"] }
-    path("/oauth/initialize") {action: [GET: "oauthInitUrl"]}    
+  path("/oauth/initialize") {action: [GET: "oauthInitUrl"]}
 	path("/oauth/callback") { action: [ GET: "callback" ] }
 }
 
@@ -44,7 +44,7 @@ def callback() {
 	} else {
 		log.warn "No authQueryString"
 	}
-	
+
 	if (state.JawboneAccessToken) {
 		log.debug "Access token already exists"
 		setup()
@@ -73,7 +73,7 @@ def callback() {
 
 def authPage() {
     log.debug "authPage"
-    def description = null          
+    def description = null
     if (state.JawboneAccessToken == null) {
 		if (!state.accessToken) {
 			log.debug "About to create access token"
@@ -82,12 +82,13 @@ def authPage() {
         description = "Click to enter Jawbone Credentials"
         def redirectUrl = buildRedirectUrl
         log.debug "RedirectURL = ${redirectUrl}"
-        def donebutton= state.JawboneAccessToken != null 
+        def donebutton= state.JawboneAccessToken != null
         return dynamicPage(name: "Credentials", title: "Jawbone UP", nextPage: null, uninstall: true, install: donebutton) {
+							 section { paragraph title: "Note:", "This device has not been officially tested and certified to “Work with SmartThings”. You can connect it to your SmartThings home but performance may vary and we will not be able to provide support or assistance." }
                section { href url:redirectUrl, style:"embedded", required:true, title:"Jawbone UP", state: hast ,description:description }
         }
     } else {
-        description = "Jawbone Credentials Already Entered." 
+        description = "Jawbone Credentials Already Entered."
         return dynamicPage(name: "Credentials", title: "Jawbone UP", uninstall: true, install:true) {
                section { href url: buildRedirectUrl("receivedToken"), style:"embedded", state: "complete", title:"Jawbone UP", description:description }
         }
@@ -107,7 +108,7 @@ def receiveToken(redirectUrl = null) {
     def params = [
       uri: "https://jawbone.com/auth/oauth2/token?${toQueryString(oauthParams)}",
     ]
-    httpGet(params) { response -> 
+    httpGet(params) { response ->
     	log.debug "${response.data}"
 		log.debug "Setting access token to ${response.data.access_token}, refresh token to ${response.data.refresh_token}"
     	state.JawboneAccessToken = response.data.access_token
@@ -149,7 +150,7 @@ def connectionStatus(message, redirectUrl = null) {
 			<meta http-equiv="refresh" content="3; url=${redirectUrl}" />
 		"""
 	}
-	
+
     def html = """
         <!DOCTYPE html>
         <html>
@@ -229,12 +230,12 @@ def validateCurrentToken() {
 	log.debug "validateCurrentToken"
     def url = "https://jawbone.com/nudge/api/v.1.1/users/@me/refreshToken"
     def requestBody = "secret=${appSettings.clientSecret}"
-	
+
 	try {
 		httpPost(uri: url, headers: ["Authorization": "Bearer ${state.JawboneAccessToken}" ],  body: requestBody) {response ->
 	    	if (response.status == 200) {
 				log.debug "${response.data}"
-				log.debug "Setting refresh token to ${response.data.data.refresh_token}"
+				log.debug "Setting refresh token"
 	     		state.refreshToken = response.data.data.refresh_token
 	        }
 	    }
@@ -258,7 +259,7 @@ def validateCurrentToken() {
 							state.remove("refreshToken")
 						}
 					} else {
-						log.debug "Setting access token to ${data.access_token}, refresh token to ${data.refresh_token}"
+						log.debug "Setting access token"
 						state.JawboneAccessToken = data.access_token
 						state.refreshToken = data.refresh_token
 					}
@@ -271,10 +272,10 @@ def validateCurrentToken() {
 }
 
 def initialize() {
-    log.debug "Callback URL - Webhook"  
-	def localServerUrl = getApiServerUrl() 
+    log.debug "Callback URL - Webhook"
+	def localServerUrl = getApiServerUrl()
 	def hookUrl = "${localServerUrl}/api/token/${state.accessToken}/smartapps/installations/${app.id}/hookCallback"
-    def webhook = "https://jawbone.com/nudge/api/v.1.1/users/@me/pubsub?webhook=$hookUrl"      
+    def webhook = "https://jawbone.com/nudge/api/v.1.1/users/@me/pubsub?webhook=$hookUrl"
 	httpPost(uri: webhook, headers: ["Authorization": "Bearer ${state.JawboneAccessToken}" ])
 }
 
@@ -284,16 +285,16 @@ def setup() {
 
 	if (state.JawboneAccessToken) {
 		def urlmember = "https://jawbone.com/nudge/api/users/@me/"
-		def member = null    
-		httpGet(uri: urlmember, headers: ["Authorization": "Bearer ${state.JawboneAccessToken}" ]) {response -> 
+		def member = null
+		httpGet(uri: urlmember, headers: ["Authorization": "Bearer ${state.JawboneAccessToken}" ]) {response ->
 		    member = response.data.data
 		}
-	
+
 		if (member) {
 			state.member = member
 			def externalId = "${app.id}.${member.xid}"
 
-			// find the appropriate child device based on my app id and the device network id 
+			// find the appropriate child device based on my app id and the device network id
 			def deviceWrapper = getChildDevice("${externalId}")
 
 			// invoke the generatePresenceEvent method on the child device
@@ -312,7 +313,7 @@ def setup() {
 }
 
 def installed() {
-	
+
 	if (!state.accessToken) {
 		log.debug "About to create access token"
 		createAccessToken()
@@ -324,7 +325,7 @@ def installed() {
 }
 
 def updated() {
-	
+
 	if (!state.accessToken) {
 		log.debug "About to create access token"
 		createAccessToken()
@@ -348,29 +349,29 @@ def uninstalled() {
 }
 
 def pollChild(childDevice) {
-    def member = state.member 
-    generatePollingEvents (member, childDevice)   
+    def member = state.member
+    generatePollingEvents (member, childDevice)
 }
 
 def generatePollingEvents (member, childDevice) {
     // lets figure out if the member is currently "home" (At the place)
-    def urlgoals = "https://jawbone.com/nudge/api/users/@me/goals" 
-    def urlmoves = "https://jawbone.com/nudge/api/users/@me/moves"  
-    def urlsleeps = "https://jawbone.com/nudge/api/users/@me/sleeps"     
+    def urlgoals = "https://jawbone.com/nudge/api/users/@me/goals"
+    def urlmoves = "https://jawbone.com/nudge/api/users/@me/moves"
+    def urlsleeps = "https://jawbone.com/nudge/api/users/@me/sleeps"
     def goals = null
     def moves = null
- 	def sleeps = null   
-    httpGet(uri: urlgoals, headers: ["Authorization": "Bearer ${state.JawboneAccessToken}" ]) {response -> 
+ 	def sleeps = null
+    httpGet(uri: urlgoals, headers: ["Authorization": "Bearer ${state.JawboneAccessToken}" ]) {response ->
         goals = response.data.data
-    }   
-    httpGet(uri: urlmoves, headers: ["Authorization": "Bearer ${state.JawboneAccessToken}" ]) {response -> 
+    }
+    httpGet(uri: urlmoves, headers: ["Authorization": "Bearer ${state.JawboneAccessToken}" ]) {response ->
         moves = response.data.data.items[0]
-    }    
-   
+    }
+
     try { // we are going to just ignore any errors
         log.debug "Member = ${member.first}"
         log.debug "Moves Goal = ${goals.move_steps} Steps"
-        log.debug "Moves = ${moves.details.steps} Steps" 
+        log.debug "Moves = ${moves.details.steps} Steps"
 
         childDevice?.sendEvent(name:"steps", value: moves.details.steps)
         childDevice?.sendEvent(name:"goal", value: goals.move_steps)
@@ -378,29 +379,29 @@ def generatePollingEvents (member, childDevice) {
     }
     catch (e) {
             // eat it
-    }       
+    }
 }
 
 def generateInitialEvent (member, childDevice) {
     // lets figure out if the member is currently "home" (At the place)
-    def urlgoals = "https://jawbone.com/nudge/api/users/@me/goals" 
-    def urlmoves = "https://jawbone.com/nudge/api/users/@me/moves"  
-    def urlsleeps = "https://jawbone.com/nudge/api/users/@me/sleeps"     
+    def urlgoals = "https://jawbone.com/nudge/api/users/@me/goals"
+    def urlmoves = "https://jawbone.com/nudge/api/users/@me/moves"
+    def urlsleeps = "https://jawbone.com/nudge/api/users/@me/sleeps"
     def goals = null
     def moves = null
- 	def sleeps = null   
-    httpGet(uri: urlgoals, headers: ["Authorization": "Bearer ${state.JawboneAccessToken}" ]) {response -> 
+ 	def sleeps = null
+    httpGet(uri: urlgoals, headers: ["Authorization": "Bearer ${state.JawboneAccessToken}" ]) {response ->
         goals = response.data.data
-    }   
-    httpGet(uri: urlmoves, headers: ["Authorization": "Bearer ${state.JawboneAccessToken}" ]) {response -> 
+    }
+    httpGet(uri: urlmoves, headers: ["Authorization": "Bearer ${state.JawboneAccessToken}" ]) {response ->
         moves = response.data.data.items[0]
-    }    
-    
+    }
+
     try { // we are going to just ignore any errors
         log.debug "Member = ${member.first}"
         log.debug "Moves Goal = ${goals.move_steps} Steps"
         log.debug "Moves = ${moves.details.steps} Steps"
-        log.debug "Sleeping state = false"   
+        log.debug "Sleeping state = false"
         childDevice?.generateSleepingEvent(false)
         childDevice?.sendEvent(name:"steps", value: moves.details.steps)
         childDevice?.sendEvent(name:"goal", value: goals.move_steps)
@@ -408,27 +409,27 @@ def generateInitialEvent (member, childDevice) {
     }
     catch (e) {
             // eat it
-    }       
+    }
 }
 
 def setColor (steps,goal,childDevice) {
     def result = steps * 100 / goal
-    if (result < 25) 
+    if (result < 25)
     	childDevice?.sendEvent(name:"steps", value: "steps", label: steps)
-    else if ((result >= 25) && (result < 50)) 
+    else if ((result >= 25) && (result < 50))
         childDevice?.sendEvent(name:"steps", value: "steps1", label: steps)
-    else if ((result >= 50) && (result < 75)) 
+    else if ((result >= 50) && (result < 75))
         childDevice?.sendEvent(name:"steps", value: "steps1", label: steps)
-    else if (result >= 75)     
-        childDevice?.sendEvent(name:"steps", value: "stepsgoal", label: steps)   
+    else if (result >= 75)
+        childDevice?.sendEvent(name:"steps", value: "stepsgoal", label: steps)
 }
 
 def hookEventHandler() {
     // log.debug "In hookEventHandler method."
     log.debug "request = ${request}"
-    
-    def json = request.JSON 
-    
+
+    def json = request.JSON
+
     // get some stuff we need
     def userId = json.events.user_xid[0]
     def	json_type = json.events.type[0]
@@ -437,39 +438,39 @@ def hookEventHandler() {
     //log.debug json
     log.debug "Userid = ${userId}"
     log.debug "Notification Type: " + json_type
-    log.debug "Notification Action: " + json_action 
-    
+    log.debug "Notification Action: " + json_action
+
     // find the appropriate child device based on my app id and the device network id
     def externalId = "${app.id}.${userId}"
     def childDevice = getChildDevice("${externalId}")
-            
+
     if (childDevice) {
-    	switch (json_action) {   
-	        case "enter_sleep_mode":      
-            	childDevice?.generateSleepingEvent(true)           
-                break           
-            case "exit_sleep_mode":       
-            	childDevice?.generateSleepingEvent(false) 
-                break 
-            case "creation": 
+    	switch (json_action) {
+	        case "enter_sleep_mode":
+            	childDevice?.generateSleepingEvent(true)
+                break
+            case "exit_sleep_mode":
+            	childDevice?.generateSleepingEvent(false)
+                break
+            case "creation":
                 childDevice?.sendEvent(name:"steps", value: 0)
           		break
             case "updation":
-                def urlgoals = "https://jawbone.com/nudge/api/users/@me/goals"     
-                def urlmoves = "https://jawbone.com/nudge/api/users/@me/moves"       
+                def urlgoals = "https://jawbone.com/nudge/api/users/@me/goals"
+                def urlmoves = "https://jawbone.com/nudge/api/users/@me/moves"
                 def goals = null
-                def moves = null    
-                httpGet(uri: urlgoals, headers: ["Authorization": "Bearer ${state.JawboneAccessToken}" ]) {response -> 
+                def moves = null
+                httpGet(uri: urlgoals, headers: ["Authorization": "Bearer ${state.JawboneAccessToken}" ]) {response ->
  	               goals = response.data.data
-                }       
-                httpGet(uri: urlmoves, headers: ["Authorization": "Bearer ${state.JawboneAccessToken}" ]) {response -> 
+                }
+                httpGet(uri: urlmoves, headers: ["Authorization": "Bearer ${state.JawboneAccessToken}" ]) {response ->
                    moves = response.data.data.items[0]
-                }        
+                }
                 log.debug "Goal = ${goals.move_steps} Steps"
-        		log.debug "Steps = ${moves.details.steps} Steps"
+        				log.debug "Steps = ${moves.details.steps} Steps"
                 childDevice?.sendEvent(name:"steps", value: moves.details.steps)
-                childDevice?.sendEvent(name:"goal", value: goals.move_steps)       
-                //setColor(moves.details.steps,goals.move_steps,childDevice)   
+                childDevice?.sendEvent(name:"goal", value: goals.move_steps)
+                //setColor(moves.details.steps,goals.move_steps,childDevice)
                 break
 			case "deletion":
 				app.delete()

--- a/smartapps/michaelstruck/smart-home-ventilation.src/smart-home-ventilation.groovy
+++ b/smartapps/michaelstruck/smart-home-ventilation.src/smart-home-ventilation.groovy
@@ -14,7 +14,7 @@
  *	for the specific language governing permissions and limitations under the License.
  *
  */
- 
+
 definition(
 	name: "Smart Home Ventilation",
     namespace: "MichaelStruck",
@@ -164,7 +164,7 @@ def installed() {
 def updated() {
     unschedule()
     turnOffSwitch() //Turn off all switches if the schedules are changed while in mid-schedule
-    unsubscribe
+    unsubscribe()
     log.debug "Updated with settings: ${settings}"
     init()
 }
@@ -174,12 +174,12 @@ def init() {
     schedule (midnightTime, midNight)
 	subscribe(location, "mode", locationHandler)
     startProcess()
-}    
+}
 
 // Common methods
 
 def startProcess () {
-    createDayArray() 
+    createDayArray()
 	state.dayCount=state.data.size()
     if (state.dayCount){
 		state.counter = 0
@@ -190,7 +190,7 @@ def startProcess () {
 def startDay() {
 	def start = convertEpoch(state.data[state.counter].start)
 	def stop = convertEpoch(state.data[state.counter].stop)
-      
+
     runOnce(start, turnOnSwitch, [overwrite: true])
     runOnce(stop, incDay, [overwrite: true])
 }
@@ -218,7 +218,7 @@ def locationHandler(evt) {
     }
 	if (!result) {
     	startProcess()
-    }	
+    }
 }
 
 def midNight(){
@@ -238,7 +238,7 @@ def turnOffSwitch() {
     }
     log.debug "Home ventilation switches are off."
 }
-    
+
 def schedDesc(on1, off1, on2, off2, on3, off3, on4, off4, modeList, dayList) {
 	def title = ""
 	def dayListClean = "On "
@@ -252,7 +252,7 @@ def schedDesc(on1, off1, on2, off2, on3, off3, on4, off4, modeList, dayList) {
             	dayListClean = "${dayListClean}, "
             }
         }
-	} 
+	}
     else {
     	dayListClean = "Every day"
     }
@@ -272,7 +272,7 @@ def schedDesc(on1, off1, on2, off2, on3, off3, on4, off4, modeList, dayList) {
             	modeListClean = "${modeListClean} ${modePrefix}"
         	}
         }
-	} 
+	}
     else {
     	modeListClean = "${modeListClean}all modes"
     }
@@ -283,16 +283,16 @@ def schedDesc(on1, off1, on2, off2, on3, off3, on4, off4, modeList, dayList) {
     	title += "\nSchedule 2: ${humanReadableTime(on2)} to ${humanReadableTime(off2)}"
     }
     if (on3 && off3) {
-    	title += "\nSchedule 3: ${humanReadableTime(on3)} to ${humanReadableTime(off3)}" 
+    	title += "\nSchedule 3: ${humanReadableTime(on3)} to ${humanReadableTime(off3)}"
     }
     if (on4 && off4) {
-    	title += "\nSchedule 4: ${humanReadableTime(on4)} to ${humanReadableTime(off4)}" 
+    	title += "\nSchedule 4: ${humanReadableTime(on4)} to ${humanReadableTime(off4)}"
     }
     if (on1 || on2 || on3 || on4) {
     	title += "\n$modeListClean"
-    	title += "\n$dayListClean" 
+    	title += "\n$dayListClean"
     }
-    
+
     if (!on1 && !on2 && !on3 && !on4) {
     	title="Click to configure scenario"
     }
@@ -374,7 +374,7 @@ def createDayArray() {
            timeOk(timeOnD1, timeOffD1)
            timeOk(timeOnD2, timeOffD2)
            timeOk(timeOnD3, timeOffD3)
-           timeOk(timeOnD4, timeOffD4)        
+           timeOk(timeOnD4, timeOffD4)
         }
     }
     state.data.sort{it.start}
@@ -384,7 +384,7 @@ def createDayArray() {
 
 private def textAppName() {
 	def text = "Smart Home Ventilation"
-}	
+}
 
 private def textVersion() {
     def text = "Version 2.1.2 (05/31/2015)"

--- a/smartapps/smartthings/beacon-control.src/beacon-control.groovy
+++ b/smartapps/smartthings/beacon-control.src/beacon-control.groovy
@@ -114,13 +114,16 @@ def beaconHandler(evt) {
 
 	if (allOk) {
 		def data = new groovy.json.JsonSlurper().parseText(evt.data)
-		log.debug "<beacon-control> data: $data - phones: " + phones*.deviceNetworkId
+                // removed logging of device names. can be added back for debugging
+		//log.debug "<beacon-control> data: $data - phones: " + phones*.deviceNetworkId
 
 		def beaconName = getBeaconName(evt)
-		log.debug "<beacon-control> beaconName: $beaconName"
+                // removed logging of device names. can be added back for debugging
+		//log.debug "<beacon-control> beaconName: $beaconName"
 
 		def phoneName = getPhoneName(data)
-		log.debug "<beacon-control> phoneName: $phoneName"
+                // removed logging of device names. can be added back for debugging
+		//log.debug "<beacon-control> phoneName: $phoneName"
 		if (phoneName != null) {
             def action = data.presence == "1" ? "arrived" : "left"
             def msg = "$phoneName has $action ${action == 'arrived' ? 'at ' : ''}the $beaconName"

--- a/smartapps/smartthings/bon-voyage.src/bon-voyage.groovy
+++ b/smartapps/smartthings/bon-voyage.src/bon-voyage.groovy
@@ -49,13 +49,15 @@ preferences {
 
 def installed() {
 	log.debug "Installed with settings: ${settings}"
-	log.debug "Current mode = ${location.mode}, people = ${people.collect{it.label + ': ' + it.currentPresence}}"
+        // commented out log statement because presence sensor label could contain user's name
+	//log.debug "Current mode = ${location.mode}, people = ${people.collect{it.label + ': ' + it.currentPresence}}"
 	subscribe(people, "presence", presence)
 }
 
 def updated() {
 	log.debug "Updated with settings: ${settings}"
-	log.debug "Current mode = ${location.mode}, people = ${people.collect{it.label + ': ' + it.currentPresence}}"
+        // commented out log statement because presence sensor label could contain user's name
+	//log.debug "Current mode = ${location.mode}, people = ${people.collect{it.label + ': ' + it.currentPresence}}"
 	unsubscribe()
 	subscribe(people, "presence", presence)
 }

--- a/smartapps/smartthings/ecobee-connect.src/ecobee-connect.groovy
+++ b/smartapps/smartthings/ecobee-connect.src/ecobee-connect.groovy
@@ -20,6 +20,8 @@
  *      JLH - 02-15-2014 - Fuller use of ecobee API
  *      10-28-2015 DVCSMP-604 - accessory sensor, DVCSMP-1174, DVCSMP-1111 - not respond to routines
  */
+include 'asynchttp_v1'
+
 definition(
 		name: "Ecobee (Connect)",
 		namespace: "smartthings",
@@ -244,9 +246,7 @@ def getEcobeeThermostats() {
 		uri: apiEndpoint,
 		path: "/1/thermostat",
 		headers: ["Content-Type": "text/json", "Authorization": "Bearer ${atomicState.authToken}"],
-        // TODO - the query string below is not consistent with the Ecobee docs:
-        // https://www.ecobee.com/home/developer/api/documentation/v1/operations/get-thermostats.shtml
-		query: [format: 'json', body: toJson(bodyParams)]
+		query: [json: toJson(bodyParams)]
 	]
 
 	def stats = [:]
@@ -265,9 +265,8 @@ def getEcobeeThermostats() {
 	} catch (groovyx.net.http.HttpResponseException e) {
         log.trace "Exception polling children: " + e.response.data.status
         if (e.response.data.status.code == 14) {
-            atomicState.action = "getEcobeeThermostats"
             log.debug "Refreshing your auth_token!"
-            refreshAuthToken()
+            refreshAuthToken([async: false, nextAction: "getEcobeeThermostats"])
         }
     }
 	atomicState.thermostats = stats
@@ -358,16 +357,22 @@ def initialize() {
 	atomicState.timeSendPush = null
 	atomicState.reAttempt = 0
 
-	pollHandler() //first time polling data data from thermostat
+	initialPoll() //first time polling data data from thermostat
 
 	//automatically update devices status every 5 mins
 	runEvery5Minutes("poll")
 
 }
 
-def pollHandler() {
-	log.debug "pollHandler()"
-	pollChildren(null) // Hit the ecobee API for update on all thermostats
+/**
+ * Polls the child devices (synchronously).
+ * This is used during app install/update, and is synchronous
+ * to maintain current behavior that will cause install/update to fail
+ * if polling fails.
+ */
+def initialPoll() {
+	log.debug "initialPoll()"
+	pollChildrenSync() // Hit the ecobee API for update on all thermostats
 
 	atomicState.thermostats.each {stat ->
 		def dni = stat.key
@@ -380,36 +385,38 @@ def pollHandler() {
 	}
 }
 
-def pollChildren(child = null) {
-    def thermostatIdsString = getChildDeviceIdsString()
+/**
+ * Polls Ecobee (asynchronously) for updated device state data.
+ * Called from within this Connect SmartApp as well as the child
+ * devices.
+ */
+def poll() {
+    log.debug "polling asynchronously"
+    asynchttp_v1.get('asyncPollResponseHandler', getPollParams())
+}
+
+/**
+ * Makes a (synchronous) request to the Ecobee API to get the data for the thermostats.
+ * This request is made synchronously here because it is called as part of the
+ * install/updated lifecycle, and changing it to asynchronous during the install/update
+ * lifecycle may change the behavior if there is an error in polling.
+ *
+ * If further analysis shows that polling can be done asynchronously during
+ * install/update without any adverse consequences, this should then be made
+ * asynchronous just as the scheduled polling is.
+ */
+def pollChildrenSync() {
     log.debug "polling children: $thermostatIdsString"
 
-    def requestBody = [
-        selection: [
-            selectionType: "thermostats",
-            selectionMatch: thermostatIdsString,
-            includeExtendedRuntime: true,
-            includeSettings: true,
-            includeRuntime: true,
-            includeSensors: true
-        ]
-    ]
+    def params = getPollParams()
+    params.query << ["Content-Type": "application/json"]
 
 	def result = false
-
-	def pollParams = [
-        uri: apiEndpoint,
-        path: "/1/thermostat",
-        headers: ["Content-Type": "text/json", "Authorization": "Bearer ${atomicState.authToken}"],
-        // TODO - the query string below is not consistent with the Ecobee docs:
-        // https://www.ecobee.com/home/developer/api/documentation/v1/operations/get-thermostats.shtml
-        query: [format: 'json', body: toJson(requestBody)]
-    ]
+    log.debug "making synchronous poll request"
 
 	try{
-		httpGet(pollParams) { resp ->
+		httpGet(params) { resp ->
 			if(resp.status == 200) {
-                log.debug "poll results returned resp.data ${resp.data}"
                 atomicState.remoteSensors = resp.data.thermostatList.remoteSensors
                 updateSensorData()
                 storeThermostatData(resp.data.thermostatList)
@@ -420,40 +427,95 @@ def pollChildren(child = null) {
 	} catch (groovyx.net.http.HttpResponseException e) {
 		log.trace "Exception polling children: " + e.response.data.status
         if (e.response.data.status.code == 14) {
-            atomicState.action = "pollChildren"
             log.debug "Refreshing your auth_token!"
-            refreshAuthToken()
+            refreshAuthToken([async: false, nextAction: "pollChildrenSync"])
         }
 	}
 	return result
 }
 
-// Poll Child is invoked from the Child Device itself as part of the Poll Capability
-def pollChild() {
-	def devices = getChildDevices()
-
-	if (pollChildren()) {
-		devices.each { child ->
-			if (!child.device.deviceNetworkId.startsWith("ecobee_sensor")) {
-				if(atomicState.thermostats[child.device.deviceNetworkId] != null) {
-					def tData = atomicState.thermostats[child.device.deviceNetworkId]
-					log.info "pollChild(child)>> data for ${child.device.deviceNetworkId} : ${tData.data}"
-					child.generateEvent(tData.data) //parse received message from parent
-				} else if(atomicState.thermostats[child.device.deviceNetworkId] == null) {
-					log.error "ERROR: Device connection removed? no data for ${child.device.deviceNetworkId}"
-					return null
-				}
-			}
-		}
-	} else {
-		log.info "ERROR: pollChildren()"
-		return null
-	}
-
+/**
+ * Response handler for asynchronous request to get thermostat data.
+ * Given a successful response, updates the sensor data, stores the thermostat
+ * data, and generates child device events.
+ *
+ * If the access token has expired, will issue a request to refresh the token
+ * (and pending successful token refresh, the poll request will be made again).
+ */
+def asyncPollResponseHandler(response, data) {
+    log.trace "async poll response handler"
+    if (!response.hasError()) {
+        if (response.status == 200) {
+            def json
+            try {
+                json = response.getJson()
+            } catch (e) {
+                log.error ("error parsing JSON", e)
+            }
+            if (json) {
+                atomicState.remoteSensors = json.thermostatList.remoteSensors
+                updateSensorData()
+                storeThermostatData(json.thermostatList)
+                generateChildThermostatEvent()
+            }
+        } else {
+            log.warn "Response returned non-200 response. Status: ${response.status}, data: ${response.getData()}"
+        }
+    } else {
+        log.trace "Exception polling children: ${response.getErrorMessage()}"
+        def errorJson
+        try {
+            errorJson = response.getErrorJson()
+        } catch (e) {
+            log.error("Unable to parse error json response", e)
+        }
+        if (errorJson?.status?.code == 14) {
+            log.debug "Refreshing your auth_token!"
+            refreshAuthToken([async: true, nextAction: "poll"])
+        } else {
+            log.warn "Error polling children that is not due to an expired token. Response: ${response.getErrorData()}"
+        }
+    }
 }
 
-void poll() {
-	pollChild()
+private getPollParams() {
+    def thermostatIdsString = getChildDeviceIdsString()
+    def requestBody = [
+        selection: [
+            selectionType: "thermostats",
+            selectionMatch: thermostatIdsString,
+            includeExtendedRuntime: true,
+            includeSettings: true,
+            includeRuntime: true,
+            includeSensors: true
+        ]
+    ]
+    return [
+        uri: apiEndpoint,
+        path: "/1/thermostat",
+        headers: ["Authorization": "Bearer ${atomicState.authToken}"],
+        query: [json: toJson(requestBody)]
+    ]
+}
+
+/**
+ * Calls each child thermostat device to generate an event with the thermostat
+ * data.
+ */
+def generateChildThermostatEvent() {
+    log.trace("generateChildThermostatEvent")
+    getChildDevices().each { child ->
+        if (!child.device.deviceNetworkId.startsWith("ecobee_sensor")){
+            if(atomicState.thermostats[child.device.deviceNetworkId] != null) {
+                def tData = atomicState.thermostats[child.device.deviceNetworkId]
+                log.debug "calling child.generateEvent($tData.data)"
+                child.generateEvent(tData.data) //parse received message from parent
+            } else if(atomicState.thermostats[child.device.deviceNetworkId] == null) {
+                log.error "ERROR: Device connection removed? no data for ${child.device.deviceNetworkId}"
+                return null
+            }
+        }
+    }
 }
 
 def availableModes(child) {
@@ -553,47 +615,104 @@ def toQueryString(Map m) {
 	return m.collect { k, v -> "${k}=${URLEncoder.encode(v.toString())}" }.sort().join("&")
 }
 
-private refreshAuthToken() {
-	log.debug "refreshing auth token"
+/**
+ * Uses the refresh token to get a new access token, then executes the nextAction.
+ * @param options - a map of options. valid options are async: true/false, which
+ *                  specifies if the refresh token request will be done asynchronously or not (default is false)
+ *                  nextAction: "nameOfMethod" specifies what method to execute after
+ *                  the token is refreshed (not required).
+ * (note: using a map as the parameter because we need to call it from a schedueled
+ * execution and we can only pass a data map to scheduled executions)
+ */
+private void refreshAuthToken(options) {
+    if(!atomicState.refreshToken) {
+		log.warn "Cannot not refresh OAuth token since there is no refreshToken stored"
+    } else {
+        def refreshParams = [
+            uri   : apiEndpoint,
+            path  : "/token",
+            query : [grant_type: 'refresh_token', code: "${atomicState.refreshToken}", client_id: smartThingsClientId],
+        ]
+        if (options.async) {
+            refreshAuthTokenAsync(refreshParams, options.nextAction)
+        } else {
+            refreshAuthTokenSync(refreshParams, options.nextAction)
+        }
+    }
+}
 
-	if(!atomicState.refreshToken) {
-		log.warn "Can not refresh OAuth token since there is no refreshToken stored"
-	} else {
-		def refreshParams = [
-			method: 'POST',
-			uri   : apiEndpoint,
-			path  : "/token",
-			query : [grant_type: 'refresh_token', code: "${atomicState.refreshToken}", client_id: smartThingsClientId],
-		]
-
-		def notificationMessage = "is disconnected from SmartThings, because the access credential changed or was lost. Please go to the Ecobee (Connect) SmartApp and re-enter your account login credentials."
-		//changed to httpPost
-		try {
-			def jsonMap
-			httpPost(refreshParams) { resp ->
-				if(resp.status == 200) {
-					log.debug "Token refreshed...calling saved RestAction now!"
-					debugEvent("Token refreshed ... calling saved RestAction now!")
-					saveTokenAndResumeAction(resp.data)
-			    }
+private void refreshAuthTokenSync(params, nextAction = null) {
+    try {
+        httpPost(refreshParams) { resp ->
+            if(resp.status == 200) {
+                log.debug "Token refreshed...calling saved RestAction now!"
+                debugEvent("Token refreshed ... calling saved RestAction now!")
+                saveTokenAndResumeAction(resp.data, nextAction)
             }
-		} catch (groovyx.net.http.HttpResponseException e) {
-			log.error "refreshAuthToken() >> Error: e.statusCode ${e.statusCode}"
-			def reAttemptPeriod = 300 // in sec
-			if (e.statusCode != 401) { // this issue might comes from exceed 20sec app execution, connectivity issue etc.
-				runIn(reAttemptPeriod, "refreshAuthToken")
-			} else if (e.statusCode == 401) { // unauthorized
-				atomicState.reAttempt = atomicState.reAttempt + 1
-				log.warn "reAttempt refreshAuthToken to try = ${atomicState.reAttempt}"
-				if (atomicState.reAttempt <= 3) {
-					runIn(reAttemptPeriod, "refreshAuthToken")
-				} else {
-					sendPushAndFeeds(notificationMessage)
-					atomicState.reAttempt = 0
-				}
-			}
-		}
-	}
+        }
+    } catch (groovyx.net.http.HttpResponseException e) {
+        log.error "refreshAuthToken() >> Error: e.statusCode ${e.statusCode}"
+        reauthTokenErrorHandler(e.statusCode)
+    }
+}
+
+private void refreshAuthTokenAsync(refreshParams, nextAction = null) {
+    log.debug "making asynchronous refresh request"
+    asynchttp_v1.post('refreshTokenResponseHandler', refreshParams, [nextAction: nextAction])
+}
+
+/**
+ * The response handler for the request to refresh the authorization handler.
+ * Stores the new authorization token and refresh token, and executes any action
+ * (method) that failed due to the authorization token expiring.
+ */
+private void refreshTokenResponseHandler(response, data) {
+    if (!response.hasError()) {
+        if (response.status == 200) {
+            def json
+            try {
+            	json = response.getJson()
+            } catch (e) {
+            	log.error "error parsing json from response data: $response.data"
+            }
+            if (json) {
+                log.debug "asnyc refreshTokenHandler: Token refreshed...calling saved RestAction now!"
+                debugEvent("async Token refreshed ... calling saved RestAction now!")
+             	saveTokenAndResumeAction(json, data.nextAction)
+            } else {
+            	log.warn "successfully parsed json but result is empty or null"
+            }
+        } else {
+            log.debug "Non 200 response returned. Response code: ${response.code}, data: ${response.getData()}"
+        }
+    } else {
+        log.debug "async refreshTokenHandler: RESPONSE ERROR: ${response.getErrorJson()}"
+        reauthTokenErrorHandler(response.getErrorJson().code)
+    }
+}
+
+/**
+ * Retries refreshing the authorization token. Will attempt to get the refresh
+ * token later, in case there were errors retrieving it.
+ * Will retry a fixed number of times before sending a push notification to the
+ * user instructing them to reauthenticate
+ */
+private void reauthTokenErrorHandler(responseCode) {
+    def retryInterval = 300 // in seconds
+    def notificationMessage = "is disconnected from SmartThings, because the access credential changed or was lost. Please go to the Ecobee (Connect) SmartApp and re-enter your account login credentials."
+    // might get non-401 error from exceeding 20 second app limit, connectivity issues, etc.
+    if (responseCode != 401) {
+        runIn(retryInterval, "refreshAuthToken", [async: true])
+    } else if (responseCode == 401) { // unauthorized
+        atomicState.reAttempt = atomicState.reAttempt + 1
+        log.warn "reAttempt refreshAuthToken to try = ${atomicState.reAttempt}"
+        if (atomicState.reAttempt <= 3) {
+            runIn(retryInterval, "refreshAuthToken", [async: true])
+        } else {
+            sendPushAndFeeds(notificationMessage)
+            atomicState.reAttempt = 0
+        }
+    }
 }
 
 /**
@@ -603,20 +722,20 @@ private refreshAuthToken() {
  *
  * @param json - an object representing the parsed JSON response from Ecobee
  */
-private void saveTokenAndResumeAction(json) {
-    log.debug "token response json: $json"
+private void saveTokenAndResumeAction(json, String nextAction) {
+    def debugMessage = "token response, scope: ${json?.scope}, expires_in: ${json?.expires_in}, token_type: ${json?.token_type}"
+    log.debug "debugMessage"
     if (json) {
-        debugEvent("Response = $json")
+        debugEvent(debugMessage)
         atomicState.refreshToken = json?.refresh_token
         atomicState.authToken = json?.access_token
-        if (atomicState.action) {
-            log.debug "got refresh token, executing next action: ${atomicState.action}"
-            "${atomicState.action}"()
+        if (nextAction) {
+            log.debug "got refresh token, will execute next action (passed in!): $nextAction"
+            "$nextAction"()
         }
     } else {
         log.warn "did not get response body from refresh token response"
     }
-    atomicState.action = ""
 }
 
 /**
@@ -756,7 +875,6 @@ private boolean sendCommandToEcobee(Map bodyParams) {
 	try{
         httpPost(cmdParams) { resp ->
             if(resp.status == 200) {
-                log.debug "updated ${resp.data}"
                 def returnStatus = resp.data.status.code
                 if (returnStatus == 0) {
                     log.debug "Successful call to ecobee API."
@@ -771,11 +889,10 @@ private boolean sendCommandToEcobee(Map bodyParams) {
         log.trace "Exception Sending Json: " + e.response.data.status
         debugEvent ("sent Json & got http status ${e.statusCode} - ${e.response.data.status.code}")
         if (e.response.data.status.code == 14) {
-            // TODO - figure out why we're setting the next action to be pollChildren
+            // TODO - figure out why we're setting the next action to be poll
             // after refreshing auth token. Is it to keep UI in sync, or just copy/paste error?
-            atomicState.action = "pollChildren"
             log.debug "Refreshing your auth_token!"
-            refreshAuthToken()
+            refreshAuthToken([async: true, nextAction: "poll"])
         } else {
             debugEvent("Authentication error, invalid authentication method, lack of credentials, etc.")
             log.error "Authentication error, invalid authentication method, lack of credentials, etc."

--- a/smartapps/smartthings/energy-alerts.src/energy-alerts.groovy
+++ b/smartapps/smartthings/energy-alerts.src/energy-alerts.groovy
@@ -64,7 +64,7 @@ def meterHandler(evt) {
     def lastValue = atomicState.lastValue as double
     atomicState.lastValue = meterValue
 
-    def dUnit ? evt.unit : "Watts"
+    def dUnit = evt.unit ?: "Watts"
 
     def aboveThresholdValue = aboveThreshold as int
     if (meterValue > aboveThresholdValue) {

--- a/smartapps/smartthings/flood-alert.src/flood-alert.groovy
+++ b/smartapps/smartthings/flood-alert.src/flood-alert.groovy
@@ -54,10 +54,10 @@ def waterWetHandler(evt) {
 	def alreadySentSms = recentEvents.count { it.value && it.value == "wet" } > 1
 
 	if (alreadySentSms) {
-		log.debug "SMS already sent to $phone within the last $deltaSeconds seconds"
+		log.debug "SMS already sent within the last $deltaSeconds seconds"
 	} else {
 		def msg = "${alarm.displayName} is wet!"
-		log.debug "$alarm is wet, texting $phone"
+		log.debug "$alarm is wet, texting phone number"
 
 		if (location.contactBookEnabled) {
 			sendNotificationToContacts(msg, recipients)

--- a/smartapps/smartthings/garage-door-monitor.src/garage-door-monitor.groovy
+++ b/smartapps/smartthings/garage-door-monitor.src/garage-door-monitor.groovy
@@ -90,7 +90,7 @@ def takeAction(){
 }
 
 def sendTextMessage() {
-	log.debug "$multisensor was open too long, texting $phone"
+	log.debug "$multisensor was open too long, texting phone"
 
 	updateSmsHistory()
 	def openMinutes = maxOpenTime * (state.smsHistory?.size() ?: 1)

--- a/smartapps/smartthings/greetings-earthling.src/greetings-earthling.groovy
+++ b/smartapps/smartthings/greetings-earthling.src/greetings-earthling.groovy
@@ -47,13 +47,13 @@ preferences {
 
 def installed() {
 	log.debug "Installed with settings: ${settings}"
-	log.debug "Current mode = ${location.mode}, people = ${people.collect{it.label + ': ' + it.currentPresence}}"
+	// log.debug "Current mode = ${location.mode}, people = ${people.collect{it.label + ': ' + it.currentPresence}}"
 	subscribe(people, "presence", presence)
 }
 
 def updated() {
 	log.debug "Updated with settings: ${settings}"
-	log.debug "Current mode = ${location.mode}, people = ${people.collect{it.label + ': ' + it.currentPresence}}"
+	// log.debug "Current mode = ${location.mode}, people = ${people.collect{it.label + ': ' + it.currentPresence}}"
 	unsubscribe()
 	subscribe(people, "presence", presence)
 }
@@ -71,11 +71,10 @@ def presence(evt)
 			def person = getPerson(evt)
 			def recentNotPresent = person.statesSince("presence", t0).find{it.value == "not present"}
 			if (recentNotPresent) {
-				log.debug "skipping notification of arrival of ${person.displayName} because last departure was only ${now() - recentNotPresent.date.time} msec ago"
+				log.debug "skipping notification of arrival of Person because last departure was only ${now() - recentNotPresent.date.time} msec ago"
 			}
 			else {
 				def message = "${person.displayName} arrived at home, changing mode to '${newMode}'"
-				log.info message
 				send(message)
 				setLocationMode(newMode)
 			}
@@ -106,6 +105,4 @@ private send(msg) {
             sendSms(phone, msg)
         }
     }
-
-	log.debug msg
 }

--- a/smartapps/smartthings/habit-helper.src/habit-helper.groovy
+++ b/smartapps/smartthings/habit-helper.src/habit-helper.groovy
@@ -57,12 +57,11 @@ def scheduleCheck()
 	def message = message1 ?: "SmartThings - Habit Helper Reminder!"
 
     if (location.contactBookEnabled) {
-        log.debug "Texting reminder: ($message) to contacts:${recipients?.size()}"
+        log.debug "Texting reminder to contacts:${recipients?.size()}"
         sendNotificationToContacts(message, recipients)
     }
     else {
-
-        log.debug "Texting reminder: ($message) to $phone1"
+        log.debug "Texting reminder"
         sendSms(phone1, message)
     }
 }

--- a/smartapps/smartthings/hue-connect.src/hue-connect.groovy
+++ b/smartapps/smartthings/hue-connect.src/hue-connect.groovy
@@ -724,13 +724,13 @@ private void updateBridgeStatus(childDevice) {
 }
 
 /**
- * Check if all Hue bridges have been heard from in the last 16 minutes, if not an Offline event will be sent
- * for the bridge. Also, set ID number on bridge if not done previously.
+ * Check if all Hue bridges have been heard from in the last 11 minutes, if not an Offline event will be sent
+ * for the bridge and all connected lights. Also, set ID number on bridge if not done previously.
  */
 private void checkBridgeStatus() {
     def bridges = getHueBridges()
-    // Check if each bridge has been heard from within the last 16 minutes (3 poll intervals times 5 minutes plus buffer)
-    def time = now() - (1000 * 60 * 30)
+    // Check if each bridge has been heard from within the last 11 minutes (2 poll intervals times 5 minutes plus buffer)
+    def time = now() - (1000 * 60 * 11)
     bridges.each {
         def d = getChildDevice(it.value.mac)
 	    if(d) {
@@ -748,7 +748,7 @@ private void checkBridgeStatus() {
 					it.value.online = false
 				}
 				getChildDevices().each {
-					it.sendEvent(name: "DeviceWatch-DeviceOffline", value: "offline")
+					it.sendEvent(name: "DeviceWatch-DeviceOffline", value: "offline", isStateChange: true, displayed: false)
 				}
 			} else {
 				d.sendEvent(name: "status", value: "Online")//setOnline(false)
@@ -960,7 +960,7 @@ private handlePoll(body) {
 			} else {
 				state.bulbs[bulb.key]?.online = false
 				log.warn "$device is not reachable by Hue bridge"
-				device.sendEvent(name: "DeviceWatch-DeviceOffline", value: "offline")
+				device.sendEvent(name: "DeviceWatch-DeviceOffline", value: "offline", displayed: false, isStateChange: true)
 			}
 		}
 	}

--- a/smartapps/smartthings/hue-connect.src/hue-connect.groovy
+++ b/smartapps/smartthings/hue-connect.src/hue-connect.groovy
@@ -1182,9 +1182,8 @@ private poll() {
 	def host = getBridgeIP()
 	def uri = "/api/${state.username}/lights/"
 	log.debug "GET: $host$uri"
-	sendHubCommand(new physicalgraph.device.HubAction("""GET ${uri} HTTP/1.1
-HOST: ${host}
-""", physicalgraph.device.Protocol.LAN, selectedHue))
+	sendHubCommand(new physicalgraph.device.HubAction("GET ${uri} HTTP/1.1\r\n" +
+		"HOST: ${host}\r\n\r\n", physicalgraph.device.Protocol.LAN, selectedHue))
 }
 
 private isOnline(id) {
@@ -1200,13 +1199,11 @@ private put(path, body) {
 	log.debug "PUT:  $host$uri"
 	log.debug "BODY: ${bodyJSON}"
 
-	sendHubCommand(new physicalgraph.device.HubAction("""PUT $uri HTTP/1.1
-HOST: ${host}
-Content-Length: ${length}
-
-${bodyJSON}
-""", physicalgraph.device.Protocol.LAN, "${selectedHue}"))
-
+	sendHubCommand(new physicalgraph.device.HubAction("PUT $uri HTTP/1.1\r\n" +
+		"HOST: ${host}\r\n" +
+		"Content-Length: ${length}\r\n" +
+		"\r\n" +
+		"${bodyJSON}", physicalgraph.device.Protocol.LAN, "${selectedHue}"))
 }
 
 /*

--- a/smartapps/smartthings/hue-connect.src/hue-connect.groovy
+++ b/smartapps/smartthings/hue-connect.src/hue-connect.groovy
@@ -740,16 +740,21 @@ private void checkBridgeStatus() {
 				d.sendEvent(name: "idNumber", value: it.value.idNumber)
 		    }
 
-	        if (it.value.lastActivity < time) { // it.value.lastActivity != null &&
-	            log.warn "Bridge $it.key is Offline"
-	            d.sendEvent(name: "status", value: "Offline")
-                // set all lights to offline since bridge is not reachable
-                state.bulbs?.each {it.value.online = false}
-	        } else {
+			if (it.value.lastActivity < time) { // it.value.lastActivity != null &&
+				log.warn "Bridge $it.key is Offline"
+				d.sendEvent(name: "status", value: "Offline")
+
+				state.bulbs?.each {
+					it.value.online = false
+				}
+				getChildDevices().each {
+					it.sendEvent(name: "DeviceWatch-DeviceOffline", value: "offline")
+				}
+			} else {
 				d.sendEvent(name: "status", value: "Online")//setOnline(false)
-	        }
-	    }
-    }
+			}
+		}
+	}
 }
 
 def isValidSource(macAddress) {
@@ -955,6 +960,7 @@ private handlePoll(body) {
 			} else {
 				state.bulbs[bulb.key]?.online = false
 				log.warn "$device is not reachable by Hue bridge"
+				device.sendEvent(name: "DeviceWatch-DeviceOffline", value: "offline")
 			}
 		}
 	}

--- a/smartapps/smartthings/it-moved.src/it-moved.groovy
+++ b/smartapps/smartthings/it-moved.src/it-moved.groovy
@@ -53,14 +53,14 @@ def accelerationActiveHandler(evt) {
 	def alreadySentSms = recentEvents.count { it.value && it.value == "active" } > 1
 
 	if (alreadySentSms) {
-		log.debug "SMS already sent to $phone1 within the last $deltaSeconds seconds"
+		log.debug "SMS already sent within the last $deltaSeconds seconds"
 	} else {
         if (location.contactBookEnabled) {
-            log.debug "$accelerationSensor has moved, texting contacts: ${recipients?.size()}"
+            log.debug "accelerationSensor has moved, texting contacts: ${recipients?.size()}"
             sendNotificationToContacts("${accelerationSensor.label ?: accelerationSensor.name} moved", recipients)
         }
         else {
-            log.debug "$accelerationSensor has moved, texting $phone1"
+            log.debug "accelerationSensor has moved, sending text message"
             sendSms(phone1, "${accelerationSensor.label ?: accelerationSensor.name} moved")
         }
 	}

--- a/smartapps/smartthings/its-too-hot.src/its-too-hot.groovy
+++ b/smartapps/smartthings/its-too-hot.src/its-too-hot.groovy
@@ -69,7 +69,7 @@ def temperatureHandler(evt) {
 		def alreadySentSms = recentEvents.count { it.doubleValue >= tooHot } > 1
 
 		if (alreadySentSms) {
-			log.debug "SMS already sent to within the last $delta Minutes minutes"
+			log.debug "SMS already sent within the last $deltaMinutes minutes"
 			// TODO: Send "Temperature back to normal" SMS, turn switch off
 		} else {
 			log.debug "Temperature rose above $tooHot:  sending SMS and activating $mySwitch"

--- a/smartapps/smartthings/its-too-hot.src/its-too-hot.groovy
+++ b/smartapps/smartthings/its-too-hot.src/its-too-hot.groovy
@@ -69,10 +69,10 @@ def temperatureHandler(evt) {
 		def alreadySentSms = recentEvents.count { it.doubleValue >= tooHot } > 1
 
 		if (alreadySentSms) {
-			log.debug "SMS already sent to $phone1 within the last $deltaMinutes minutes"
+			log.debug "SMS already sent to within the last $delta Minutes minutes"
 			// TODO: Send "Temperature back to normal" SMS, turn switch off
 		} else {
-			log.debug "Temperature rose above $tooHot:  sending SMS to $phone1 and activating $mySwitch"
+			log.debug "Temperature rose above $tooHot:  sending SMS and activating $mySwitch"
 			def tempScale = location.temperatureScale ?: "F"
 			send("${temperatureSensor1.displayName} is too hot, reporting a temperature of ${evt.value}${evt.unit?:tempScale}")
 			switch1?.on()

--- a/smartapps/smartthings/lifx-connect.src/lifx-connect.groovy
+++ b/smartapps/smartthings/lifx-connect.src/lifx-connect.groovy
@@ -50,9 +50,9 @@ def authPage() {
 		}
 		def description = "Tap to enter LIFX credentials"
 		def redirectUrl = "${serverUrl}/oauth/initialize?appId=${app.id}&access_token=${state.accessToken}&apiServerUrl=${apiServerUrl}" // this triggers oauthInit() below
-//        def redirectUrl = "${apiServerUrl}"
-        log.debug "app id: ${app.id}"
-		log.debug "redirect url: ${redirectUrl}"
+		// def redirectUrl = "${apiServerUrl}"
+		// log.debug "app id: ${app.id}"
+		// log.debug "redirect url: ${redirectUrl}"s
 		return dynamicPage(name: "Credentials", title: "Connect to LIFX", nextPage: null, uninstall: true, install:true) {
 			section {
 				href(url:redirectUrl, required:true, title:"Connect to LIFX", description:"Tap here to connect your LIFX account")
@@ -372,7 +372,7 @@ def updateDevices() {
 		def childDevice = getChildDevice(device.id)
 		selectors.add("${device.id}")
 		if (!childDevice) {
-			log.info("Adding device ${device.id}: ${device.product}")
+			// log.info("Adding device ${device.id}: ${device.product}")
 			def data = [
 					label: device.label,
 					level: Math.round((device.brightness ?: 1) * 100),

--- a/smartapps/smartthings/logitech-harmony-connect.src/logitech-harmony-connect.groovy
+++ b/smartapps/smartthings/logitech-harmony-connect.src/logitech-harmony-connect.groovy
@@ -102,7 +102,8 @@ def authPage() {
         description = "Click to enter Harmony Credentials"
         def redirectUrl = buildRedirectUrl
         return dynamicPage(name: "Credentials", title: "Harmony", nextPage: null, uninstall: true, install:false) {
-               section { href url:redirectUrl, style:"embedded", required:true, title:"Harmony", description:description }
+            section { paragraph title: "Note:", "This device has not been officially tested and certified to “Work with SmartThings”. You can connect it to your SmartThings home but performance may vary and we will not be able to provide support or assistance." }
+            section { href url:redirectUrl, style:"embedded", required:true, title:"Harmony", description:description }
         }
     } else {
 		//device discovery request every 5 //25 seconds
@@ -119,7 +120,6 @@ def authPage() {
 			discoverDevices()
 		}
 		return dynamicPage(name:"Credentials", title:"Discovery Started!", nextPage:"", refreshInterval:refreshInterval, install:true, uninstall: true) {
-      section { paragraph title: "Note:", "This device has not been officially tested and certified to “Work with SmartThings”. You can connect it to your SmartThings home but performance may vary and we will not be able to provide support or assistance." }
 			section("Please wait while we discover your Harmony Hubs and Activities. Discovery can take five minutes or more, so sit back and relax! Select your device below once discovered.") {
 				input "selectedhubs", "enum", required:false, title:"Select Harmony Hubs (${numFoundHub} found)", multiple:true, options:huboptions
 			}
@@ -315,8 +315,6 @@ def installed() {
 }
 
 def updated() {
-	unsubscribe()
-  unschedule()
 	if (!state.accessToken) {
 		log.debug "About to create access token"
 		createAccessToken()

--- a/smartapps/smartthings/logitech-harmony-connect.src/logitech-harmony-connect.groovy
+++ b/smartapps/smartthings/logitech-harmony-connect.src/logitech-harmony-connect.groovy
@@ -51,7 +51,7 @@ definition(
 }
 
 preferences(oauthPage: "deviceAuthorization") {
-    page(name: "Credentials", title: "Connect to your Logitech Harmony device", content: "authPage", install: false, nextPage: "deviceAuthorization")
+  page(name: "Credentials", title: "Connect to your Logitech Harmony device", content: "authPage", install: false, nextPage: "deviceAuthorization")
 	page(name: "deviceAuthorization", title: "Logitech Harmony device authorization", install: true) {
 		section("Allow Logitech Harmony to control these things...") {
 			input "switches", "capability.switch", title: "Which Switches?", multiple: true, required: false
@@ -119,6 +119,7 @@ def authPage() {
 			discoverDevices()
 		}
 		return dynamicPage(name:"Credentials", title:"Discovery Started!", nextPage:"", refreshInterval:refreshInterval, install:true, uninstall: true) {
+      section { paragraph title: "Note:", "This device has not been officially tested and certified to “Work with SmartThings”. You can connect it to your SmartThings home but performance may vary and we will not be able to provide support or assistance." }
 			section("Please wait while we discover your Harmony Hubs and Activities. Discovery can take five minutes or more, so sit back and relax! Select your device below once discovered.") {
 				input "selectedhubs", "enum", required:false, title:"Select Harmony Hubs (${numFoundHub} found)", multiple:true, options:huboptions
 			}

--- a/smartapps/smartthings/presence-change-push.src/presence-change-push.groovy
+++ b/smartapps/smartthings/presence-change-push.src/presence-change-push.groovy
@@ -41,10 +41,10 @@ def updated() {
 
 def presenceHandler(evt) {
 	if (evt.value == "present") {
-		log.debug "${presence.label ?: presence.name} has arrived at the ${location}"
+		// log.debug "${presence.label ?: presence.name} has arrived at the ${location}"
     	sendPush("${presence.label ?: presence.name} has arrived at the ${location}")
 	} else if (evt.value == "not present") {
-		log.debug "${presence.label ?: presence.name} has left the ${location}"
+		// log.debug "${presence.label ?: presence.name} has left the ${location}"
     	sendPush("${presence.label ?: presence.name} has left the ${location}")
 	}
 }

--- a/smartapps/smartthings/presence-change-text.src/presence-change-text.groovy
+++ b/smartapps/smartthings/presence-change-text.src/presence-change-text.groovy
@@ -47,7 +47,7 @@ def updated() {
 
 def presenceHandler(evt) {
 	if (evt.value == "present") {
-		log.debug "${presence.label ?: presence.name} has arrived at the ${location}"
+		// log.debug "${presence.label ?: presence.name} has arrived at the ${location}"
 
         if (location.contactBookEnabled) {
             sendNotificationToContacts("${presence.label ?: presence.name} has arrived at the ${location}", recipients)
@@ -56,7 +56,7 @@ def presenceHandler(evt) {
             sendSms(phone1, "${presence.label ?: presence.name} has arrived at the ${location}")
         }
 	} else if (evt.value == "not present") {
-		log.debug "${presence.label ?: presence.name} has left the ${location}"
+		// log.debug "${presence.label ?: presence.name} has left the ${location}"
 
         if (location.contactBookEnabled) {
             sendNotificationToContacts("${presence.label ?: presence.name} has left the ${location}", recipients)

--- a/smartapps/smartthings/ridiculously-automated-garage-door.src/ridiculously-automated-garage-door.groovy
+++ b/smartapps/smartthings/ridiculously-automated-garage-door.src/ridiculously-automated-garage-door.groovy
@@ -67,7 +67,7 @@ def updated() {
 }
 
 def subscribe() {
-	log.debug "present: ${cars.collect{it.displayName + ': ' + it.currentPresence}}"
+	// log.debug "present: ${cars.collect{it.displayName + ': ' + it.currentPresence}}"
 	subscribe(doorSensor, "contact", garageDoorContact)
 
 	subscribe(cars, "presence", carPresence)

--- a/smartapps/smartthings/severe-weather-alert.src/severe-weather-alert.groovy
+++ b/smartapps/smartthings/severe-weather-alert.src/severe-weather-alert.groovy
@@ -26,17 +26,22 @@ definition(
 )
 
 preferences {
-	section ("In addition to push notifications, send text alerts to...") {
-        input("recipients", "contact", title: "Send notifications to") {
-            input "phone1", "phone", title: "Phone Number 1", required: false
-            input "phone2", "phone", title: "Phone Number 2", required: false
-            input "phone3", "phone", title: "Phone Number 3", required: false
-        }
+
+  if (!(location.zipCode || ( location.latitude && location.longitude )) && location.channelName == 'samsungtv') {
+		section { paragraph title: "Note:", "Location is required for this SmartApp. Go to 'Location Name' settings to setup your correct location." }
 	}
 
-	section ("Zip code (optional, defaults to location coordinates)...") {
-		input "zipcode", "text", title: "Zip Code", required: false
-	}
+  if (location.channelName != 'samsungtv') {
+		section( "Set your location" ) { input "zipCode", "text", title: "Zip code" }
+  }
+
+	section ("In addition to push notifications, send text alerts to...") {
+      input("recipients", "contact", title: "Send notifications to") {
+          input "phone1", "phone", title: "Phone Number 1", required: false
+          input "phone2", "phone", title: "Phone Number 2", required: false
+          input "phone3", "phone", title: "Phone Number 3", required: false
+      }
+	 }
 }
 
 def installed() {
@@ -61,7 +66,7 @@ def checkForSevereWeather() {
 	def alerts
 	if(locationIsDefined()) {
 		if(zipcodeIsValid()) {
-			alerts = getWeatherFeature("alerts", zipcode)?.alerts
+			alerts = getWeatherFeature("alerts", zipCode)?.alerts
 		} else {
 			log.warn "Severe Weather Alert: Invalid zipcode entered, defaulting to location's zipcode"
 			alerts = getWeatherFeature("alerts")?.alerts

--- a/smartapps/smartthings/smart-security.src/smart-security.groovy
+++ b/smartapps/smartthings/smart-security.src/smart-security.groovy
@@ -156,7 +156,7 @@ def residentMotion(evt)
 	//    	startReArmSequence()
 	//    }
 	//}
-  unsubscribe(‘residentMotion’)
+  unsubscribe(residentMotions)
 }
 
 def contact(evt)

--- a/smartapps/smartthings/smart-security.src/smart-security.groovy
+++ b/smartapps/smartthings/smart-security.src/smart-security.groovy
@@ -71,7 +71,7 @@ def updated() {
 private subscribeToEvents()
 {
 	subscribe intrusionMotions, "motion", intruderMotion
-	subscribe residentMotions, "motion", residentMotion
+	// subscribe residentMotions, "motion", residentMotion
 	subscribe intrusionContacts, "contact", contact
 	subscribe alarms, "alarm", alarm
 	subscribe(app, appTouch)
@@ -156,6 +156,7 @@ def residentMotion(evt)
 	//    	startReArmSequence()
 	//    }
 	//}
+  unsubscribe(‘residentMotion’)
 }
 
 def contact(evt)
@@ -214,7 +215,7 @@ def checkForReArm()
 	}
 	else {
 		log.warn "checkForReArm: lastIntruderMotion was null, unable to check for re-arming intrusion detection"
-	}	
+	}
 }
 
 private startAlarmSequence()

--- a/smartapps/smartthings/text-me-when-it-opens.src/text-me-when-it-opens.groovy
+++ b/smartapps/smartthings/text-me-when-it-opens.src/text-me-when-it-opens.groovy
@@ -48,7 +48,7 @@ def updated()
 
 def contactOpenHandler(evt) {
 	log.trace "$evt.value: $evt, $settings"
-	log.debug "$contact1 was opened, texting $phone1"
+  log.debug "$contact1 was opened, sending text"
     if (location.contactBookEnabled) {
         sendNotificationToContacts("Your ${contact1.label ?: contact1.name} was opened", recipients)
     }

--- a/smartapps/smartthings/text-me-when-theres-motion-and-im-not-here.src/text-me-when-theres-motion-and-im-not-here.groovy
+++ b/smartapps/smartthings/text-me-when-theres-motion-and-im-not-here.src/text-me-when-theres-motion-and-im-not-here.groovy
@@ -50,7 +50,7 @@ def updated() {
 
 def motionActiveHandler(evt) {
 	log.trace "$evt.value: $evt, $settings"
-	
+
 	if (presence1.latestValue("presence") == "not present") {
 		// Don't send a continuous stream of text messages
 		def deltaSeconds = 10
@@ -60,14 +60,14 @@ def motionActiveHandler(evt) {
 		def alreadySentSms = recentEvents.count { it.value && it.value == "active" } > 1
 
 		if (alreadySentSms) {
-			log.debug "SMS already sent to $phone1 within the last $deltaSeconds seconds"
+			log.debug "SMS already sent within the last $deltaSeconds seconds"
 		} else {
             if (location.contactBookEnabled) {
                 log.debug "$motion1 has moved while you were out, sending notifications to: ${recipients?.size()}"
                 sendNotificationToContacts("${motion1.label} ${motion1.name} moved while you were out", recipients)
             }
             else {
-                log.debug "$motion1 has moved while you were out, texting $phone1"
+                log.debug "$motion1 has moved while you were out, sending text"
                 sendSms(phone1, "${motion1.label} ${motion1.name} moved while you were out")
             }
 		}

--- a/smartapps/smartthings/the-gun-case-moved.src/the-gun-case-moved.groovy
+++ b/smartapps/smartthings/the-gun-case-moved.src/the-gun-case-moved.groovy
@@ -53,13 +53,13 @@ def accelerationActiveHandler(evt) {
 	def alreadySentSms = recentEvents.count { it.value && it.value == "active" } > 1
 
 	if (alreadySentSms) {
-		log.debug "SMS already sent to $phone1 within the last $deltaSeconds seconds"
+		log.debug "SMS already sent to phone within the last $deltaSeconds seconds"
 	} else {
         if (location.contactBookEnabled) {
             sendNotificationToContacts("Gun case has moved!", recipients)
         }
         else {
-            log.debug "$accelerationSensor has moved, texting $phone1"
+            log.debug "$accelerationSensor has moved, texting phone"
             sendSms(phone1, "Gun case has moved!")
         }
 	}

--- a/smartapps/smartthings/wemo-connect.src/wemo-connect.groovy
+++ b/smartapps/smartthings/wemo-connect.src/wemo-connect.groovy
@@ -86,6 +86,7 @@ def firstPage()
 		def lightSwitchesDiscovered = lightSwitchesDiscovered()
 
 		return dynamicPage(name:"firstPage", title:"Discovery Started!", nextPage:"", refreshInterval: refreshInterval, install:true, uninstall: true) {
+			section { paragraph title: "Note:", "This device has not been officially tested and certified to “Work with SmartThings”. You can connect it to your SmartThings home but performance may vary and we will not be able to provide support or assistance." }
 			section("Select a device...") {
 				input "selectedSwitches", "enum", required:false, title:"Select Wemo Switches \n(${switchesDiscovered.size() ?: 0} found)", multiple:true, options:switchesDiscovered
 				input "selectedMotions", "enum", required:false, title:"Select Wemo Motions \n(${motionsDiscovered.size() ?: 0} found)", multiple:true, options:motionsDiscovered

--- a/smartapps/smartthings/withings.src/withings.groovy
+++ b/smartapps/smartthings/withings.src/withings.groovy
@@ -60,7 +60,7 @@ def authPage() {
 
 def oauthInitUrl() {
 	def token = getToken()
-	log.debug "initiateOauth got token: $token"
+	//log.debug "initiateOauth got token: $token"
 
 	// store these for validate after the user takes the oauth journey
 	state.oauth_request_token = token.oauth_token
@@ -76,7 +76,7 @@ def getToken() {
 	]
 	def requestTokenBaseUrl = "https://oauth.withings.com/account/request_token"
 	def url = buildSignedUrl(requestTokenBaseUrl, params)
-	log.debug "getToken - url: $url"
+	//log.debug "getToken - url: $url"
 
 	return getJsonFromUrl(url)
 }
@@ -182,7 +182,7 @@ def exchangeToken() {
 
 	def requestTokenBaseUrl = "https://oauth.withings.com/account/access_token"
 	def url = buildSignedUrl(requestTokenBaseUrl, params, tokenSecret)
-	log.debug "signed url: $url with secret $tokenSecret"
+	//log.debug "signed url: $url with secret $tokenSecret"
 
 	def token = getJsonFromUrl(url)
 
@@ -198,8 +198,8 @@ def exchangeToken() {
 
 def load() {
 	def json = get(getMeasurement(new Date() - 30))
-
-	log.debug "swapped, then received: $json"
+	// removed logging of actual json payload.  Can be put back for debugging
+	log.debug "swapped, then received json"
 	parse(data:json)
 
 	def html = """


### PR DESCRIPTION
When we enroll existing Health Check devices in our platform, some devices will be offline. Since calling `configure()` will update the periodic reporting intervals for online devices, Device-Watch will have an expectation of how often they are checking in according to the newer value. We want to keep the checkInterval to the older value - `3 * 60 * 60 + 60` seconds until DTH confirms that the newer config is successful. 

By parsing out the response in `parse()` for successful configuration, DTH will update Device-Watch with the correct `checkInterval` value. 
- Also addresses the fix for CHF-416 `zigbee-dimmer` / `zigbee-rgbw-bulb` / `zigbee-white-color-temperature-bulb` on `refresh()` it configures to the new onOffConfig intervals. 

<img width="810" alt="updatedcheckinterval" src="https://cloud.githubusercontent.com/assets/255235/19093998/93115f74-8a42-11e6-93d0-76960ffdf887.png">

CHF - @mortent @ShunmugaSundar @parijatdas @skt123 @pchomal @dchem @darksun 
Device Protocols @tpmanley @workingmonk 
