### PR TITLE
[CHF-551] Health Check Z-Wave Lock

### DIFF
--- a/devicetypes/smartthings/zwave-lock.src/.st-ignore
+++ b/devicetypes/smartthings/zwave-lock.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/zwave-lock.src/README.md
+++ b/devicetypes/smartthings/zwave-lock.src/README.md
@@ -1,0 +1,45 @@
+# Z-Wave Switch
+
+Cloud Execution
+
+Works with: 
+
+* [Yale Key Free Touchscreen Deadbolt (YRD240)](https://www.smartthings.com/works-with-smartthings/yale/yale-key-free-touchscreen-deadbolt-yrd240)
+
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+* [Troubleshooting](#Troubleshooting)
+
+## Capabilities
+
+* **Actuator** - represents that a Device has commands
+* **Battery** - defines device uses a battery
+* **Lock** - allows for the control of a lock device
+* **Lock Codes** - allows for the lock code control of a lock device
+* **Polling** - represents that poll() can be implemented for the device
+* **Refresh** - _refresh()_ command for status updates
+* **Sensor** - detects sensor events
+* **Health Check** - indicates ability to get device health notifications
+
+## Device Health
+
+Z-Wave Locks are polled by the hub.
+As of hubCore version 0.14.38 the hub sends up reports every 15 minutes regardless of whether the state changed.
+Device-Watch allows 2 check-in misses from device plus some lag time. So Check-in interval = (2*15 + 2)mins = 32 mins.
+Not to mention after going OFFLINE when the device is plugged back in, it might take a considerable amount of time for
+the device to appear as ONLINE again. This is because if this listening device does not respond to two poll requests in a row,
+it is not polled for 5 minutes by the hub. This can delay up the process of being marked ONLINE by quite some time.
+
+* __32min__ checkInterval
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
+Pairing needs to be tried again by placing the device closer to the hub.
+Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following link:
+* [General Z-Wave/ZigBee Yale Lock Troubleshooting](https://support.smartthings.com/hc/en-us/articles/205138400-How-to-connect-Yale-locks)
+
+

--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -20,11 +20,13 @@ metadata {
 		capability "Sensor"
 		capability "Lock Codes"
 		capability "Battery"
+		capability "Health Check"
 
 		command "unlockwtimeout"
 
 		fingerprint deviceId: "0x4003", inClusters: "0x98"
 		fingerprint deviceId: "0x4004", inClusters: "0x98"
+		fingerprint mfr:"0129", prod:"0002", model:"0000", deviceJoinName: "Yale Key Free Touchscreen Deadbolt"
 	}
 
 	simulator {
@@ -67,6 +69,8 @@ import physicalgraph.zwave.commands.doorlockv1.*
 import physicalgraph.zwave.commands.usercodev1.*
 
 def updated() {
+	// Device-Watch simply pings if no device events received for 32min(checkInterval)
+	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 	try {
 		if (!state.init) {
 			state.init = true
@@ -502,6 +506,13 @@ def unlock() {
 
 def unlockwtimeout() {
 	lockAndCheck(DoorLockOperationSet.DOOR_LOCK_MODE_DOOR_UNSECURED_WITH_TIMEOUT)
+}
+
+/**
+ * PING is used by Device-Watch in attempt to reach the Device
+ * */
+def ping() {
+	refresh()
 }
 
 def refresh() {


### PR DESCRIPTION
1. Added health check for Yale Key Free Touchscreen Deadbolt (YRD240).
2. 'checkInterval' is kept at 32min.
3. Ping is implemented using refresh().
4. Added the fingerprint of the Yale Key Free Lock with the manufacturer and product code obtained from the raw description after pairing.
5. Added the readMe as well.