### PR TITLE
[CHF-539] Health Check FortrezZ Water Valve

### DIFF
--- a/devicetypes/smartthings/fortrezz-water-valve.src/.st-ignore
+++ b/devicetypes/smartthings/fortrezz-water-valve.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/fortrezz-water-valve.src/README.md
+++ b/devicetypes/smartthings/fortrezz-water-valve.src/README.md
@@ -1,0 +1,39 @@
+# FortrezZ Water Valve
+
+Cloud Execution
+
+Works with: 
+
+* [FortrezZ Water Valve](https://www.smartthings.com/works-with-smartthings/other/fortrezz-water-valve)
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+* [Troubleshooting](#troubleshooting)
+
+## Capabilities
+
+* **Actuator** - represents that a Device has commands
+* **Health Check** - indicates ability to get device health notifications
+* **Valve** - allows for the control of a valve device
+* **Refresh** - _refresh()_ command for status updates
+* **Sensor** - detects sensor events
+
+## Device Health
+
+FortrezZ Water Valve is polled by the hub.
+As of hubCore version 0.14.38 the hub sends up reports every 15 minutes regardless of whether the state changed.
+Device-Watch allows 2 check-in misses from device plus some lag time. So Check-in interval = (2*15 + 2)mins = 32 mins.
+Not to mention after going OFFLINE when the device is plugged back in, it might take a considerable amount of time for
+the device to appear as ONLINE again. This is because if this listening device does not respond to two poll requests in a row,
+it is not polled for 5 minutes by the hub. This can delay up the process of being marked ONLINE by quite some time.
+
+* __32min__ checkInterval
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
+Pairing needs to be tried again by placing the device closer to the hub.
+Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following link:
+* [FortrezZ Water Valve Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/202088434-FortrezZ-Water-Valve-Shutoff)

--- a/devicetypes/smartthings/fortrezz-water-valve.src/fortrezz-water-valve.groovy
+++ b/devicetypes/smartthings/fortrezz-water-valve.src/fortrezz-water-valve.groovy
@@ -14,11 +14,13 @@
 metadata {
 	definition (name: "Fortrezz Water Valve", namespace: "smartthings", author: "SmartThings") {
 		capability "Actuator"
+		capability "Health Check"
 		capability "Valve"
 		capability "Refresh"
 		capability "Sensor"
         
 		fingerprint deviceId: "0x1000", inClusters: "0x25,0x72,0x86,0x71,0x22,0x70"
+		fingerprint mfr:"0084", prod:"0213", model:"0215", deviceJoinName: "FortrezZ Water Valve"
 	}
 
 	// simulator metadata
@@ -48,6 +50,11 @@ metadata {
 	}
 }
 
+def updated(){
+// Device-Watch simply pings if no device events received for 32min(checkInterval)
+	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
+}
+
 def parse(String description) {
 	log.trace description
 	def result = null
@@ -74,6 +81,13 @@ def open() {
 
 def close() {
 	zwave.switchBinaryV1.switchBinarySet(switchValue: 0xFF).format()
+}
+
+/**
+ * PING is used by Device-Watch in attempt to reach the Device
+ * */
+def ping() {
+	refresh()
 }
 
 def refresh() {


### PR DESCRIPTION
1. Added health check for FortrezZ Water Valve.
2. 'checkInterval' is kept at 32min.
3. Ping is implemented using refresh().
4. Added the fingerprint of the FortrezZ Water Valve with the manufacturer and product code obtained from the raw description after pairing.
5. We've tested the checkInterval duration and the devices are marked OFFLINE within the stipulated time.
6. Added the README.md file.
@jackchi @ShunmugaSundar Please check and merge the changes.