### PR TITLE
DPROT-242 Properly handle setLevel for zigbee-dimmer

### DIFF
--- a/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
@@ -93,7 +93,13 @@ def on() {
 }
 
 def setLevel(value) {
-    zigbee.setLevel(value)
+    def additionalCmds = []
+    if (device.getDataValue("model") == "iQBR30" && value.toInteger() > 0) { // Handle iQ bulb not following spec
+        additionalCmds = zigbee.on()
+    } else if (device.getDataValue("manufacturer") == "MRVL") { // Handle marvel stack not reporting
+        additionalCmds = refresh()
+    }
+    zigbee.setLevel(value) + additionalCmds
 }
 /**
  * PING is used by Device-Watch in attempt to reach the Device
@@ -103,7 +109,7 @@ def ping() {
 }
 
 def refresh() {
-    zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.onOffConfig(0, 300) + zigbee.levelConfig()
+    zigbee.onOffRefresh() + zigbee.levelRefresh()
 }
 
 def configure() {
@@ -113,5 +119,5 @@ def configure() {
     sendEvent(name: "checkInterval", value: 2 * 10 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
 
     // OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
-    zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.onOffConfig(0, 300) + zigbee.levelConfig()
+    refresh() + zigbee.onOffConfig(0, 300) + zigbee.levelConfig()
 }


### PR DESCRIPTION
This works around a few devices that use this DTH that do not properly
handle the setLevel command.

This resolves: https://smartthings.atlassian.net/browse/DPROT-242

@tpmanley @workingmonk 

Vinay, it would be nice to get this out today as some devices aren't behaving as we would like, but I understand if it's not feasible with such short notice.  Thoughts?