### PR TITLE
[CHF-504] [CHF-505] Implementation of HealthCheck for Leviton 5A Incandescent Switch (VRS05-1LZ) and Leviton 15A Split Duplex Receptacle (VRR15-1LZ)

### DIFF
--- a/devicetypes/smartthings/zwave-switch-generic.src/zwave-switch-generic.groovy
+++ b/devicetypes/smartthings/zwave-switch-generic.src/zwave-switch-generic.groovy
@@ -26,6 +26,8 @@ metadata {
 		fingerprint mfr:"001D", prod:"1D04", model:"0334", deviceJoinName: "Leviton Outlet"
 		fingerprint mfr:"001D", prod:"1C02", model:"0334", deviceJoinName: "Leviton Switch"
 		fingerprint mfr:"001D", prod:"0301", model:"0334", deviceJoinName: "Leviton 15A Switch"
+		fingerprint mfr:"001D", prod:"0F01", model:"0334", deviceJoinName: "Leviton 5A Incandescent Switch"
+		fingerprint mfr:"001D", prod:"1603", model:"0334", deviceJoinName: "Leviton 15A Split Duplex Receptacle"
 		fingerprint mfr:"011A", prod:"0101", model:"0102", deviceJoinName: "Enerwave On/Off Switch"
 		fingerprint mfr:"011A", prod:"0101", model:"0603", deviceJoinName: "Enerwave Duplex Receptacle"
 	}


### PR DESCRIPTION
Added the fingerprint of
a) Leviton 5A Incandescent Switch (VRS05-1LZ)
b) Leviton 15A Split Duplex Receptacle (VRR15-1LZ)
with the manufacturer, product code and model number obtained from the raw description after pairing.
@jackchi @ShunmugaSundar Please check and merge the changes.