### PR TITLE
[DPROT-183] Remove read attribute for new mfg code

### DIFF
--- a/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
@@ -264,7 +264,6 @@ def refresh()
 {
 	log.debug "refresh temperature, humidity, and battery"
 	return zigbee.readAttribute(0xFC45, 0x0000, ["mfgCode": 0xC2DF]) +   // Original firmware
-			zigbee.readAttribute(0xFC45, 0x0000, ["mfgCode": 0x104E]) +  // New firmware
 			zigbee.readAttribute(0x0402, 0x0000) +
 			zigbee.readAttribute(0x0001, 0x0020)
 }


### PR DESCRIPTION
Because of the interaction between the DTH running in the cloud and the
one running in appengine, we can't make this change yet as for unupdated
devices the humidity gets replaced with null.  So we back out the call
with the new mfgID as there aren't devices out there yet using it.

This relates to: https://smartthings.atlassian.net/browse/DPROT-183

@tpmanley @workingmonk 
