### PR TITLE
[CHF-441] Added Health Check Implementation for WeMo LED Bulb

### DIFF
--- a/devicetypes/smartthings/zigbee-dimmer.src/README.md
+++ b/devicetypes/smartthings/zigbee-dimmer.src/README.md
@@ -1,10 +1,11 @@
-# OSRAM Lightify LED On/Off/Dim
+# Zigbee Dimmer
 
 
 
 Works with: 
 
 * [OSRAM Lightify LED On/Off/Dim](https://shop.smartthings.com/#!/products/osram-led-smart-bulb-on-off-dim)
+* [WeMo LED Bulb](https://support.smartthings.com/hc/en-us/articles/204259040-Belkin-WeMo-LED-Bulb-F7C033-)
 
 ## Table of contents
 
@@ -23,14 +24,16 @@ Works with:
 
 ## Device Health
 
-A Category C1 Zigbee dimmer with maxReportTime of 5 mins.
-Check-in interval is double the value of maxReportTime. 
+A Zigbee dimmer with maxReportTime of 5 mins.
+Check-in interval is double the value of maxReportTime.
 This gives the device twice the amount of time to respond before it is marked as offline.
-Check-in interval = 12 mins
+Enrolls with default periodic reporting until newer 5 min interval is confirmed
+It then enrolls the device with updated checkInterval i.e. 12 mins
 
 ## Troubleshooting
 
 If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
 Pairing needs to be tried again by placing the device closer to the hub.
 Other troubleshooting tips are listed as follows:
-* [Troubleshooting:](https://support.smartthings.com/hc/en-us/articles/207191763-OSRAM-LIGHTIFY-LED-Smart-Connected-Light-A19-On-Off-Dim)
+* [OSRAM Lightify LED On/Off/Dim Troubleshooting:](https://support.smartthings.com/hc/en-us/articles/207191763-OSRAM-LIGHTIFY-LED-Smart-Connected-Light-A19-On-Off-Dim)
+* [WeMo LED Bulb Troubleshooting:](https://support.smartthings.com/hc/en-us/articles/204259040-Belkin-WeMo-LED-Bulb-F7C033-)


### PR DESCRIPTION
@jackchi @ShunmugaSundar 
Tested with WeMo LED Bulb. 
Health Check was already implemented with CheckInterval (3 * 10 * 60 + 1 * 60) in configure().
But in the PR 1320 it was mentioned to keep the checkInterval to the older value (3 * 60 * 60 + 1 * 60) until DTH confirms that the newer config is successful.
Please confirm the changes and merge.