### PR TITLE
[DVCSMP-2175] Do not delete all binding table entries

### DIFF
--- a/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
@@ -88,7 +88,7 @@ def parse(String description) {
             List<String> cmds = []
             bindingTable.table_entries.inject(cmds) { acc, entry ->
                 // The binding entry is not for our hub and should be deleted
-                if (entry["dstAddr"] != zigbeeEui) {
+                if (entry["dstAddr"] != zigbee.zigbeeEui) {
                     acc.addAll(removeBinding(entry.clusterId, entry.srcAddr, entry.srcEndpoint, entry.dstAddr, entry.dstEndpoint))
                 }
                 acc


### PR DESCRIPTION
There was a bug when comparing the destination address for binding table
entries that would cause all binding table entries to be deleted.  This
fixes that.

This is a fix for: https://smartthings.atlassian.net/browse/DVCSMP-2175

@tpmanley @workingmonk 