### PR TITLE
DVCSMP-2219: GE Link: fixed problem creating level events

### DIFF
--- a/devicetypes/smartthings/ge-link-bulb.src/ge-link-bulb.groovy
+++ b/devicetypes/smartthings/ge-link-bulb.src/ge-link-bulb.groovy
@@ -87,7 +87,7 @@ metadata {
 def parse(String description) {
     def resultMap = zigbee.getEvent(description)
     if (resultMap) {
-        if ((resultMap.name == "level" && state.trigger == "setLevel") || resultMap.name != "level") {  //doing this to account for weird level reporting bug with GE Link Bulbs
+        if (resultMap.name != "level" || resultMap.value != 0) {  // Ignore level reports of 0 sent when bulb turns off
             sendEvent(resultMap)
         }
     }
@@ -188,12 +188,10 @@ def updated() {
 }
 
 def on() {
-    state.trigger = "on/off"
     zigbee.on()
 }
 
 def off() {
-    state.trigger = "on/off"
     zigbee.off()
 }
 
@@ -206,7 +204,6 @@ def refresh() {
 }
 
 def setLevel(value) {
-    state.trigger = "setLevel"
     def cmd
     def delayForRefresh = 500
     if (dimRate && (state?.rate != null)) {


### PR DESCRIPTION
The bug causing level events not to be created happens when the setLevel
command runs in the cloud but the Device Type Handler is running locally
in the hub. Since state is not synced from the cloud to the hub the
`state.trigger` value was never set to `"setLevel"` on the hub which means
no level events would be created. The change is to not be reliant on state.
Instead we just don't create level events if the level is 0 since there is
no legitimate way for the level to be 0.

https://smartthings.atlassian.net/browse/DVCSMP-2219