### PR TITLE
[CHF-429] Device Health enrollment refactored into updated()

### DIFF
--- a/devicetypes/smartthings/cree-bulb.src/cree-bulb.groovy
+++ b/devicetypes/smartthings/cree-bulb.src/cree-bulb.groovy
@@ -59,6 +59,15 @@ metadata {
     }
 }
 
+def installed() {
+    log.debug "${device} installed"
+}
+
+def updated() {
+    log.debug "${device} updated"
+    configureHealthCheck()
+}
+
 // Parse incoming device messages to generate events
 def parse(String description) {
     log.debug "description is $description"
@@ -96,6 +105,14 @@ def refresh() {
     zigbee.onOffRefresh() + zigbee.levelRefresh()
 }
 
+def configureHealthCheck() {
+    log.debug "configureHealthCheck"
+    unschedule("healthPoll")
+    runEvery5Minutes("healthPoll")
+    // Device-Watch allows 2 check-in misses from device
+    sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+}
+
 def healthPoll() {
     log.debug "healthPoll()"
     def cmds = zigbee.onOffRefresh() + zigbee.levelRefresh()
@@ -103,9 +120,5 @@ def healthPoll() {
 }
 
 def configure() {
-    unschedule()
-    runEvery5Minutes("healthPoll")
-    // Device-Watch allows 2 check-in misses from device
-    sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
-    zigbee.onOffRefresh() + zigbee.levelRefresh()
+    refresh()
 }

--- a/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
+++ b/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
@@ -74,6 +74,15 @@ metadata {
 	}
 }
 
+def installed() {
+	log.debug "${device} installed"
+}
+
+def updated() {
+	log.debug "${device} updated"
+	configureHealthCheck()
+}
+
 // Parse incoming device messages to generate events
 def parse(String description) {
 	log.debug "description is $description"
@@ -140,10 +149,14 @@ def refresh() {
 	zigbee.onOffRefresh() + zigbee.electricMeasurementPowerRefresh()
 }
 
-def configure() {
+def configureHealthCheck() {
 	// Device-Watch allows 3 check-in misses from device (plus 1 min lag time)
 	// enrolls with default periodic reporting until newer 5 min interval is confirmed
 	sendEvent(name: "checkInterval", value: 3 * 10 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+}
+
+def configure() {
+
 
 	// OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
 	refresh() + zigbee.onOffConfig(0, 300) + powerConfig()

--- a/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
@@ -84,6 +84,15 @@ metadata {
 	}
 }
 
+def installed() {
+	log.debug "${device} installed"
+}
+
+def updated() {
+	log.debug "${device} updated"
+	configureHealthCheck()
+}
+
 def parse(String description) {
 	log.debug "description: $description"
 
@@ -303,11 +312,13 @@ def refresh() {
 	return refreshCmds + enrollResponse()
 }
 
-def configure() {
+def configureHealthCheck() {
 	// Device-Watch allows 3 check-in misses from device (plus 1 min lag time)
 	// enrolls with default periodic reporting until newer 5 min interval is confirmed
 	sendEvent(name: "checkInterval", value: 3 * 60 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+}
 
+def configure() {
 	// temperature minReportTime 30 seconds, maxReportTime 5 min. Reporting interval if no activity
 	// battery minReport 30 seconds, maxReportTime 6 hrs by default
 	return refresh() + zigbee.batteryConfig() + zigbee.temperatureConfig(30, 300) // send refresh cmds as part of config

--- a/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
@@ -88,6 +88,15 @@ metadata {
 	}
 }
 
+def installed() {
+	log.debug "${device} installed"
+}
+
+def updated() {
+	log.debug "${device} updated"
+	configureHealthCheck()
+}
+
 def parse(String description) {
 	log.debug "description: $description"
 
@@ -318,11 +327,13 @@ def refresh() {
 	return refreshCmds + enrollResponse()
 }
 
-def configure() {
+def configureHealthCheck() {
 	// Device-Watch allows 3 check-in misses from device (plus 1 min lag time)
 	// enrolls with default periodic reporting until newer 5 min interval is confirmed
 	sendEvent(name: "checkInterval", value: 3 * 60 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+}
 
+def configure() {
 	// temperature minReportTime 30 seconds, maxReportTime 5 min. Reporting interval if no activity
 	// battery minReport 30 seconds, maxReportTime 6 hrs by default
 	return refresh() + zigbee.batteryConfig() + zigbee.temperatureConfig(30, 300) // send refresh cmds as part of config

--- a/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
@@ -75,6 +75,15 @@ metadata {
 	}
 }
 
+def installed() {
+	log.debug "${device} installed"
+}
+
+def updated() {
+	log.debug "${device} updated"
+	configureHealthCheck()
+}
+
 def parse(String description) {
 	log.debug "description: $description"
 
@@ -265,11 +274,12 @@ def refresh() {
 	return refreshCmds + enrollResponse()
 }
 
-def configure() {
+def configureHealthCheck() {
 	// Device-Watch allows 3 check-in misses from device (plus 1 min lag time)
 	// enrolls with default periodic reporting until newer 5 min interval is confirmed
 	sendEvent(name: "checkInterval", value: 3 * 60 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
-
+}
+def configure() {
 	log.debug "Configuring Reporting, IAS CIE, and Bindings."
 
 	// temperature minReportTime 30 seconds, maxReportTime 5 min. Reporting interval if no activity

--- a/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
@@ -69,6 +69,15 @@ metadata {
 	}
 }
 
+def installed() {
+	log.debug "${device} installed"
+}
+
+def updated() {
+	log.debug "${device} updated"
+	configureHealthCheck()
+}
+
 def parse(String description) {
 	log.debug "description: $description"
 
@@ -269,11 +278,13 @@ def refresh()
 			zigbee.readAttribute(0x0001, 0x0020)
 }
 
-def configure() {
+def configureHealthCheck() {
 	// Device-Watch allows 3 check-in misses from device (plus 1 min lag time)
 	// enrolls with default periodic reporting until newer 5 min interval is confirmed
 	sendEvent(name: "checkInterval", value: 3 * 60 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+}
 
+def configure() {
 	log.debug "Configuring Reporting and Bindings."
 	def humidityConfigCmds = [
 		"zdo bind 0x${device.deviceNetworkId} 1 1 0xFC45 {${device.zigbeeId}} {}", "delay 500",

--- a/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
@@ -48,6 +48,15 @@ metadata {
     }
 }
 
+def installed() {
+    log.debug "${device} installed"
+}
+
+def updated() {
+    log.debug "${device} updated"
+    configureHealthCheck()
+}
+
 // Parse incoming device messages to generate events
 def parse(String description) {
     log.debug "description is $description"
@@ -100,12 +109,13 @@ def refresh() {
     zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.onOffConfig(0, 300) + zigbee.levelConfig()
 }
 
-def configure() {
-    log.debug "Configuring Reporting and Bindings."
+def configureHealthCheck() {
     // Device-Watch allows 3 check-in misses from device (plus 1 min lag time)
     // enrolls with default periodic reporting until newer 5 min interval is confirmed
     sendEvent(name: "checkInterval", value: 3 * 10 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+}
 
+def configure() {
     // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
     zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.onOffConfig(0, 300) + zigbee.levelConfig()
 }

--- a/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
@@ -70,6 +70,16 @@ metadata {
     }
 }
 
+
+def installed() {
+    log.debug "${device} installed"
+}
+
+def updated() {
+    log.debug "${device} updated"
+    configureHealthCheck()
+}
+
 //Globals
 private getATTRIBUTE_HUE() { 0x0000 }
 private getATTRIBUTE_SATURATION() { 0x0001 }
@@ -138,16 +148,17 @@ def ping() {
 }
 
 def refresh() {
+    // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
     zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_COLOR_TEMPERATURE) + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE) + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION) + zigbee.onOffConfig(0, 300) + zigbee.levelConfig() + zigbee.colorTemperatureConfig() + zigbee.configureReporting(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE, 0x20, 1, 3600, 0x01) + zigbee.configureReporting(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION, 0x20, 1, 3600, 0x01)
 }
 
-def configure() {
-    log.debug "Configuring Reporting and Bindings."
+def configureHealthCheck() {
     // Device-Watch allows 3 check-in misses from device (plus 1 min lag time)
     // enrolls with default periodic reporting until newer 5 min interval is confirmed
     sendEvent(name: "checkInterval", value: 3 * 10 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+}
 
-    // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
+def configure() {
     refresh()
 }
 

--- a/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
@@ -69,6 +69,15 @@ metadata {
     }
 }
 
+def installed() {
+    log.debug "${device} installed"
+}
+
+def updated() {
+    log.debug "${device} updated"
+    configureHealthCheck()
+}
+
 // Parse incoming device messages to generate events
 def parse(String description) {
     log.debug "description is $description"
@@ -121,16 +130,17 @@ def ping() {
 }
 
 def refresh() {
+    // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
     zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.colorTemperatureRefresh() + zigbee.onOffConfig(0, 300) + zigbee.levelConfig() + zigbee.colorTemperatureConfig()
 }
 
-def configure() {
-    log.debug "Configuring Reporting and Bindings."
+def configureHealthCheck() {
     // Device-Watch allows 3 check-in misses from device (plus 1 min lag time)
     // enrolls with default periodic reporting until newer 5 min interval is confirmed
     sendEvent(name: "checkInterval", value: 3 * 10 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+}
 
-    // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
+def configure() {
     refresh()
 }
 


### PR DESCRIPTION
- Removed `Configuration` capability from Cree Bulb
- In `zigbee-dimmer.groovy` & `zigbee-rgbw-bulb.groovy` & `zigbee-white-color-temperature.groovy` DTH, the configuration is removed from `refresh()`. 

Upside: 
- Manually switching Device Types would work with Device Health
- Not all devices will have `Configuration` as a Capability. 

Downside:
- `updated()` method gets called multiple (3) times. But this shouldn't affect Device-Watch compatibility

https://smartthings.atlassian.net/browse/CHF-429

@tpmanley @mckeed Can you quickly look over this?

cc @mortent 
@parijatdas @ShunmugaSundar @skt123 @pchomal 
