### PR TITLE
DVCSMP-2484 smartsense-motion-sensor: fix motion event reporting for some devices

### DIFF
--- a/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
@@ -107,8 +107,8 @@ def parse(String description) {
 				}
 			} else if (descMap.clusterInt == 0x0406 && descMap.attrInt == 0x0000) {
 				def value = descMap.value.endsWith("01") ? "active" : "inactive"
-				log.warn "Doing a read attr motion event"
-				resultMap = getMotionResult(value)
+				log.debug "Doing a read attr motion event"
+				map = getMotionResult(value)
 			}
 		}
 	}


### PR DESCRIPTION
The motion event reporting for any device that used the Occupancy Sensor
cluster for reporting motion was broken. I'm not sure if any devices using
this DTH actually use this cluster. I think all the officially supported
devices report motion throug the IAS Zone cluster.

https://smartthings.atlassian.net/browse/DVCSMP-2484

@varzac 
@workingmonk think its worth pulling into the release this week? I was leaning towards no since I don't know that it actually affects any devices that use this DTH.