### PR TITLE
PROB-1359 set Fibaro motion ZW5 temperature scale properly

### DIFF
--- a/devicetypes/fibargroup/fibaro-motion-sensor-zw5.src/fibaro-motion-sensor-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-motion-sensor-zw5.src/fibaro-motion-sensor-zw5.groovy
@@ -127,9 +127,10 @@ def zwaveEvent(physicalgraph.zwave.commands.sensormultilevelv5.SensorMultilevelR
 	def map = [ displayed: true ]
     switch (cmd.sensorType) {
     	case 1:
-        	map.name = "temperature"
-            map.unit = cmd.scale == 1 ? "F" : "C"
-            map.value = convertTemperatureIfNeeded(cmd.scaledSensorValue, map.unit, cmd.precision)
+			def cmdScale = cmd.scale == 1 ? "F" : "C"
+			map.name = "temperature"
+            map.unit = getTemperatureScale()
+            map.value = convertTemperatureIfNeeded(cmd.scaledSensorValue, cmdScale, cmd.precision)
             break
     	case 3:
         	map.name = "illuminance"


### PR DESCRIPTION
DTH was converting the temperature properly but setting the `unit` field of the event to the incoming device temperature scale rather than the one set for the location.
