### PR TITLE
CREX-5316 - Changed icon and added label for the beep tile

### DIFF
--- a/devicetypes/smartthings/arrival-sensor.src/arrival-sensor.groovy
+++ b/devicetypes/smartthings/arrival-sensor.src/arrival-sensor.groovy
@@ -46,7 +46,7 @@ metadata {
 			state "not present", labelIcon:"st.presence.tile.not-present", backgroundColor:"#ebeef2"
 		}
 		standardTile("beep", "device.beep", decoration: "flat") {
-			state "beep", label:'', action:"tone.beep", icon:"st.secondary.beep", backgroundColor:"#ffffff"
+			state "beep", label:'Beep', action:"tone.beep", icon:"st.alarm.beep.beep", backgroundColor:"#ffffff"
 		}
 		valueTile("battery", "device.battery", decoration: "flat", inactiveLabel: false) {
 			state "battery", label:'${currentValue}% battery', unit:""/*, backgroundColors:[
@@ -61,7 +61,7 @@ metadata {
 			state "lqi", label:'${currentValue}% signal', unit:""
 		}
 		*/
-		
+
 		main "presence"
 		details(["presence", "beep", "battery"/*, "lqi"*/])
 	}


### PR DESCRIPTION
There was concern that the Beep Icon could be mistaken for a volume action.  Due to the slight delay of the beeping, the user might attempt to stop the beeping by spamming the speaker tile, causing more beeping.

Added a label to the beep tile, and changed the speaker icon to a smaller speaker icon to make room for the label.
