### PR TITLE
[DPROT-227] Manually refresh on/off status after setLevel

### DIFF
--- a/devicetypes/smartthings/cree-bulb.src/cree-bulb.groovy
+++ b/devicetypes/smartthings/cree-bulb.src/cree-bulb.groovy
@@ -82,7 +82,7 @@ def on() {
 }
 
 def setLevel(value) {
-    zigbee.setLevel(value) + ["delay 500"] + zigbee.levelRefresh()         //adding refresh because of ZLL bulb not conforming to send-me-a-report
+    zigbee.setLevel(value) + zigbee.onOffRefresh() + zigbee.levelRefresh()       //adding refresh because of ZLL bulb not conforming to send-me-a-report
 }
 
 /**

--- a/devicetypes/smartthings/zll-dimmer-bulb.src/zll-dimmer-bulb.groovy
+++ b/devicetypes/smartthings/zll-dimmer-bulb.src/zll-dimmer-bulb.groovy
@@ -89,7 +89,7 @@ def on() {
 }
 
 def setLevel(value) {
-    zigbee.setLevel(value) + ["delay 1500"] + zigbee.levelRefresh()         //adding refresh because of ZLL bulb not conforming to send-me-a-report
+    zigbee.setLevel(value) + zigbee.onOffRefresh() + zigbee.levelRefresh()         //adding refresh because of ZLL bulb not conforming to send-me-a-report
 }
 
 def refresh() {

--- a/devicetypes/smartthings/zll-rgb-bulb.src/zll-rgb-bulb.groovy
+++ b/devicetypes/smartthings/zll-rgb-bulb.src/zll-rgb-bulb.groovy
@@ -115,7 +115,7 @@ def refreshAttributes() {
 }
 
 def setLevel(value) {
-	zigbee.setLevel(value) + ["delay 1500"] + zigbee.levelRefresh()         //adding refresh because of ZLL bulb not conforming to send-me-a-report
+	zigbee.setLevel(value) + zigbee.onOffRefresh() + zigbee.levelRefresh()         //adding refresh because of ZLL bulb not conforming to send-me-a-report
 }
 
 def setColor(value){

--- a/devicetypes/smartthings/zll-rgbw-bulb.src/zll-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zll-rgbw-bulb.src/zll-rgbw-bulb.groovy
@@ -135,7 +135,7 @@ def setColorTemperature(value) {
 }
 
 def setLevel(value) {
-    zigbee.setLevel(value) + ["delay 1500"] + zigbee.levelRefresh()         //adding refresh because of ZLL bulb not conforming to send-me-a-report
+    zigbee.setLevel(value) + zigbee.onOffRefresh() + zigbee.levelRefresh()        //adding refresh because of ZLL bulb not conforming to send-me-a-report
 }
 
 def setColor(value){

--- a/devicetypes/smartthings/zll-white-color-temperature-bulb.src/zll-white-color-temperature-bulb.groovy
+++ b/devicetypes/smartthings/zll-white-color-temperature-bulb.src/zll-white-color-temperature-bulb.groovy
@@ -90,7 +90,7 @@ def on() {
 }
 
 def setLevel(value) {
-    zigbee.setLevel(value) + ["delay 1500"] + zigbee.levelRefresh()
+    zigbee.setLevel(value) + zigbee.onOffRefresh() + zigbee.levelRefresh()
 }
 
 def refresh() {


### PR DESCRIPTION
This is because ZLL bulbs do not report or allow for configuration of
reporting of attributes.  As a result if we change a value, we have to
manually call a read of that attribute to update our status.

This is a part of: https://smartthings.atlassian.net/browse/DPROT-227

@tpmanley @workingmonk 