### PR TITLE
Revert "[CHF-429] Device Health enrollment refactored into updated()"

### DIFF
--- a/devicetypes/smartthings/cree-bulb.src/cree-bulb.groovy
+++ b/devicetypes/smartthings/cree-bulb.src/cree-bulb.groovy
@@ -59,15 +59,6 @@ metadata {
     }
 }
 
-def installed() {
-    log.debug "${device} installed"
-}
-
-def updated() {
-    log.debug "${device} updated"
-    configureHealthCheck()
-}
-
 // Parse incoming device messages to generate events
 def parse(String description) {
     log.debug "description is $description"
@@ -105,14 +96,6 @@ def refresh() {
     zigbee.onOffRefresh() + zigbee.levelRefresh()
 }
 
-def configureHealthCheck() {
-    log.debug "configureHealthCheck"
-    unschedule("healthPoll")
-    runEvery5Minutes("healthPoll")
-    // Device-Watch allows 2 check-in misses from device
-    sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
-}
-
 def healthPoll() {
     log.debug "healthPoll()"
     def cmds = zigbee.onOffRefresh() + zigbee.levelRefresh()
@@ -120,5 +103,9 @@ def healthPoll() {
 }
 
 def configure() {
-    refresh()
+    unschedule()
+    runEvery5Minutes("healthPoll")
+    // Device-Watch allows 2 check-in misses from device
+    sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+    zigbee.onOffRefresh() + zigbee.levelRefresh()
 }

--- a/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
+++ b/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
@@ -74,15 +74,6 @@ metadata {
 	}
 }
 
-def installed() {
-	log.debug "${device} installed"
-}
-
-def updated() {
-	log.debug "${device} updated"
-	configureHealthCheck()
-}
-
 // Parse incoming device messages to generate events
 def parse(String description) {
 	log.debug "description is $description"
@@ -149,14 +140,10 @@ def refresh() {
 	zigbee.onOffRefresh() + zigbee.electricMeasurementPowerRefresh()
 }
 
-def configureHealthCheck() {
+def configure() {
 	// Device-Watch allows 3 check-in misses from device (plus 1 min lag time)
 	// enrolls with default periodic reporting until newer 5 min interval is confirmed
 	sendEvent(name: "checkInterval", value: 3 * 10 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
-}
-
-def configure() {
-
 
 	// OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
 	refresh() + zigbee.onOffConfig(0, 300) + powerConfig()

--- a/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
@@ -84,15 +84,6 @@ metadata {
 	}
 }
 
-def installed() {
-	log.debug "${device} installed"
-}
-
-def updated() {
-	log.debug "${device} updated"
-	configureHealthCheck()
-}
-
 def parse(String description) {
 	log.debug "description: $description"
 
@@ -312,13 +303,11 @@ def refresh() {
 	return refreshCmds + enrollResponse()
 }
 
-def configureHealthCheck() {
+def configure() {
 	// Device-Watch allows 3 check-in misses from device (plus 1 min lag time)
 	// enrolls with default periodic reporting until newer 5 min interval is confirmed
 	sendEvent(name: "checkInterval", value: 3 * 60 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
-}
 
-def configure() {
 	// temperature minReportTime 30 seconds, maxReportTime 5 min. Reporting interval if no activity
 	// battery minReport 30 seconds, maxReportTime 6 hrs by default
 	return refresh() + zigbee.batteryConfig() + zigbee.temperatureConfig(30, 300) // send refresh cmds as part of config

--- a/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
@@ -88,15 +88,6 @@ metadata {
 	}
 }
 
-def installed() {
-	log.debug "${device} installed"
-}
-
-def updated() {
-	log.debug "${device} updated"
-	configureHealthCheck()
-}
-
 def parse(String description) {
 	log.debug "description: $description"
 
@@ -327,13 +318,11 @@ def refresh() {
 	return refreshCmds + enrollResponse()
 }
 
-def configureHealthCheck() {
+def configure() {
 	// Device-Watch allows 3 check-in misses from device (plus 1 min lag time)
 	// enrolls with default periodic reporting until newer 5 min interval is confirmed
 	sendEvent(name: "checkInterval", value: 3 * 60 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
-}
 
-def configure() {
 	// temperature minReportTime 30 seconds, maxReportTime 5 min. Reporting interval if no activity
 	// battery minReport 30 seconds, maxReportTime 6 hrs by default
 	return refresh() + zigbee.batteryConfig() + zigbee.temperatureConfig(30, 300) // send refresh cmds as part of config

--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -115,34 +115,6 @@ metadata {
 	}
  }
 
-def installed() {
-	log.debug "${device} installed"
-}
-
-def updated() {
-	log.debug "updated called"
-	log.info "garage value : $garageSensor"
-	if (garageSensor == "Yes") {
-		def descriptionText = "Updating device to garage sensor"
-		if (device.latestValue("status") == "open") {
-			sendEvent(name: 'status', value: 'garage-open', descriptionText: descriptionText, translatable: true)
-		}
-		else if (device.latestValue("status") == "closed") {
-			sendEvent(name: 'status', value: 'garage-closed', descriptionText: descriptionText, translatable: true)
-		}
-	}
-	else {
-		def descriptionText = "Updating device to open/close sensor"
-		if (device.latestValue("status") == "garage-open") {
-			sendEvent(name: 'status', value: 'open', descriptionText: descriptionText, translatable: true)
-		}
-		else if (device.latestValue("status") == "garage-closed") {
-			sendEvent(name: 'status', value: 'closed', descriptionText: descriptionText, translatable: true)
-		}
-	}
-	configureHealthCheck()
-}
-
 def parse(String description) {
 	Map map = [:]
 	if (description?.startsWith('catchall:')) {
@@ -272,6 +244,29 @@ private Map parseIasMessage(String description) {
 			}
 
 	return resultMap
+}
+
+def updated() {
+	log.debug "updated called"
+	log.info "garage value : $garageSensor"
+	if (garageSensor == "Yes") {
+		def descriptionText = "Updating device to garage sensor"
+		if (device.latestValue("status") == "open") {
+			sendEvent(name: 'status', value: 'garage-open', descriptionText: descriptionText, translatable: true)
+		}
+		else if (device.latestValue("status") == "closed") {
+			sendEvent(name: 'status', value: 'garage-closed', descriptionText: descriptionText, translatable: true)
+		}
+	}
+	else {
+		def descriptionText = "Updating device to open/close sensor"
+		if (device.latestValue("status") == "garage-open") {
+			sendEvent(name: 'status', value: 'open', descriptionText: descriptionText, translatable: true)
+		}
+		else if (device.latestValue("status") == "garage-closed") {
+			sendEvent(name: 'status', value: 'closed', descriptionText: descriptionText, translatable: true)
+		}
+	}
 }
 
 def getTemperature(value) {
@@ -416,13 +411,11 @@ def refresh() {
 	return refreshCmds + enrollResponse()
 }
 
-def configureHealthCheck(){
+def configure() {
 	// Device-Watch allows 3 check-in misses from device (plus 1 min lag time)
 	// enrolls with default periodic reporting until newer 5 min interval is confirmed
 	sendEvent(name: "checkInterval", value: 3 * 60 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
-}
 
-def configure() {
 	log.debug "Configuring Reporting"
 
 	// temperature minReportTime 30 seconds, maxReportTime 5 min. Reporting interval if no activity

--- a/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
@@ -75,15 +75,6 @@ metadata {
 	}
 }
 
-def installed() {
-	log.debug "${device} installed"
-}
-
-def updated() {
-	log.debug "${device} updated"
-	configureHealthCheck()
-}
-
 def parse(String description) {
 	log.debug "description: $description"
 
@@ -274,12 +265,11 @@ def refresh() {
 	return refreshCmds + enrollResponse()
 }
 
-def configureHealthCheck() {
+def configure() {
 	// Device-Watch allows 3 check-in misses from device (plus 1 min lag time)
 	// enrolls with default periodic reporting until newer 5 min interval is confirmed
 	sendEvent(name: "checkInterval", value: 3 * 60 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
-}
-def configure() {
+
 	log.debug "Configuring Reporting, IAS CIE, and Bindings."
 
 	// temperature minReportTime 30 seconds, maxReportTime 5 min. Reporting interval if no activity

--- a/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
@@ -69,15 +69,6 @@ metadata {
 	}
 }
 
-def installed() {
-	log.debug "${device} installed"
-}
-
-def updated() {
-	log.debug "${device} updated"
-	configureHealthCheck()
-}
-
 def parse(String description) {
 	log.debug "description: $description"
 
@@ -277,13 +268,11 @@ def refresh()
 			zigbee.readAttribute(0x0001, 0x0020)
 }
 
-def configureHealthCheck() {
+def configure() {
 	// Device-Watch allows 3 check-in misses from device (plus 1 min lag time)
 	// enrolls with default periodic reporting until newer 5 min interval is confirmed
 	sendEvent(name: "checkInterval", value: 3 * 60 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
-}
 
-def configure() {
 	log.debug "Configuring Reporting and Bindings."
 	def humidityConfigCmds = [
 		"zdo bind 0x${device.deviceNetworkId} 1 1 0xFC45 {${device.zigbeeId}} {}", "delay 500",

--- a/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
@@ -48,15 +48,6 @@ metadata {
     }
 }
 
-def installed() {
-    log.debug "${device} installed"
-}
-
-def updated() {
-    log.debug "${device} updated"
-    configureHealthCheck()
-}
-
 // Parse incoming device messages to generate events
 def parse(String description) {
     log.debug "description is $description"
@@ -109,13 +100,12 @@ def refresh() {
     zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.onOffConfig(0, 300) + zigbee.levelConfig()
 }
 
-def configureHealthCheck() {
+def configure() {
+    log.debug "Configuring Reporting and Bindings."
     // Device-Watch allows 3 check-in misses from device (plus 1 min lag time)
     // enrolls with default periodic reporting until newer 5 min interval is confirmed
     sendEvent(name: "checkInterval", value: 3 * 10 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
-}
 
-def configure() {
     // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
     zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.onOffConfig(0, 300) + zigbee.levelConfig()
 }

--- a/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
@@ -70,16 +70,6 @@ metadata {
     }
 }
 
-
-def installed() {
-    log.debug "${device} installed"
-}
-
-def updated() {
-    log.debug "${device} updated"
-    configureHealthCheck()
-}
-
 //Globals
 private getATTRIBUTE_HUE() { 0x0000 }
 private getATTRIBUTE_SATURATION() { 0x0001 }
@@ -148,17 +138,16 @@ def ping() {
 }
 
 def refresh() {
-    // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
     zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_COLOR_TEMPERATURE) + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE) + zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION) + zigbee.onOffConfig(0, 300) + zigbee.levelConfig() + zigbee.colorTemperatureConfig() + zigbee.configureReporting(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE, 0x20, 1, 3600, 0x01) + zigbee.configureReporting(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION, 0x20, 1, 3600, 0x01)
 }
 
-def configureHealthCheck() {
+def configure() {
+    log.debug "Configuring Reporting and Bindings."
     // Device-Watch allows 3 check-in misses from device (plus 1 min lag time)
     // enrolls with default periodic reporting until newer 5 min interval is confirmed
     sendEvent(name: "checkInterval", value: 3 * 10 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
-}
 
-def configure() {
+    // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
     refresh()
 }
 

--- a/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
@@ -69,15 +69,6 @@ metadata {
     }
 }
 
-def installed() {
-    log.debug "${device} installed"
-}
-
-def updated() {
-    log.debug "${device} updated"
-    configureHealthCheck()
-}
-
 // Parse incoming device messages to generate events
 def parse(String description) {
     log.debug "description is $description"
@@ -130,17 +121,16 @@ def ping() {
 }
 
 def refresh() {
-    // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
     zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.colorTemperatureRefresh() + zigbee.onOffConfig(0, 300) + zigbee.levelConfig() + zigbee.colorTemperatureConfig()
 }
 
-def configureHealthCheck() {
+def configure() {
+    log.debug "Configuring Reporting and Bindings."
     // Device-Watch allows 3 check-in misses from device (plus 1 min lag time)
     // enrolls with default periodic reporting until newer 5 min interval is confirmed
     sendEvent(name: "checkInterval", value: 3 * 10 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
-}
 
-def configure() {
+    // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
     refresh()
 }
 


### PR DESCRIPTION
Reverts SmartThingsCommunity/SmartThingsPublic#1395

@tpmanley @mckeed 

We also need to revert this PR. If user updates Device preferences, `update()` gets called without the correct `checkInterval`. 

cc @mortent 