### PR TITLE
[CHF-544] Health Check Zwave Smoke Alarm

### DIFF
--- a/devicetypes/smartthings/zwave-smoke-alarm.src/.st-ignore
+++ b/devicetypes/smartthings/zwave-smoke-alarm.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/zwave-smoke-alarm.src/README.md
+++ b/devicetypes/smartthings/zwave-smoke-alarm.src/README.md
@@ -1,0 +1,40 @@
+# Z-wave Smoke Alarm
+
+Cloud Execution
+
+Works with: 
+
+* [First Alert Smoke Detector and Carbon Monoxide Alarm (ZCOMBO)](https://www.smartthings.com/works-with-smartthings/sensors/first-alert-smoke-detector-and-carbon-monoxide-alarm-zcombo)
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+* [Battery](#battery-specification)
+* [Troubleshooting](#troubleshooting)
+
+## Capabilities
+
+* **Smoke Detector** - measure smoke and optionally carbon monoxide levels
+* **Carbon Monoxide Detector** - measure carbon monoxide levels
+* **Sensor** - detects sensor events
+* **Battery** - defines device uses a battery
+* **Health Check** - indicates ability to get device health notifications
+
+## Device Health
+
+First Alert Smoke Detector and Carbon Monoxide Alarm (ZCOMBO) is a Z-wave sleepy device and checks in every 1 hour.
+Device-Watch allows 2 check-in misses from device plus some lag time. So Check-in interval = (2*60 + 2)mins = 122 mins.
+
+* __122min__ checkInterval
+
+## Battery Specification
+
+Two AA 1.5V batteries are required.
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
+Pairing needs to be tried again by placing the device closer to the hub.
+Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following link:
+* [First Alert Smoke Detector and Carbon Monoxide Alarm (ZCOMBO) Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/201581984-First-Alert-Smoke-Detector-and-Carbon-Monoxide-Alarm-ZCOMBO-)

--- a/devicetypes/smartthings/zwave-smoke-alarm.src/zwave-smoke-alarm.groovy
+++ b/devicetypes/smartthings/zwave-smoke-alarm.src/zwave-smoke-alarm.groovy
@@ -17,10 +17,12 @@ metadata {
 		capability "Carbon Monoxide Detector"
 		capability "Sensor"
 		capability "Battery"
+		capability "Health Check"
 
 		attribute "alarmState", "string"
 
 		fingerprint deviceId: "0xA100", inClusters: "0x20,0x80,0x70,0x85,0x71,0x72,0x86"
+		fingerprint mfr:"0138", prod:"0001", model:"0002", deviceJoinName: "First Alert Smoke Detector and Carbon Monoxide Alarm (ZCOMBO)"
 	}
 
 	simulator {
@@ -51,6 +53,11 @@ metadata {
 	}
 }
 
+def updated(){
+// Device checks in every hour, this interval allows us to miss one check-in notification before marking offline
+	sendEvent(name: "checkInterval", value: 2 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
+}
+
 def parse(String description) {
 	def results = []
 	if (description.startsWith("Err")) {
@@ -64,7 +71,6 @@ def parse(String description) {
 	log.debug "'$description' parsed to ${results.inspect()}"
 	return results
 }
-
 
 def createSmokeOrCOEvents(name, results) {
 	def text = null


### PR DESCRIPTION
1. Added health check for First Alert Smoke Detector and Carbon Monoxide Alarm (ZCOMBO).
2. 'checkInterval' is kept at 122min.
3. It is a Z-wave sleepy device with 1hr check-in.
4. Added the fingerprint of the First Alert ZCOMBO Smoke Alarm with the manufacturer and product code obtained from the raw description after pairing.
5. We've tested the checkInterval duration and the devices are marked OFFLINE within the stipulated time.
6. Added the README.md file.
@jackchi @ShunmugaSundar Please check and merge the changes.