### PR TITLE
DVCSMP-2155 ZigBee switch power DH health check

### DIFF
--- a/devicetypes/smartthings/zigbee-switch-power.src/zigbee-switch-power.groovy
+++ b/devicetypes/smartthings/zigbee-switch-power.src/zigbee-switch-power.groovy
@@ -20,6 +20,7 @@ metadata {
         capability "Power Meter"
         capability "Sensor"
         capability "Switch"
+        capability "Health Check"
 
         fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0B04"
         fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0702"
@@ -77,10 +78,26 @@ def on() {
 }
 
 def refresh() {
-    zigbee.onOffRefresh() + zigbee.simpleMeteringPowerRefresh() + zigbee.electricMeasurementPowerRefresh() + zigbee.onOffConfig() + zigbee.simpleMeteringPowerConfig() + zigbee.electricMeasurementPowerConfig()
+    Integer reportIntervalMinutes = 5
+    zigbee.onOffRefresh() + zigbee.simpleMeteringPowerRefresh() + zigbee.electricMeasurementPowerRefresh() + zigbee.onOffConfig(0,reportIntervalMinutes * 60) + zigbee.simpleMeteringPowerConfig() + zigbee.electricMeasurementPowerConfig()
 }
 
 def configure() {
-    log.debug "Configuring Reporting and Bindings."
+    log.debug "in configure()"
+    configureHealthCheck()
+}
+
+def configureHealthCheck() {
+    Integer hcIntervalMinutes = 12
     refresh()
+    sendEvent(name: "checkInterval", value: hcIntervalMinutes * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+}
+
+def updated() {
+    log.debug "in updated()"
+    configureHealthCheck()
+}
+
+def ping() {
+    return zigbee.onOffRefresh()
 }


### PR DESCRIPTION
- Add capability Health Check
- specify 5 minute reporting interval to `zigbee.onOffConfig()` in `refresh()`
- call `refresh()` then set the checkInterval attribute in `configureHealthCheck()` 
- call `configureHealthCheck()` from both `configure()` and `updated()`
- implement `ping()` by sending the `zigbee.onOffRefresh()` command

For the Google Home project, supports specifically
- GE/Jasco ZigBee Plug-in Smart Switch (45853)
- GE/Jasco ZigBee In-Wall Smart Switch (45856)

The DH itself supports those, plus the Smartthings Outlet V4
- `fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 000F, 0B04", outClusters: "0019"`

and two other generic fingerprints:
- `fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0B04"`
- `fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0702"`
