### PR TITLE
DPROT-238 Fix typo on toInteger zigbee dimmer power

### DIFF
--- a/devicetypes/smartthings/zigbee-dimmer-power.src/zigbee-dimmer-power.groovy
+++ b/devicetypes/smartthings/zigbee-dimmer-power.src/zigbee-dimmer-power.groovy
@@ -97,7 +97,7 @@ def on() {
 }
 
 def setLevel(value) {
-    zigbee.setLevel(value) + (value?.ToInteger() > 0 ? zigbee.on() : [])
+    zigbee.setLevel(value) + (value?.toInteger() > 0 ? zigbee.on() : [])
 }
 
 /**


### PR DESCRIPTION
This relates to: https://smartthings.atlassian.net/browse/DPROT-238

@tpmanley @workingmonk 

I initially made this error when I wrote it, and I fixed it while testing with my custom DTH, but I failed to copy it back over correctly :man_facepalming: I don't have a zigbee-dimmer-power at home so I can easily test.  I'll have Steven test before merging this time.