### PR TITLE
To Nyce sensor DTHs, added Capability "Sensor" per http://docs.smartt…

### DIFF
--- a/devicetypes/smartthings/nyce-motion-sensor.src/nyce-motion-sensor.groovy
+++ b/devicetypes/smartthings/nyce-motion-sensor.src/nyce-motion-sensor.groovy
@@ -21,6 +21,7 @@ metadata {
 		capability "Configuration"
 		capability "Battery"
 		capability "Refresh"
+		capability "Sensor"
         
         command "enrollResponse"
 

--- a/devicetypes/smartthings/nyce-open-closed-sensor.src/nyce-open-closed-sensor.groovy
+++ b/devicetypes/smartthings/nyce-open-closed-sensor.src/nyce-open-closed-sensor.groovy
@@ -24,6 +24,7 @@ metadata {
 		capability "Contact Sensor"
 		capability "Refresh"
 		capability "Health Check"
+		capability "Sensor"
 
 		command "enrollResponse"
 


### PR DESCRIPTION
There are some integrations (SmartApps) out there using the "Actuator" and "Sensor" Capabilities and instances of these Nyce Sensor Devices (and perhaps more) do not show up for them. _Example_ SmartApp "ActionTiles".
- Ref Docs: http://docs.smartthings.com/en/latest/device-type-developers-guide/overview.html?highlight=sensor%20actuator#actuator-and-sensor
- Ref Issue #1058.
- Ref @tslagle13 for more info regarding **ActionTiles**'s use of these standard Capabilities as device authorization input filters.
- Internal Ref: [`ActionTiles's Helpdesk Ticket #604`](http://support.actiontiles.com/topics/1044-nyce-hinge-door-sensor-support/).

**CC:** @tylerlange , @workingmonk 

_Thank-you!_