### PR TITLE
PROB-1428 zll-dimmer-bulb: Fix bug in configure preventing devices from joining

### DIFF
--- a/devicetypes/smartthings/zll-dimmer-bulb.src/zll-dimmer-bulb.groovy
+++ b/devicetypes/smartthings/zll-dimmer-bulb.src/zll-dimmer-bulb.groovy
@@ -127,8 +127,8 @@ def configureHealthCheck() {
 
 def configure() {
     log.debug "configure()"
-    zigbee.onOffConfig() + zigbee.levelConfig() + zigbee.onOffRefresh() + zigbee.levelRefresh()
     configureHealthCheck()
+    zigbee.onOffConfig() + zigbee.levelConfig() + zigbee.onOffRefresh() + zigbee.levelRefresh()
 }
 
 def updated() {


### PR DESCRIPTION
The configureHealthCheck method and therefore the configure method was
returning a boolean which was causing an exception during the initial
join that would prevent the device from showing up to the user.

https://smartthings.atlassian.net/browse/PROB-1428