### PR TITLE
[CHF-436] Health check for Leviton DZPD3-1LW Plug-in Lamp Dimmer Module (Z-Wave)

### DIFF
--- a/devicetypes/smartthings/zwave-dimmer-switch-generic.src/.st-ignore
+++ b/devicetypes/smartthings/zwave-dimmer-switch-generic.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/zwave-dimmer-switch-generic.src/README.md
+++ b/devicetypes/smartthings/zwave-dimmer-switch-generic.src/README.md
@@ -1,0 +1,39 @@
+# Z-wave Dimmer
+
+
+
+Works with: 
+
+* [Leviton Plug-in Lamp Dimmer Module (DZPD3-1LW)](http://www.leviton.com/OA_HTML/ProductDetail.jsp?partnumber=DZPD3-1LW)
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+* [Troubleshooting](#troubleshooting)
+
+## Capabilities
+
+* **Switch Level** - it's defined to accept two parameters, the level and the rate of dimming
+* **Actuator** - represents that a Device has commands
+* **Health Check** - indicates ability to get device health notifications
+* **Switch** - can detect state (possible values: on/off)
+* **Polling** - represents that poll() can be implemented for the device
+* **Refresh** - _refresh()_ command for status updates
+* **Sensor** - detects sensor events
+
+## Device Health
+
+A Category C5 Leviton Plug-in Lamp Dimmer Module (DZPA1-1LW) (Z-Wave) polled by the hub.
+As of hubCore version 0.14.38 the hub sends up reports every 15 minutes regardless of whether the state changed.
+Device-Watch allows 2 check-in misses from device plus some lag time. So Check-in interval = (2*15 + 2)mins = 32 mins.
+Not to mention after going OFFLINE when the device is plugged back in, it might take a considerable amount of time for
+the device to appear as ONLINE again. This is because if this listening device does not respond to two poll requests in a row,
+it is not polled for 5 minutes by the hub. This can delay up the process of being marked ONLINE by quite some time.
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
+Pairing needs to be tried again by placing the device closer to the hub.
+Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following link:
+* [Leviton Plug-in Lamp Dimmer Module (DZPD3-1LW) Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/206171053-How-to-connect-Leviton-Z-Wave-devices)

--- a/devicetypes/smartthings/zwave-dimmer-switch-generic.src/zwave-dimmer-switch-generic.groovy
+++ b/devicetypes/smartthings/zwave-dimmer-switch-generic.src/zwave-dimmer-switch-generic.groovy
@@ -15,12 +15,14 @@ metadata {
 	definition (name: "Z-Wave Dimmer Switch Generic", namespace: "smartthings", author: "SmartThings") {
 		capability "Switch Level"
 		capability "Actuator"
+		capability "Health Check"
 		capability "Switch"
 		capability "Polling"
 		capability "Refresh"
 		capability "Sensor"
 
 		fingerprint inClusters: "0x26", deviceJoinName: "Z-Wave Dimmer"
+		fingerprint mfr:"001D", prod:"1902", deviceJoinName: "Z-Wave Dimmer"
 	}
 
 	simulator {
@@ -66,6 +68,11 @@ metadata {
 		details(["switch", "level", "refresh"])
 
 	}
+}
+
+def updated(){
+// Device-Watch simply pings if no device events received for 32min(checkInterval)
+	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 }
 
 def parse(String description) {
@@ -183,6 +190,13 @@ def setLevel(value, duration) {
 
 def poll() {
 	zwave.switchMultilevelV1.switchMultilevelGet().format()
+}
+
+/**
+ * PING is used by Device-Watch in attempt to reach the Device
+ * */
+def ping() {
+	refresh()
 }
 
 def refresh() {


### PR DESCRIPTION
1. Added health check for Leviton DZPD3-1LW Plug-in Lamp Dimmer Module (Z-Wave).
2. 'checkInterval' is kept at 32min.
3. Ping is implemented using refresh().
4. Added the fingerprint of the Leviton DZPD3 Plug-in Dimmer Module (Z-Wave) with the manufacturer and product code obtained from the raw description after pairing.
5. We've tested the checkInterval duration and the devices are marked OFFLINE within the stipulated time.
6. Added the README.md file.

@jackchi @ShunmugaSundar Please check and merge the changes.
