### PR TITLE
[CHF-454] [CHF-456] Implementation of HealthCheck for Leviton Switch DZS15-1LZ (Z-wave) and Leviton Outlet DZR15-1LZ (Z-wave)

### DIFF
--- a/devicetypes/smartthings/zwave-switch-generic.src/README.md
+++ b/devicetypes/smartthings/zwave-switch-generic.src/README.md
@@ -4,8 +4,10 @@
 
 Works with: 
 
-* [Leviton Appliance Module (DZPA1-1LW)](https://support.smartthings.com/hc/en-us/articles/205881176-Leviton-Appliance-Module-DZPA1-1LW-)
-* [GE Plug-In Outdoor Smart Switch (GE 12720) (Z-Wave)](https://support.smartthings.com/hc/en-us/articles/200903080-GE-Plug-In-Outdoor-Smart-Switch-GE-12720-Z-Wave-)
+* [Leviton Appliance Module (DZPA1-1LW)](https://www.smartthings.com/works-with-smartthings/outlets/leviton-appliance-module)
+* [GE Plug-In Outdoor Smart Switch (GE 12720) (Z-Wave)](https://www.smartthings.com/works-with-smartthings/outlets/ge-plug-in-outdoor-smart-switch)
+* [Leviton Outlet (DZR15-1LZ)](https://www.smartthings.com/works-with-smartthings/outlets/leviton-outlet)
+* [Leviton Switch (DZS15-1LZ)](https://www.smartthings.com/works-with-smartthings/switches-and-dimmers/leviton-switch)
 
 ## Table of contents
 
@@ -23,7 +25,7 @@ Works with:
 
 ## Device Health
 
-A Category C5 Leviton Appliance Module (DZPA1-1LW) and GE Plug-In Outdoor Smart Switch (GE 12720) (Z-Wave) polled by the hub.
+Leviton Appliance Module (DZPA1-1LW), GE Plug-In Outdoor Smart Switch (GE 12720), Leviton Outlet (DZR15-1LZ) and Leviton Switch (DZS15-1LZ) (Z-Wave) are polled by the hub.
 As of hubCore version 0.14.38 the hub sends up reports every 15 minutes regardless of whether the state changed.
 Device-Watch allows 2 check-in misses from device plus some lag time. So Check-in interval = (2*15 + 2)mins = 32 mins.
 Not to mention after going OFFLINE when the device is plugged back in, it might take a considerable amount of time for
@@ -35,5 +37,7 @@ it is not polled for 5 minutes by the hub. This can delay up the process of bein
 If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
 Pairing needs to be tried again by placing the device closer to the hub.
 Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following link:
-* [Leviton Appliance Module (DZPA1-1LW) Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/205881176-Leviton-Appliance-Module-DZPA1-1LW-)
+* [Leviton Appliance Module (DZPA1-1LW) Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/206171053-How-to-connect-Leviton-Z-Wave-devices)
 * [GE Plug-In Outdoor Smart Switch (GE 12720) (Z-Wave) Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/200903080-GE-Plug-In-Outdoor-Smart-Switch-GE-12720-Z-Wave-)
+* [Leviton Outlet (DZR15-1LZ) Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/206171053-How-to-connect-Leviton-Z-Wave-devices)
+* [Leviton Switch (DZS15-1LZ) Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/206171053-How-to-connect-Leviton-Z-Wave-devices)

--- a/devicetypes/smartthings/zwave-switch-generic.src/zwave-switch-generic.groovy
+++ b/devicetypes/smartthings/zwave-switch-generic.src/zwave-switch-generic.groovy
@@ -23,6 +23,8 @@ metadata {
 		fingerprint inClusters: "0x25", deviceJoinName: "Z-Wave Switch"
 		fingerprint mfr:"001D", prod:"1A02", model:"0334", deviceJoinName: "Leviton Appliance Module"
 		fingerprint mfr:"0063", prod:"4F50", model:"3031", deviceJoinName: "GE Plug-in Outdoor Switch"
+		fingerprint mfr:"001D", prod:"1D04", model:"0334", deviceJoinName: "Leviton Outlet"
+		fingerprint mfr:"001D", prod:"1C02", model:"0334", deviceJoinName: "Leviton Switch"
 	}
 
 	// simulator metadata


### PR DESCRIPTION
1. Added the fingerprint of the Leviton Switch DZS15-1LZ and Leviton Outlet DZR15-1LZ (Z-Wave) with the manufacturer, product code and model number obtained from the raw description after pairing.
2. Modified the deviceJoinName accordingly.
3. We've tested the checkInterval duration and the devices are marked OFFLINE within the stipulated time.
4. Modified the README.md file accordingly.
@jackchi  @ShunmugaSundar  Please check and merge the changes.