### PR TITLE
DPROT-200: Pass unhandled messages up to the cloud

### DIFF
--- a/devicetypes/smartthings/smartpower-dimming-outlet.src/smartpower-dimming-outlet.groovy
+++ b/devicetypes/smartthings/smartpower-dimming-outlet.src/smartpower-dimming-outlet.groovy
@@ -69,15 +69,17 @@ metadata {
 def parse(String description) {
 	log.debug "description is $description"
 
+	def event = [:]
 	def finalResult = isKnownDescription(description)
 	if (finalResult != "false") {
 		log.info finalResult
 		if (finalResult.type == "update") {
 			log.info "$device updates: ${finalResult.value}"
+			event = null
 		}
 		else if (finalResult.type == "power") {
 			def powerValue = (finalResult.value as Integer)/10
-			sendEvent(name: "power", value: powerValue)
+			event = createEvent(name: "power", value: powerValue)
 
 			/*
 				Dividing by 10 as the Divisor is 10000 and unit is kW for the device. AttrId: 0302 and 0300. Simplifying to 10
@@ -87,13 +89,14 @@ def parse(String description) {
 			*/
 		}
 		else {
-			sendEvent(name: finalResult.type, value: finalResult.value)
+			event = createEvent(name: finalResult.type, value: finalResult.value)
 		}
 	}
 	else {
 		log.warn "DID NOT PARSE MESSAGE for description : $description"
 		log.debug parseDescriptionAsMap(description)
 	}
+	return event
 }
 
 // Commands to device

--- a/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
+++ b/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
@@ -79,6 +79,7 @@ def parse(String description) {
 	log.debug "description is $description"
 
 	def finalResult = zigbee.getKnownDescription(description)
+	def event = [:]
 
 	//TODO: Remove this after getKnownDescription can parse it automatically
 	if (!finalResult && description!="updated")
@@ -88,10 +89,11 @@ def parse(String description) {
 		log.info "final result = $finalResult"
 		if (finalResult.type == "update") {
 			log.info "$device updates: ${finalResult.value}"
+			event = null
 		}
 		else if (finalResult.type == "power") {
 			def powerValue = (finalResult.value as Integer)/10
-			sendEvent(name: "power", value: powerValue, descriptionText: '{{ device.displayName }} power is {{ value }} Watts', translatable: true )
+			event = createEvent(name: "power", value: powerValue, descriptionText: '{{ device.displayName }} power is {{ value }} Watts', translatable: true)
 			/*
 				Dividing by 10 as the Divisor is 10000 and unit is kW for the device. AttrId: 0302 and 0300. Simplifying to 10
 				power level is an integer. The exact power level with correct units needs to be handled in the device type
@@ -100,7 +102,7 @@ def parse(String description) {
 		}
 		else {
 			def descriptionText = finalResult.value == "on" ? '{{ device.displayName }} is On' : '{{ device.displayName }} is Off'
-			sendEvent(name: finalResult.type, value: finalResult.value, descriptionText: descriptionText, translatable: true)
+			event = createEvent(name: finalResult.type, value: finalResult.value, descriptionText: descriptionText, translatable: true)
 		}
 	}
 	else {
@@ -109,10 +111,11 @@ def parse(String description) {
 		if (cluster && cluster.clusterId == 0x0006 && cluster.command == 0x07){
 			if (cluster.data[0] == 0x00) {
 				log.debug "ON/OFF REPORTING CONFIG RESPONSE: " + cluster
-				sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+				event = createEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
 			}
 			else {
 				log.warn "ON/OFF REPORTING CONFIG FAILED- error code:${cluster.data[0]}"
+				event = null
 			}
 		}
 		else {
@@ -120,6 +123,7 @@ def parse(String description) {
 			log.debug "${cluster}"
 		}
 	}
+	return event
 }
 
 def off() {

--- a/devicetypes/smartthings/smartsense-garage-door-multi.src/smartsense-garage-door-multi.groovy
+++ b/devicetypes/smartthings/smartsense-garage-door-multi.src/smartsense-garage-door-multi.groovy
@@ -86,7 +86,7 @@ metadata {
 
 def parse(String description) {
 	log.debug "parse($description)"
-	def results = null
+	def results = [:]
 
 	if (!isSupportedDescription(description) || zigbee.isZoneType19(description)) {
 		// Ignore this in favor of orientation-based state

--- a/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
@@ -102,7 +102,7 @@ def parse(String description) {
 	}
 
 	log.debug "Parse returned $map"
-	def result = map ? createEvent(map) : null
+	def result = map ? createEvent(map) : [:]
 
 	if (description?.startsWith('enroll request')) {
 		List cmds = enrollResponse()

--- a/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
@@ -106,7 +106,7 @@ def parse(String description) {
 	}
 
 	log.debug "Parse returned $map"
-	def result = map ? createEvent(map) : null
+	def result = map ? createEvent(map) : [:]
 
 	if (description?.startsWith('enroll request')) {
 		List cmds = enrollResponse()

--- a/devicetypes/smartthings/smartsense-motion-temp-sensor.src/smartsense-motion-temp-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-temp-sensor.src/smartsense-motion-temp-sensor.groovy
@@ -90,7 +90,7 @@ def parse(String description) {
     }
 
 	log.debug "Parse returned $map"
-	def result = map ? createEvent(map) : null
+	def result = map ? createEvent(map) : [:]
 
     if (description?.startsWith('enroll request')) {
     	List cmds = enrollResponse()

--- a/devicetypes/smartthings/smartsense-motion.src/smartsense-motion.groovy
+++ b/devicetypes/smartthings/smartsense-motion.src/smartsense-motion.groovy
@@ -44,7 +44,7 @@ metadata {
 }
 
 def parse(String description) {
-	def results
+	def results = [:]
 	if (isZoneType19(description) || !isSupportedDescription(description)) {
 		results = parseBasicMessage(description)
 	}
@@ -57,21 +57,25 @@ def parse(String description) {
 
 private Map parseBasicMessage(description) {
 	def name = parseName(description)
-	def value = parseValue(description)
-	def linkText = getLinkText(device)
-	def descriptionText = parseDescriptionText(linkText, value, description)
-	def handlerName = value
-	def isStateChange = isStateChange(device, name, value)
+	if (name != null) {
+		def value = parseValue(description)
+		def linkText = getLinkText(device)
+		def descriptionText = parseDescriptionText(linkText, value, description)
+		def handlerName = value
+		def isStateChange = isStateChange(device, name, value)
 
-	def results = [
-		name: name,
-		value: value,
-		linkText: linkText,
-		descriptionText: descriptionText,
-		handlerName: handlerName,
-		isStateChange: isStateChange,
-		displayed: displayed(description, isStateChange)
-	]
+		def results = [
+				name           : name,
+				value          : value,
+				linkText       : linkText,
+				descriptionText: descriptionText,
+				handlerName    : handlerName,
+				isStateChange  : isStateChange,
+				displayed      : displayed(description, isStateChange)
+		]
+	} else {
+		results = [:]
+	}
 	log.debug "Parse returned $results.descriptionText"
 	return results
 }

--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -127,7 +127,7 @@ def parse(String description) {
 		map = parseIasMessage(description)
 	}
 
-	def result = map ? createEvent(map) : null
+	def result = map ? createEvent(map) : [:]
 
 	if (description?.startsWith('enroll request')) {
 		List cmds = enrollResponse()

--- a/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
@@ -93,7 +93,7 @@ def parse(String description) {
     }
 
 	log.debug "Parse returned $map"
-	def result = map ? createEvent(map) : null
+	def result = map ? createEvent(map) : [:]
 
     if (description?.startsWith('enroll request')) {
     	List cmds = enrollResponse()

--- a/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
@@ -84,7 +84,7 @@ def parse(String description) {
 	}
 
 	log.debug "Parse returned $map"
-	return map ? createEvent(map) : null
+	return map ? createEvent(map) : [:]
 }
 
 private Map parseCatchAllMessage(String description) {


### PR DESCRIPTION
Currently these DTHs return null when they parse a message that they
don't have specific handling for.  This ends up sending the message up
to the cloud as an event, which prevented us from potentially parsing
that message in the cloud.  By instead returning an empty map we can
instead send the message up to the cloud to be parsed there.  This
allows us to add handling in the cloud for new message without requiring
and AppEngine deploy for them to work.

This resolves: https://smartthings.atlassian.net/browse/DPROT-200

@tpmanley 