### PR TITLE
DVCSMP-2485 Fix Curb Control V2 SmartApp breaking SmartThingsPublic builds

### DIFF
--- a/smartapps/curb-v2/curb-control.src/curb-control-v2.groovy
+++ b/smartapps/curb-v2/curb-control.src/curb-control-v2.groovy
@@ -5,7 +5,7 @@
  *
  */
 definition(
-    name: "Curb Control",
+    name: "Curb Control v2",
     namespace: "curb-v2",
     author: "Savanni D&#39;Gerinel",
     description: "Control point for Curb/SmartThings integration",
@@ -13,7 +13,8 @@ definition(
     iconUrl: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience.png",
     iconX2Url: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience@2x.png",
     iconX3Url: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience@2x.png",
-    oauth: true)
+    oauth: true
+)
 
 
 preferences {
@@ -63,12 +64,11 @@ def deviceHandler(evt) {}
 
 private void update(devices) {
 	log.debug "update, request: params: ${params}, devices: $devices.id"
-    
-    
+
 	//def command = request.JSON?.command
     def command = params.command
     //let's create a toggle option here
-	if (command) 
+	if (command)
     {
 		def device = devices.find { it.id == params.id }
 		if (!device) {


### PR DESCRIPTION
Seeing the following error after the Curb Control v2 app was merged because it has a duplicate class name as the v2 app.  This change updates the new app to `v2` to avoid the name conflict.  If we want them to have the same name then these should most likely just be 1 app instead of having 2 versions.  If we want the new name to still be `Curb Control` then we should rename the original version to v1, etc...

```
> Building 25% > :compileSmartappsGroovy/home/ubuntu/SmartThingsPublic/smartapps/curb/curb-control.src/curb-control.groovy: 7: Invalid duplicate class definition of class curb-control : The sources /home/ubuntu/SmartThingsPublic/smartapps/curb/curb-control.src/curb-control.groovy and /home/ubuntu/SmartThingsPublic/smartapps/curb-v2/curb-control.src/curb-control.groovy each contain a class with the name curb-control.
> Building 25% > :compileSmartappsGroovy @ line 7, column 1.
> Building 25% > :compileSmartappsGroovy   definition(
> Building 25% > :compileSmartappsGroovy   ^
> Building 25% > :compileSmartappsGroovy
> Building 25% > :compileSmartappsGroovy1 error
> Building 25% > :compileSmartappsGroovy
> Building 25% > :compileSmartappsGroovy:compileSmartappsGroovy
```