### PR TITLE
[DPROT-238] Manually call on with setLevel

### DIFF
--- a/devicetypes/smartthings/zigbee-dimmer-power.src/zigbee-dimmer-power.groovy
+++ b/devicetypes/smartthings/zigbee-dimmer-power.src/zigbee-dimmer-power.groovy
@@ -97,7 +97,7 @@ def on() {
 }
 
 def setLevel(value) {
-    zigbee.setLevel(value)
+    zigbee.setLevel(value) + (value?.ToInteger() > 0 ? zigbee.on() : [])
 }
 
 /**


### PR DESCRIPTION
This is to work around misbehaving devices that don't properly honor the
move to level with on off command.

This resolves: https://smartthings.atlassian.net/browse/DPROT-238

@tpmanley @workingmonk 