### PR TITLE
[CHF-455] Implementation of HealthCheck for Leviton Universal Dimmer DZMX1-LZ (Z-wave)

### DIFF
--- a/devicetypes/smartthings/zwave-dimmer-switch-generic.src/README.md
+++ b/devicetypes/smartthings/zwave-dimmer-switch-generic.src/README.md
@@ -4,7 +4,8 @@
 
 Works with: 
 
-* [Leviton Plug-in Lamp Dimmer Module (DZPD3-1LW)](http://www.leviton.com/OA_HTML/ProductDetail.jsp?partnumber=DZPD3-1LW)
+* [Leviton Plug-in Lamp Dimmer Module (DZPD3-1LW)](https://www.smartthings.com/works-with-smartthings/outlets/leviton-plug-in-lamp-dimmer-module)
+* [Leviton Universal Dimmer (DZMX1-LZ)](https://www.smartthings.com/works-with-smartthings/switches-and-dimmers/leviton-universal-dimmer)
 
 ## Table of contents
 
@@ -24,7 +25,7 @@ Works with:
 
 ## Device Health
 
-A Category C5 Leviton Plug-in Lamp Dimmer Module (DZPA1-1LW) (Z-Wave) polled by the hub.
+Leviton Plug-in Lamp Dimmer Module (DZPA1-1LW) (Z-wave) and Leviton Universal Dimmer (DZMX1-LZ) (Z-Wave) are polled by the hub.
 As of hubCore version 0.14.38 the hub sends up reports every 15 minutes regardless of whether the state changed.
 Device-Watch allows 2 check-in misses from device plus some lag time. So Check-in interval = (2*15 + 2)mins = 32 mins.
 Not to mention after going OFFLINE when the device is plugged back in, it might take a considerable amount of time for
@@ -37,3 +38,4 @@ If the device doesn't pair when trying from the SmartThings mobile app, it is po
 Pairing needs to be tried again by placing the device closer to the hub.
 Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following link:
 * [Leviton Plug-in Lamp Dimmer Module (DZPD3-1LW) Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/206171053-How-to-connect-Leviton-Z-Wave-devices)
+* [Leviton Universal Dimmer (DZMX1-LZ) Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/206171053-How-to-connect-Leviton-Z-Wave-devices)

--- a/devicetypes/smartthings/zwave-dimmer-switch-generic.src/zwave-dimmer-switch-generic.groovy
+++ b/devicetypes/smartthings/zwave-dimmer-switch-generic.src/zwave-dimmer-switch-generic.groovy
@@ -23,6 +23,7 @@ metadata {
 
 		fingerprint inClusters: "0x26", deviceJoinName: "Z-Wave Dimmer"
 		fingerprint mfr:"001D", prod:"1902", deviceJoinName: "Z-Wave Dimmer"
+		fingerprint mfr:"001D", prod:"1B03", model:"0334", deviceJoinName: "Leviton Universal Dimmer"
 	}
 
 	simulator {


### PR DESCRIPTION
1. Added the fingerprint of Leviton Universal Dimmer DZMX1-LZ (Z-wave) with the manufacturer, product code and model number obtained from the raw description after pairing.
2. Modified the deviceJoinName accordingly.
3. We've tested the checkInterval duration and the device is marked OFFLINE within the stipulated time.
4. Modified the README.md file accordingly.
@jackchi @ShunmugaSundar Please check and merge the changes.