### PR TITLE
[CHF-540] Health Check Zwave-garage-door-opener

### DIFF
--- a/devicetypes/smartthings/zwave-garage-door-opener.src/.st-ignore
+++ b/devicetypes/smartthings/zwave-garage-door-opener.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/zwave-garage-door-opener.src/README.md
+++ b/devicetypes/smartthings/zwave-garage-door-opener.src/README.md
@@ -1,0 +1,41 @@
+# Z-wave Garage Door Opener
+
+Cloud Execution
+
+Works with: 
+
+* [Linear GoControl Garage Door Opener](https://www.smartthings.com/works-with-smartthings/other/linear-gocontrol-garage-door-opener)
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+* [Troubleshooting](#troubleshooting)
+
+## Capabilities
+
+* **Actuator** - represents that a Device has commands
+* **Door Control** - allow for the control of a door
+* **Garage Door Control** - allow for the control of a garage door
+* **Health Check** - indicates ability to get device health notifications
+* **Contact Sensor** - can detect contact (with possible values - open/closed)
+* **Refresh** - _refresh()_ command for status updates
+* **Sensor** - detects sensor events
+
+## Device Health
+
+Linear GoControl Garage Door Opener is polled by the hub.
+As of hubCore version 0.14.38 the hub sends up reports every 15 minutes regardless of whether the state changed.
+Device-Watch allows 2 check-in misses from device plus some lag time. So Check-in interval = (2*15 + 2)mins = 32 mins.
+Not to mention after going OFFLINE when the device is plugged back in, it might take a considerable amount of time for
+the device to appear as ONLINE again. This is because if this listening device does not respond to two poll requests in a row,
+it is not polled for 5 minutes by the hub. This can delay up the process of being marked ONLINE by quite some time.
+
+* __32min__ checkInterval
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
+Pairing needs to be tried again by placing the device closer to the hub.
+Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following link:
+* [Linear GoControl Garage Door Opener Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/204831116-GoControl-Linear-Garage-Door-Opener-GD00Z-4-)

--- a/devicetypes/smartthings/zwave-garage-door-opener.src/zwave-garage-door-opener.groovy
+++ b/devicetypes/smartthings/zwave-garage-door-opener.src/zwave-garage-door-opener.groovy
@@ -18,12 +18,14 @@ metadata {
 		capability "Actuator"
 		capability "Door Control"
 		capability "Garage Door Control"
+		capability "Health Check"
 		capability "Contact Sensor"
 		capability "Refresh"
 		capability "Sensor"
 
 		fingerprint deviceId: "0x4007", inClusters: "0x98"
 		fingerprint deviceId: "0x4006", inClusters: "0x98"
+		fingerprint mfr:"014F", prod:"4744", model:"3030", deviceJoinName: "Linear GoControl Garage Door Opener"
 	}
 
 	simulator {
@@ -62,6 +64,11 @@ metadata {
 }
 
 import physicalgraph.zwave.commands.barrieroperatorv1.*
+
+def updated(){
+// Device-Watch simply pings if no device events received for 32min(checkInterval)
+	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
+}
 
 def parse(String description) {
 	def result = null
@@ -285,6 +292,13 @@ def open() {
 
 def close() {
 	secure(zwave.barrierOperatorV1.barrierOperatorSet(requestedBarrierState: BarrierOperatorSet.REQUESTED_BARRIER_STATE_CLOSE))
+}
+
+/**
+ * PING is used by Device-Watch in attempt to reach the Device
+ * */
+def ping() {
+	refresh()
 }
 
 def refresh() {


### PR DESCRIPTION
1. Added health check for Linear GoControl Garage Door Opener.
2. 'checkInterval' is kept at 32min.
3. Ping is implemented using refresh().
4. Added the fingerprint of the Linear GoControl Garage Door Opener with the manufacturer and product code obtained from the raw description after pairing.
5. We've tested the checkInterval duration and the devices are marked OFFLINE within the stipulated time.
6. Added the README.md file.
@jackchi @ShunmugaSundar Please check and merge the changes.