### PR TITLE
[CHF-486] Implementation of HealthCheck for Fortrezz MIMOLite

### DIFF
--- a/devicetypes/smartthings/mimolite-garage-door-controller.src/mimolite-garage-door-controller.groovy
+++ b/devicetypes/smartthings/mimolite-garage-door-controller.src/mimolite-garage-door-controller.groovy
@@ -32,6 +32,7 @@ metadata {
 	// Automatically generated. Make future change here.
 	definition (name: "MimoLite Garage Door Controller", namespace: "smartthings", author: "Todd Wackford") {
 		capability "Configuration"
+		capability "Health Check"
 		capability "Polling"
 		capability "Switch"
 		capability "Refresh"
@@ -43,6 +44,7 @@ metadata {
 		command "off"
         
         fingerprint deviceId: "0x1000", inClusters: "0x72,0x86,0x71,0x30,0x31,0x35,0x70,0x85,0x25,0x03"
+		fingerprint mfr:"0084", prod:"0453", model:"0111", deviceJoinName: "MIMOLite"
 	}
 
 	simulator {
@@ -77,6 +79,16 @@ metadata {
 		main (["switch", "contact"])
 		details(["switch", "powered", "refresh", "configure"])
 	}
+}
+
+def installed(){
+// Device-Watch simply pings if no device events received for checkInterval duration of 32min = 2 * 15min + 2min lag time
+	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
+}
+
+def updated(){
+// Device-Watch simply pings if no device events received for checkInterval duration of 32min = 2 * 15min + 2min lag time
+	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 }
 
 def parse(String description) {
@@ -168,6 +180,13 @@ def off() {
 
 def poll() {
 	zwave.switchBinaryV1.switchBinaryGet().format()
+}
+
+/**
+ * PING is used by Device-Watch in attempt to reach the Device
+ * */
+def ping() {
+	refresh()
 }
 
 def refresh() {


### PR DESCRIPTION
1. Added health check for Fortrezz MIMOLite (Z-Wave).
2. 'checkInterval' is kept at 32min.
3. Ping is implemented using refresh().
4. Added the fingerprint of Fortrezz MIMOLite (Z-Wave) with the manufacturer, product code and model number obtained from the raw description after pairing.
5. Modified the deviceJoinName accordingly.
6. We've tested the checkInterval duration and the devices are marked OFFLINE within the stipulated time.
@jackchi @ShunmugaSundar Please check and merge the changes.