### PR TITLE
[DVCSMP-2433] Device Filtering change for Z-wave devices

### DIFF
--- a/devicetypes/smartthings/mimolite-garage-door-controller.src/mimolite-garage-door-controller.groovy
+++ b/devicetypes/smartthings/mimolite-garage-door-controller.src/mimolite-garage-door-controller.groovy
@@ -36,6 +36,7 @@ metadata {
 		capability "Switch"
 		capability "Refresh"
 		capability "Contact Sensor"
+		capability "Light"
 
 		attribute "powered", "string"
 

--- a/devicetypes/smartthings/zwave-dimmer-switch-generic.src/zwave-dimmer-switch-generic.groovy
+++ b/devicetypes/smartthings/zwave-dimmer-switch-generic.src/zwave-dimmer-switch-generic.groovy
@@ -20,6 +20,7 @@ metadata {
 		capability "Polling"
 		capability "Refresh"
 		capability "Sensor"
+		capability "Light"
 
 		fingerprint inClusters: "0x26", deviceJoinName: "Z-Wave Dimmer"
 		fingerprint mfr:"001D", prod:"1902", deviceJoinName: "Z-Wave Dimmer"

--- a/devicetypes/smartthings/zwave-metering-dimmer.src/zwave-metering-dimmer.groovy
+++ b/devicetypes/smartthings/zwave-metering-dimmer.src/zwave-metering-dimmer.groovy
@@ -25,6 +25,7 @@ metadata {
 		capability "Switch Level"
 		capability "Sensor"
 		capability "Actuator"
+		capability "Light"
 
 		command "reset"
 

--- a/devicetypes/smartthings/zwave-metering-switch.src/zwave-metering-switch.groovy
+++ b/devicetypes/smartthings/zwave-metering-switch.src/zwave-metering-switch.groovy
@@ -21,6 +21,7 @@ metadata {
 		capability "Refresh"
 		capability "Configuration"
 		capability "Sensor"
+		capability "Light"
 
 		command "reset"
 

--- a/devicetypes/smartthings/zwave-switch-generic.src/zwave-switch-generic.groovy
+++ b/devicetypes/smartthings/zwave-switch-generic.src/zwave-switch-generic.groovy
@@ -19,6 +19,7 @@ metadata {
 		capability "Polling"
 		capability "Refresh"
 		capability "Sensor"
+		capability "Light"
 
 		fingerprint inClusters: "0x25", deviceJoinName: "Z-Wave Switch"
 		fingerprint mfr:"001D", prod:"1A02", model:"0334", deviceJoinName: "Leviton Appliance Module"

--- a/devicetypes/smartthings/zwave-switch.src/zwave-switch.groovy
+++ b/devicetypes/smartthings/zwave-switch.src/zwave-switch.groovy
@@ -20,6 +20,7 @@ metadata {
 		capability "Refresh"
 		capability "Sensor"
 		capability "Health Check"
+		capability "Light"
 
 		fingerprint mfr:"0063", prod:"4952", deviceJoinName: "Z-Wave Wall Switch"
 		fingerprint mfr:"0063", prod:"5257", deviceJoinName: "Z-Wave Wall Switch"


### PR DESCRIPTION
Adding Device Filtering changes to the following Z-wave DTHs:

1. Z-Wave Metering Dimmer
2. Z-Wave Metering Switch
3. Z-Wave Dimmer Switch Generic
4. Z-Wave Switch
5. Z-Wave Switch Generic
6. MimoLite Garage Door Controller