### PR TITLE
To Fibaro Flood Sensor DTHs, added Capability "Sensor" per http://doc…

### DIFF
--- a/devicetypes/smartthings/fibaro-flood-sensor.src/fibaro-flood-sensor.groovy
+++ b/devicetypes/smartthings/fibaro-flood-sensor.src/fibaro-flood-sensor.groovy
@@ -40,6 +40,7 @@ metadata {
 		capability "Configuration"
 		capability "Battery"
 		capability "Health Check"
+		capability "Sensor"
        
         command		"resetParams2StDefaults"
         command		"listCurrentParams"


### PR DESCRIPTION
There are some integrations (SmartApps) out there using the "Actuator" and "Sensor" Capabilities and instances of this Fibaro Floor Sensor Devices (and perhaps more) do not show up for them. _Example_ SmartApp "ActionTiles".
- Ref Docs: http://docs.smartthings.com/en/latest/device-type-developers-guide/overview.html?highlight=sensor%20actuator#actuator-and-sensor
- Ref Issue #1058.
- Ref @tslagle13 for more info regarding **ActionTiles**'s use of these standard Capabilities as device authorization input filters.
- Internal Ref: [`ActionTiles's Helpdesk Ticket #577`](http://support.actiontiles.com/topics/990-missing-devices-on-action-tiles/).

**CC:** @tylerlange , @workingmonk 

_Thank-you!_