### PR TITLE
[DPROT-167] Remove calls to ZoneType19 methods

### DIFF
--- a/devicetypes/smartthings/open-closed-sensor.src/open-closed-sensor.groovy
+++ b/devicetypes/smartthings/open-closed-sensor.src/open-closed-sensor.groovy
@@ -40,14 +40,11 @@ metadata {
 
 // Parse incoming device messages to generate events
 def parse(String description) {
-	def name = null
-	def value = description
-	if (zigbee.isZoneType19(description)) {
-		name = "contact"
-		value = zigbee.translateStatusZoneType19(description) ? "open" : "closed"
+	def resMap
+	if (description.startsWith("zone")) {
+		resMap = createEvent(name: "contact", value: zigbee.parseZoneStatus(description).isAlarm1Set() ? "open" : "closed")
 	}
 	
-	def result = createEvent(name: name, value: value)
-	log.debug "Parse returned ${result?.descriptionText}"
-	return result
+	log.debug "Parse returned $resMap"
+	return resMap
 }

--- a/devicetypes/smartthings/smartsense-garage-door-multi.src/smartsense-garage-door-multi.groovy
+++ b/devicetypes/smartthings/smartsense-garage-door-multi.src/smartsense-garage-door-multi.groovy
@@ -88,7 +88,7 @@ def parse(String description) {
 	log.debug "parse($description)"
 	def results = [:]
 
-	if (!isSupportedDescription(description) || zigbee.isZoneType19(description)) {
+	if (!isSupportedDescription(description) || description.startsWith("zone")) {
 		// Ignore this in favor of orientation-based state
 		// results = parseSingleMessage(description)
 	}

--- a/devicetypes/smartthings/smartsense-garage-door-sensor-button.src/smartsense-garage-door-sensor-button.groovy
+++ b/devicetypes/smartthings/smartsense-garage-door-sensor-button.src/smartsense-garage-door-sensor-button.groovy
@@ -117,7 +117,7 @@ def parse(String description) {
 	log.debug "parse($description)"
 	def results = null
 
-	if (!isSupportedDescription(description) || zigbee.isZoneType19(description)) {
+	if (!isSupportedDescription(description) || description.startsWith("zone")) {
 		// Ignore this in favor of orientation-based state
 		// results = parseSingleMessage(description)
 	}

--- a/devicetypes/smartthings/smartsense-motion.src/smartsense-motion.groovy
+++ b/devicetypes/smartthings/smartsense-motion.src/smartsense-motion.groovy
@@ -45,7 +45,7 @@ metadata {
 
 def parse(String description) {
 	def results = [:]
-	if (isZoneType19(description) || !isSupportedDescription(description)) {
+	if (description.startsWith("zone") || !isSupportedDescription(description)) {
 		results = parseBasicMessage(description)
 	}
 	else if (isMotionStatusMessage(description)){
@@ -87,16 +87,12 @@ private String parseName(String description) {
 }
 
 private String parseValue(String description) {
-	if (isZoneType19(description)) {
-		if (translateStatusZoneType19(description)) {
-			return "active"
-		}
-		else {
-			return "inactive"
-		}
+	def zs = zigbee.parseZoneStatus(description)
+	if (zs) {
+		zs.isAlarm1Set() ? "active" : "inactive"
+	} else {
+		description
 	}
-
-	description
 }
 
 private parseDescriptionText(String linkText, String value, String description) {

--- a/devicetypes/smartthings/smartsense-multi.src/smartsense-multi.groovy
+++ b/devicetypes/smartthings/smartsense-multi.src/smartsense-multi.groovy
@@ -86,7 +86,7 @@ metadata {
 def parse(String description) {
 	def results
 
-	if (!isSupportedDescription(description) || zigbee.isZoneType19(description)) {
+	if (!isSupportedDescription(description) || description.startsWith("zone")) {
 		results = parseSingleMessage(description)
 	}
 	else if (description == 'updated') {
@@ -488,12 +488,7 @@ private String parseValue(String description) {
 	if (!isSupportedDescription(description)) {
 		return description
 	}
-	else if (zigbee.translateStatusZoneType19(description)) {
-		return "open"
-	}
-	else {
-		return "closed"
-	}
+	return zigbee.parseZoneStatus(description)?.isAlarm1Set() ? "open" : "closed"
 }
 
 private parseDescriptionText(String linkText, String value, String description) {

--- a/devicetypes/smartthings/smartsense-virtual-open-closed.src/smartsense-virtual-open-closed.groovy
+++ b/devicetypes/smartthings/smartsense-virtual-open-closed.src/smartsense-virtual-open-closed.groovy
@@ -96,7 +96,7 @@ metadata {
 def parse(String description) {
 	def results
 
-	if (!isSupportedDescription(description) || zigbee.isZoneType19(description)) {
+	if (!isSupportedDescription(description) || description.startsWith("zone")) {
 		// Ignore this in favor of orientation-based state
 		// results = parseSingleMessage(description)
 	}


### PR DESCRIPTION
We want to move toward the deprecation of these methods, and it starts
with the removal of calls to those methods from our DTHs.

This relates to: https://smartthings.atlassian.net/browse/DPROT-167

@tpmanley @workingmonk 