### PR TITLE
[DPROT-227, DPROT-228] Read on/off status for bulbs that don't report

### DIFF
--- a/devicetypes/smartthings/cree-bulb.src/cree-bulb.groovy
+++ b/devicetypes/smartthings/cree-bulb.src/cree-bulb.groovy
@@ -74,15 +74,15 @@ def parse(String description) {
 }
 
 def off() {
-    zigbee.off()
+    zigbee.off() + ["delay 500"] + zigbee.onOffRefresh()
 }
 
 def on() {
-    zigbee.on()
+    zigbee.on() + ["delay 500"] + zigbee.onOffRefresh()
 }
 
 def setLevel(value) {
-    zigbee.setLevel(value) + ["delay 500"] + zigbee.levelRefresh()         //adding refresh because of ZLL bulb not conforming to send-me-a-report
+    zigbee.setLevel(value) + ["delay 500"] + zigbee.levelRefresh() + zigbee.onOffRefresh()        //adding refresh because of ZLL bulb not conforming to send-me-a-report
 }
 
 /**

--- a/devicetypes/smartthings/zll-dimmer-bulb.src/zll-dimmer-bulb.groovy
+++ b/devicetypes/smartthings/zll-dimmer-bulb.src/zll-dimmer-bulb.groovy
@@ -89,7 +89,7 @@ def on() {
 }
 
 def setLevel(value) {
-    zigbee.setLevel(value) + ["delay 1500"] + zigbee.levelRefresh()         //adding refresh because of ZLL bulb not conforming to send-me-a-report
+    zigbee.setLevel(value) + ["delay 1500"] + zigbee.levelRefresh() + zigbee.onOffRefresh()         //adding refresh because of ZLL bulb not conforming to send-me-a-report
 }
 
 def refresh() {

--- a/devicetypes/smartthings/zll-rgb-bulb.src/zll-rgb-bulb.groovy
+++ b/devicetypes/smartthings/zll-rgb-bulb.src/zll-rgb-bulb.groovy
@@ -115,7 +115,7 @@ def refreshAttributes() {
 }
 
 def setLevel(value) {
-	zigbee.setLevel(value) + ["delay 1500"] + zigbee.levelRefresh()         //adding refresh because of ZLL bulb not conforming to send-me-a-report
+	zigbee.setLevel(value) + ["delay 1500"] + zigbee.levelRefresh() + zigbee.onOffRefresh()         //adding refresh because of ZLL bulb not conforming to send-me-a-report
 }
 
 def setColor(value){

--- a/devicetypes/smartthings/zll-rgbw-bulb.src/zll-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zll-rgbw-bulb.src/zll-rgbw-bulb.groovy
@@ -135,7 +135,7 @@ def setColorTemperature(value) {
 }
 
 def setLevel(value) {
-    zigbee.setLevel(value) + ["delay 1500"] + zigbee.levelRefresh()         //adding refresh because of ZLL bulb not conforming to send-me-a-report
+    zigbee.setLevel(value) + ["delay 1500"] + zigbee.levelRefresh() + zigbee.onOffRefresh()         //adding refresh because of ZLL bulb not conforming to send-me-a-report
 }
 
 def setColor(value){

--- a/devicetypes/smartthings/zll-white-color-temperature-bulb.src/zll-white-color-temperature-bulb.groovy
+++ b/devicetypes/smartthings/zll-white-color-temperature-bulb.src/zll-white-color-temperature-bulb.groovy
@@ -90,7 +90,7 @@ def on() {
 }
 
 def setLevel(value) {
-    zigbee.setLevel(value) + ["delay 1500"] + zigbee.levelRefresh()
+    zigbee.setLevel(value) + ["delay 1500"] + zigbee.levelRefresh() + zigbee.onOffRefresh()
 }
 
 def refresh() {


### PR DESCRIPTION
Many ZLL bulbs don't report changes to attributes we are interested in.
As a result, we are now manually querying for the status on commands
that could change the status.  In many places this was already done,
however, in a few it was not.  With some upcoming zigbee-library changes
these will be necessary to make sure the state is kept up to date.

This relates to: https://smartthings.atlassian.net/browse/DPROT-227
This relates to: https://smartthings.atlassian.net/browse/DPROT-228

@tpmanley @workingmonk 