### PR TITLE
DPROT-215 Don't use sendEvent for AppEngine parse events

### DIFF
--- a/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
@@ -128,7 +128,7 @@ private Map parseCatchAllMessage(String description) {
 				if (cluster.command == 0x07) {
 					if (cluster.data[0] == 0x00){
 						log.debug "TEMP REPORTING CONFIG RESPONSE" + cluster
-						sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+						resultMap = [name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID]]
 					}
 					else {
 						log.warn "TEMP REPORTING CONFIG FAILED- error code:${cluster.data[0]}"

--- a/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
@@ -132,7 +132,7 @@ private Map parseCatchAllMessage(String description) {
 				if (cluster.command == 0x07) {
 					if (cluster.data[0] == 0x00) {
 						log.debug "TEMP REPORTING CONFIG RESPONSE" + cluster
-						sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+						resultMap = [name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID]]
 					}
 					else {
 						log.warn "TEMP REPORTING CONFIG FAILED- error code:${cluster.data[0]}"

--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -161,7 +161,7 @@ private Map parseCatchAllMessage(String description) {
 				if (cluster.command == 0x07) {
 					if(cluster.data[0] == 0x00) {
 						log.debug "TEMP REPORTING CONFIG RESPONSE" + cluster
-						sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+						resultMap = [name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID]]
 					}
 					else {
 						log.warn "TEMP REPORTING CONFIG FAILED- error code:${cluster.data[0]}"
@@ -339,7 +339,7 @@ private Map getContactResult(value) {
 	log.debug "Contact: ${device.displayName} value = ${value}"
 	def descriptionText = value == 'open' ? '{{ device.displayName }} was opened' : '{{ device.displayName }} was closed'
 	sendEvent(name: 'contact', value: value, descriptionText: descriptionText, displayed: false, translatable: true)
-	sendEvent(name: 'status', value: value, descriptionText: descriptionText, translatable: true)
+	return [name: 'status', value: value, descriptionText: descriptionText, translatable: true]
 }
 
 private getAccelerationResult(numValue) {

--- a/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
@@ -119,7 +119,7 @@ private Map parseCatchAllMessage(String description) {
 				if (cluster.command == 0x07){
 					if (cluster.data[0] == 0x00) {
 						log.debug "TEMP REPORTING CONFIG RESPONSE" + cluster
-						sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+						resultMap = [name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID]]
 					}
 					else {
 						log.warn "TEMP REPORTING CONFIG FAILED- error code:${cluster.data[0]}"

--- a/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
@@ -103,7 +103,7 @@ private Map parseCatchAllMessage(String description) {
 				if (cluster.command == 0x07) {
 					if (cluster.data[0] == 0x00){
 						log.debug "TEMP REPORTING CONFIG RESPONSE" + cluster
-						sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+						resultMap = [name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID]]
 					}
 					else {
 						log.warn "TEMP REPORTING CONFIG FAILED- error code:${cluster.data[0]}"


### PR DESCRIPTION
With the changes made for
https://smartthings.atlassian.net/browse/DPROT-200 there were a few DTHs
that were using sendEvent to directly send events generated during
parse.  However, because using sendEvent didn't result in parse
returning an event AppEngine would send the description up to the cloud
DTH to be handled.  In some cases this resulted in multiple events for
the same device trigger.

This resolves: https://smartthings.atlassian.net/browse/DPROT-215

@tpmanley @workingmonk 