### PR TITLE
DVCSMP-2474 Arrival Sensor HA schedule needs jitter to avoid all firing at top of minute

### DIFF
--- a/devicetypes/smartthings/arrival-sensor-ha.src/arrival-sensor-ha.groovy
+++ b/devicetypes/smartthings/arrival-sensor-ha.src/arrival-sensor-ha.groovy
@@ -151,7 +151,7 @@ private handlePresenceEvent(present) {
 
 private startTimer() {
     log.debug "Scheduling periodic timer"
-    schedule("0 * * * * ?", checkPresenceCallback)
+    runEvery1Minute("checkPresenceCallback")
 }
 
 private stopTimer() {


### PR DESCRIPTION
Arrival Sensor HA currently executes about 14 million times a day (by far our most executed DTH) and quite a bit of these executions come from checkPresenceCallback schedule that runs at the top of the minute. Seeing as many as 1500 executions/sec or more for this schedule at the top of the minute. Let's change this cron schedule to use a runEvery1Minute and allow us to spread this load out more evenly across the minute to reduce latency spikes by all of them firing at the exact same second.  Don't see any good reason why they all need to fire at the top of the minute, but more importantly we just want them to consistently check every minute.