### PR TITLE
[CHF-477] Health Check for Z-Wave Dimmer Switch Generic

### DIFF
--- a/devicetypes/smartthings/zwave-dimmer-switch-generic.src/zwave-dimmer-switch-generic.groovy
+++ b/devicetypes/smartthings/zwave-dimmer-switch-generic.src/zwave-dimmer-switch-generic.groovy
@@ -24,6 +24,10 @@ metadata {
 		fingerprint inClusters: "0x26", deviceJoinName: "Z-Wave Dimmer"
 		fingerprint mfr:"001D", prod:"1902", deviceJoinName: "Z-Wave Dimmer"
 		fingerprint mfr:"001D", prod:"1B03", model:"0334", deviceJoinName: "Leviton Universal Dimmer"
+		fingerprint mfr:"011A", prod:"0102", model:"0201", deviceJoinName: "Enerwave In-Wall Dimmer"
+		fingerprint mfr:"001D", prod:"1001", model:"0334", deviceJoinName: "Leviton 3-Speed Fan Controller"
+		fingerprint mfr:"001D", prod:"0602", model:"0334", deviceJoinName: "Leviton Magnetic Low Voltage Dimmer"
+		fingerprint mfr:"001D", prod:"0401", model:"0334", deviceJoinName: "Leviton 600W Incandescent Dimmer"
 	}
 
 	simulator {


### PR DESCRIPTION
Health Check implementation for Z-Wave Dimmer Switch Generic with checkinterval of 32min for following devices:

1. Leviton 600W Incandescent Dimmer
2. Leviton Magnetic Low Voltage Dimmer
3. Leviton 3-Speed Fan Controller
4. Enerwave In-Wall Dimmer (ZW500D)