### PR TITLE
To Bose Soundtouch DTHs, added Capability Sensor & Capability Actuator

### DIFF
--- a/devicetypes/smartthings/bose-soundtouch.src/bose-soundtouch.groovy
+++ b/devicetypes/smartthings/bose-soundtouch.src/bose-soundtouch.groovy
@@ -28,8 +28,8 @@ metadata {
         capability "Refresh"
         capability "Music Player"
         capability "Health Check"
-		capability "Sensor"
-		capability "Actuator"
+        capability "Sensor"
+        capability "Actuator"
 
         /**
          * Define all commands, ie, if you have a custom action not

--- a/devicetypes/smartthings/bose-soundtouch.src/bose-soundtouch.groovy
+++ b/devicetypes/smartthings/bose-soundtouch.src/bose-soundtouch.groovy
@@ -28,6 +28,8 @@ metadata {
         capability "Refresh"
         capability "Music Player"
         capability "Health Check"
+		capability "Sensor"
+		capability "Actuator"
 
         /**
          * Define all commands, ie, if you have a custom action not


### PR DESCRIPTION
There are some integrations (SmartApps) out there using the "Actuator" and "Sensor" Capabilities and instances of this Bose Soundtouch Device (and perhaps more) do not show up for them. _Example_ SmartApp "ActionTiles".
- Ref Docs: http://docs.smartthings.com/en/latest/device-type-developers-guide/overview.html?highlight=sensor%20actuator#actuator-and-sensor
- Ref Issue #1058.
- Ref @tslagle13 for more info regarding **ActionTiles**'s use of these standard Capabilities as device authorization input filters.
- Internal Ref: [`ActionTiles's Topic #1171`](http://support.actiontiles.com/topics/1171-bose-soundtouch-missing-from-authorize-things/).

**CC:** @tylerlange , @workingmonk 

_Thank-you!_