### PR TITLE
Update netatmo-connect to use non-deprecated api

### DIFF
--- a/smartapps/dianoga/netatmo-connect.src/netatmo-connect.groovy
+++ b/smartapps/dianoga/netatmo-connect.src/netatmo-connect.groovy
@@ -393,12 +393,12 @@ def getDeviceList() {
 			deviceList[key] = "${value.station_name}: ${value.module_name}"
 			state.deviceDetail[key] = value
             state.deviceState[key] = value.dashboard_data
-		}
-		response.data.body.modules.each { value ->
-			def key = value._id
-			deviceList[key] = "${state.deviceDetail[value.main_device].station_name}: ${value.module_name}"
-			state.deviceDetail[key] = value
-            state.deviceState[key] = value.dashboard_data
+			value.modules.each { value2 ->            
+                def key2 = value2._id
+                deviceList[key2] = "${value.station_name}: ${value2.module_name}"
+                state.deviceDetail[key2] = value2
+                state.deviceState[key2] = value2.dashboard_data            
+            }
 		}
 	}
 

--- a/smartapps/dianoga/netatmo-connect.src/netatmo-connect.groovy
+++ b/smartapps/dianoga/netatmo-connect.src/netatmo-connect.groovy
@@ -387,7 +387,7 @@ def getDeviceList() {
 	state.deviceDetail = [:]
 	state.deviceState = [:]
 
-	apiGet("/api/devicelist") { response ->
+	apiGet("/api/getstationsdata") { response ->
 		response.data.body.devices.each { value ->
 			def key = value._id
 			deviceList[key] = "${value.station_name}: ${value.module_name}"


### PR DESCRIPTION
**Note** I haven't actually tested this change due to time limitations. Someone should check this out and verify it behaves properly before merging.

devicedata has been deprecated in favor of getstationsdata and will be removed at the end of November.
