### PR TITLE
[DPROT-180] Correctly parse zone status in zigbee-button

### DIFF
--- a/devicetypes/smartthings/zigbee-button.src/zigbee-button.groovy
+++ b/devicetypes/smartthings/zigbee-button.src/zigbee-button.groovy
@@ -89,14 +89,8 @@ def parse(String description) {
 }
 
 private Map parseIasButtonMessage(String description) {
-    int zoneInt = Integer.parseInt((description - "zone status 0x"), 16)
-    if (zoneInt & 0x02) {
-        resultMap = getButtonResult('press')
-    } else {
-        resultMap = getButtonResult('release')
-    }
-
-    return resultMap
+    def zs = zigbee.parseZoneStatus(description)
+    return zs.isAlarm2Set() ? getButtonResult("press") : getButtonResult("release")
 }
 
 private Map getBatteryResult(rawValue) {


### PR DESCRIPTION
Previously the DTH didn't handle the extended status from zone status
reporting.  This moves to use the library for parsing zone status
which will handle the extended status properly.

This resolves: https://smartthings.atlassian.net/browse/DPROT-180

@tpmanley 
