### PR TITLE
[CHF-488] [CHF-489] [CHF-490] Implementation of HealthCheck for Enerwave Duplex Receptacle ZW15R, Enerwave On/Off Switch ZW15S and Leviton 15A Switch VRS15-1LZ

### DIFF
--- a/devicetypes/smartthings/zwave-switch-generic.src/zwave-switch-generic.groovy
+++ b/devicetypes/smartthings/zwave-switch-generic.src/zwave-switch-generic.groovy
@@ -25,6 +25,9 @@ metadata {
 		fingerprint mfr:"0063", prod:"4F50", model:"3031", deviceJoinName: "GE Plug-in Outdoor Switch"
 		fingerprint mfr:"001D", prod:"1D04", model:"0334", deviceJoinName: "Leviton Outlet"
 		fingerprint mfr:"001D", prod:"1C02", model:"0334", deviceJoinName: "Leviton Switch"
+		fingerprint mfr:"001D", prod:"0301", model:"0334", deviceJoinName: "Leviton 15A Switch"
+		fingerprint mfr:"011A", prod:"0101", model:"0102", deviceJoinName: "Enerwave On/Off Switch"
+		fingerprint mfr:"011A", prod:"0101", model:"0603", deviceJoinName: "Enerwave Duplex Receptacle"
 	}
 
 	// simulator metadata


### PR DESCRIPTION
1. Added the fingerprint of 
a) Enerwave Duplex Receptacle ZW15R (Z-Wave) 
b) Enerwave On/Off Switch ZW15S (Z-Wave) 
c) Leviton 15A Switch VRS15-1LZ (Z-Wave) 
with the manufacturer, product code and model number obtained from the raw description after pairing.
2. Modified the deviceJoinName accordingly based on the Works With SmartThings names.
3. 'checkInterval' is kept at 32min.
4. Ping is implemented using refresh().
5. We've tested the checkInterval duration and the devices are marked OFFLINE within the stipulated time.
@jackchi @ShunmugaSundar Please check and merge the changes.