### PR TITLE
DPROT-223 Increase zigbee message delays

### DIFF
--- a/devicetypes/smartthings/ge-link-bulb.src/ge-link-bulb.groovy
+++ b/devicetypes/smartthings/ge-link-bulb.src/ge-link-bulb.groovy
@@ -99,7 +99,7 @@ def parse(String description) {
 
 def poll() {
     def refreshCmds = [
-        "st wattr 0x${device.deviceNetworkId} 1 8 0x10 0x21 {${state?.dOnOff ?: '0000'}}", "delay 500"
+        "st wattr 0x${device.deviceNetworkId} 1 8 0x10 0x21 {${state?.dOnOff ?: '0000'}}", "delay 2000"
     ]
 
     return refreshCmds + zigbee.onOffRefresh() + zigbee.levelRefresh()
@@ -197,7 +197,7 @@ def off() {
 
 def refresh() {
     def refreshCmds = [
-        "st wattr 0x${device.deviceNetworkId} 1 8 0x10 0x21 {${state?.dOnOff ?: '0000'}}", "delay 500"
+        "st wattr 0x${device.deviceNetworkId} 1 8 0x10 0x21 {${state?.dOnOff ?: '0000'}}", "delay 2000"
     ]
 
     return refreshCmds + zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.onOffConfig()

--- a/devicetypes/smartthings/smartpower-dimming-outlet.src/smartpower-dimming-outlet.groovy
+++ b/devicetypes/smartthings/smartpower-dimming-outlet.src/smartpower-dimming-outlet.groovy
@@ -128,9 +128,9 @@ def setLevel(value) {
 
 def refresh() {
 	[
-			"st rattr 0x${device.deviceNetworkId} ${endpointId} 6 0", "delay 500",
-			"st rattr 0x${device.deviceNetworkId} ${endpointId} 8 0", "delay 500",
-			"st rattr 0x${device.deviceNetworkId} ${endpointId} 0x0B04 0x050B", "delay 500"
+			"st rattr 0x${device.deviceNetworkId} ${endpointId} 6 0", "delay 2000",
+			"st rattr 0x${device.deviceNetworkId} ${endpointId} 8 0", "delay 2000",
+			"st rattr 0x${device.deviceNetworkId} ${endpointId} 0x0B04 0x050B", "delay 2000"
 	]
 
 }
@@ -313,9 +313,9 @@ def isDescriptionPower(descMap) {
 
 def onOffConfig() {
 	[
-			"zdo bind 0x${device.deviceNetworkId} 1 ${endpointId} 6 {${device.zigbeeId}} {}", "delay 200",
-			"zcl global send-me-a-report 6 0 0x10 0 600 {01}",
-			"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 1500"
+			"zdo bind 0x${device.deviceNetworkId} 1 ${endpointId} 6 {${device.zigbeeId}} {}", "delay 2000",
+			"zcl global send-me-a-report 6 0 0x10 0 600 {01}", "delay 200",
+			"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 2000"
 	]
 }
 
@@ -323,9 +323,9 @@ def onOffConfig() {
 //min level change is 01
 def levelConfig() {
 	[
-			"zdo bind 0x${device.deviceNetworkId} 1 ${endpointId} 8 {${device.zigbeeId}} {}", "delay 200",
-			"zcl global send-me-a-report 8 0 0x20 5 3600 {01}",
-			"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 1500"
+			"zdo bind 0x${device.deviceNetworkId} 1 ${endpointId} 8 {${device.zigbeeId}} {}", "delay 2000",
+			"zcl global send-me-a-report 8 0 0x20 5 3600 {01}", "delay 200",
+			"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 2000"
 	]
 }
 
@@ -333,9 +333,10 @@ def levelConfig() {
 //min change in value is 05
 def powerConfig() {
 	[
-		"zdo bind 0x${device.deviceNetworkId} 1 ${endpointId} 0x0B04 {${device.zigbeeId}} {}", "delay 200",
+		"zdo bind 0x${device.deviceNetworkId} 1 ${endpointId} 0x0B04 {${device.zigbeeId}} {}", "delay 2000",
 		"zcl global send-me-a-report 0x0B04 0x050B 0x29 1 600 {05 00}",				//The send-me-a-report is custom to the attribute type for CentraLite
-		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 500"
+		"delay 200",
+		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 2000"
 	]
 }
 
@@ -344,7 +345,10 @@ def setLevelWithRate(level, rate) {
 		rate = "0000"
 	}
 	level = convertToHexString(level * 255 / 100) 				//Converting the 0-100 range to 0-FF range in hex
-	"st cmd 0x${device.deviceNetworkId} ${endpointId} 8 4 {$level $rate}"
+	[
+			"st cmd 0x${device.deviceNetworkId} ${endpointId} 8 4 {$level $rate}",
+			"delay 2000"
+	]
 }
 
 String convertToHexString(value, width=2) {

--- a/devicetypes/smartthings/smartpower-outlet-v1.src/smartpower-outlet-v1.groovy
+++ b/devicetypes/smartthings/smartpower-outlet-v1.src/smartpower-outlet-v1.groovy
@@ -51,7 +51,7 @@ def on() {
 			'zcl on-off on',
 			'delay 200',
 			"send 0x${zigbee.deviceNetworkId} 0x01 0x${zigbee.endpointId}",
-			'delay 500'
+			'delay 2000'
 
 	]
 
@@ -62,6 +62,6 @@ def off() {
 			'zcl on-off off',
 			'delay 200',
 			"send 0x${zigbee.deviceNetworkId} 0x01 0x${zigbee.endpointId}",
-			'delay 500'
+			'delay 2000'
 	]
 }

--- a/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
+++ b/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
@@ -157,9 +157,10 @@ def configure() {
 //min change in value is 01
 def powerConfig() {
 	[
-		"zdo bind 0x${device.deviceNetworkId} 1 ${endpointId} 0x0B04 {${device.zigbeeId}} {}", "delay 200",
+		"zdo bind 0x${device.deviceNetworkId} 1 ${endpointId} 0x0B04 {${device.zigbeeId}} {}", "delay 2000",
 		"zcl global send-me-a-report 0x0B04 0x050B 0x29 1 600 {05 00}",				//The send-me-a-report is custom to the attribute type for CentraLite
-		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 500"
+		"delay 200",
+		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 2000"
 	]
 }
 

--- a/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
@@ -285,8 +285,8 @@ def ping() {
 def refresh() {
 	log.debug "Refreshing Temperature and Battery"
 	def refreshCmds = [
-		"st rattr 0x${device.deviceNetworkId} 1 0x402 0", "delay 200",
-		"st rattr 0x${device.deviceNetworkId} 1 1 0x20", "delay 200"
+		"st rattr 0x${device.deviceNetworkId} 1 0x402 0", "delay 2000",
+		"st rattr 0x${device.deviceNetworkId} 1 1 0x20", "delay 2000"
 	]
 
 	return refreshCmds + enrollResponse()
@@ -308,10 +308,10 @@ def enrollResponse() {
 	[
 		//Resending the CIE in case the enroll request is sent before CIE is written
 		"zcl global write 0x500 0x10 0xf0 {${zigbeeEui}}", "delay 200",
-		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 500",
+		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 2000",
 		//Enroll Response
-		"raw 0x500 {01 23 00 00 00}",
-		"send 0x${device.deviceNetworkId} 1 1", "delay 200"
+		"raw 0x500 {01 23 00 00 00}", "delay 200",
+		"send 0x${device.deviceNetworkId} 1 1", "delay 2000"
 	]
 }
 

--- a/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
@@ -298,8 +298,8 @@ def ping() {
 def refresh() {
 	log.debug "refresh called"
 	def refreshCmds = [
-		"st rattr 0x${device.deviceNetworkId} 1 0x402 0", "delay 200",
-		"st rattr 0x${device.deviceNetworkId} 1 1 0x20", "delay 200"
+		"st rattr 0x${device.deviceNetworkId} 1 0x402 0", "delay 2000",
+		"st rattr 0x${device.deviceNetworkId} 1 1 0x20", "delay 2000"
 	]
 
 	return refreshCmds + enrollResponse()
@@ -321,10 +321,10 @@ def enrollResponse() {
 	[
 		//Resending the CIE in case the enroll request is sent before CIE is written
 		"zcl global write 0x500 0x10 0xf0 {${zigbeeEui}}", "delay 200",
-		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 500",
+		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 2000",
 		//Enroll Response
-		"raw 0x500 {01 23 00 00 00}",
-		"send 0x${device.deviceNetworkId} 1 1", "delay 200"
+		"raw 0x500 {01 23 00 00 00}", "delay 200",
+		"send 0x${device.deviceNetworkId} 1 1", "delay 2000"
 	]
 }
 

--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -428,10 +428,10 @@ def enrollResponse() {
 	[
 		//Resending the CIE in case the enroll request is sent before CIE is written
 		"zcl global write 0x500 0x10 0xf0 {${zigbeeEui}}", "delay 200",
-		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 500",
+		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 2000",
 		//Enroll Response
 		"raw 0x500 {01 23 00 00 00}", "delay 200",
-		"send 0x${device.deviceNetworkId} 1 1", "delay 200"
+		"send 0x${device.deviceNetworkId} 1 1", "delay 2000"
 	]
 }
 

--- a/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
@@ -252,8 +252,8 @@ def ping() {
 def refresh() {
 	log.debug "Refreshing Temperature and Battery"
 	def refreshCmds = [
-        "st rattr 0x${device.deviceNetworkId} 1 0x402 0", "delay 200",
-		"st rattr 0x${device.deviceNetworkId} 1 1 0x20", "delay 200"
+        "st rattr 0x${device.deviceNetworkId} 1 0x402 0", "delay 2000",
+		"st rattr 0x${device.deviceNetworkId} 1 1 0x20", "delay 2000"
 	]
 
 	return refreshCmds + enrollResponse()
@@ -277,10 +277,10 @@ def enrollResponse() {
 	[
 		//Resending the CIE in case the enroll request is sent before CIE is written
 		"zcl global write 0x500 0x10 0xf0 {${zigbeeEui}}", "delay 200",
-		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 500",
+		"send 0x${device.deviceNetworkId} 1 ${endpointId}", "delay 2000",
 		//Enroll Response
-		"raw 0x500 {01 23 00 00 00}",
-		"send 0x${device.deviceNetworkId} 1 1", "delay 200"
+		"raw 0x500 {01 23 00 00 00}", "delay 200",
+		"send 0x${device.deviceNetworkId} 1 1", "delay 2000"
 	]
 }
 

--- a/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
@@ -270,9 +270,9 @@ def configure() {
 
 	log.debug "Configuring Reporting and Bindings."
 	def humidityConfigCmds = [
-		"zdo bind 0x${device.deviceNetworkId} 1 1 0xFC45 {${device.zigbeeId}} {}", "delay 500",
-		"zcl global send-me-a-report 0xFC45 0 0x29 30 3600 {6400}",
-		"send 0x${device.deviceNetworkId} 1 1", "delay 500"
+		"zdo bind 0x${device.deviceNetworkId} 1 1 0xFC45 {${device.zigbeeId}} {}", "delay 2000",
+		"zcl global send-me-a-report 0xFC45 0 0x29 30 3600 {6400}", "delay 200",
+		"send 0x${device.deviceNetworkId} 1 1", "delay 2000"
 	]
 
 	// temperature minReportTime 30 seconds, maxReportTime 5 min. Reporting interval if no activity


### PR DESCRIPTION
This changes our smartsense DTHs that don't use the ZigBee library for
everything to have larger delays between ZigBee messages.  This is to
reduce the network load to try to work around some of the poorer
behaving ZigBee routers we support.

This resolves: https://smartthings.atlassian.net/browse/DPROT-223

@tpmanley @workingmonk 