### PR TITLE
Update wattvision-manager.groovy to prevent UI error

### DIFF
--- a/smartapps/smartthings/wattvision-manager.src/wattvision-manager.groovy
+++ b/smartapps/smartthings/wattvision-manager.src/wattvision-manager.groovy
@@ -161,7 +161,7 @@ def wattvisionURL(senorId, startDate, endDate) {
 	}
 
 	def diff = endDate.getTime() - startDate.getTime()
-	if (diff > 259200000) { // 3 days in milliseconds
+	if (diff > 10800000) { // 3 hours in milliseconds
 		// Wattvision only allows pulling 3 hours of data at a time
 		startDate = new Date(hours: endDate.hours - 3)
 	}


### PR DESCRIPTION
UI is erroring due to invalid math on 3 hour millisecond calculation.