### PR TITLE
[CHF-425] Health Check Implementation for Z-wave switch

### DIFF
--- a/devicetypes/smartthings/zwave-switch.src/.st-ignore
+++ b/devicetypes/smartthings/zwave-switch.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/zwave-switch.src/README.md
+++ b/devicetypes/smartthings/zwave-switch.src/README.md
@@ -1,0 +1,49 @@
+# Z-Wave Switch
+
+
+Works with: 
+
+* [GE Z-Wave Plug-In Smart Switch (12719)](http://products.z-wavealliance.org/products/1193)
+* [GE Z-Wave In-Wall Smart Outlet (12721)](http://products.z-wavealliance.org/products/1195)
+* [GE Z-Wave In-Wall Smart Switch (12722)](http://products.z-wavealliance.org/products/1196)
+* [GE Z-Wave In-Wall Smart Toggle Switch (12727)](http://products.z-wavealliance.org/products/1200)
+
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+* [Troubleshooting](#Troubleshooting)
+
+## Capabilities
+
+* **Actuator** - represents that a Device has commands
+* **Indicator** - gives you the ability to set the indicator LED light on a Z-Wave switch
+* **Switch** - can detect state (possible values: on/off)
+* **Polling** - represents that poll() can be implemented for the device
+* **Refresh** - _refresh()_ command for status updates
+* **Sensor** - detects sensor events
+* **Health Check** - indicates ability to get device health notifications
+
+## Device Health
+
+Z-Wave Switches (Plug-In, In-Wall(Toggle Switch, Switch, Outlet)) are polled by the hub.
+As of hubCore version 0.14.38 the hub sends up reports every 15 minutes regardless of whether the state changed.
+Device-Watch allows 2 check-in misses from device plus some lag time. So Check-in interval = (2*15 + 2)mins = 32 mins.
+Not to mention after going OFFLINE when the device is plugged back in, it might take a considerable amount of time for
+the device to appear as ONLINE again. This is because if this listening device does not respond to two poll requests in a row,
+it is not polled for 5 minutes by the hub. This can delay up the process of being marked ONLINE by quite some time.
+
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
+Pairing needs to be tried again by placing the device closer to the hub.
+Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following link:
+* [General Z-Wave Dimmer/Switch Troubleshooting](https://support.smartthings.com/hc/en-us/articles/200955890-Troubleshooting-GE-in-wall-switch-or-dimmer-won-t-respond-to-commands-or-automations-Z-Wave-)
+* [GE Z-Wave Plug-In Smart Switch (12719) Troubleshooting](https://support.smartthings.com/hc/en-us/articles/200903070-GE-Plug-In-Smart-Switch-GE-12719-Z-Wave)
+* [GE Z-Wave In-Wall Smart Outlet (12721) Troubleshooting](https://support.smartthings.com/hc/en-us/articles/200903020-GE-In-Wall-Smart-Outlet-GE-12721-Z-Wave)
+* [GE Z-Wave In-Wall Smart Switch (12722) Troubleshooting](https://support.smartthings.com/hc/en-us/articles/200902540-GE-In-Wall-Smart-Switch-GE-12722-Z-Wave)
+* [GE Z-Wave In-Wall Smart Toggle Switch (12727) Troubleshooting](https://support.smartthings.com/hc/en-us/articles/207568933-GE-In-Wall-Smart-Toggle-Switch-GE-12727-Z-Wave)
+
+

--- a/devicetypes/smartthings/zwave-switch.src/zwave-switch.groovy
+++ b/devicetypes/smartthings/zwave-switch.src/zwave-switch.groovy
@@ -19,6 +19,7 @@ metadata {
 		capability "Polling"
 		capability "Refresh"
 		capability "Sensor"
+		capability "Health Check"
 
 		fingerprint mfr:"0063", prod:"4952", deviceJoinName: "Z-Wave Wall Switch"
 		fingerprint mfr:"0063", prod:"5257", deviceJoinName: "Z-Wave Wall Switch"
@@ -64,6 +65,8 @@ metadata {
 }
 
 def updated(){
+		// Device-Watch simply pings if no device events received for 32min(checkInterval)
+		sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
   switch (ledIndicator) {
         case "on":
             indicatorWhenOn()
@@ -154,6 +157,13 @@ def poll() {
 		zwave.switchBinaryV1.switchBinaryGet().format(),
 		zwave.manufacturerSpecificV1.manufacturerSpecificGet().format()
 	])
+}
+
+/**
+  * PING is used by Device-Watch in attempt to reach the Device
+**/
+def ping() {
+		refresh()
 }
 
 def refresh() {


### PR DESCRIPTION
Added Health Check Implementation for following Z-wave switches:
1. Plug-In Smart Switch (GE 12719)
2. In-Wall Smart Outlet (GE 12721)
3. In-Wall Smart Switch (GE 12722)
4. In-Wall Smart Toggle Switch (GE 12727)
