### PR TITLE
[CHF-562] Health Check zwave-door-window-sensor

### DIFF
--- a/devicetypes/smartthings/zwave-door-window-sensor.src/.st-ignore
+++ b/devicetypes/smartthings/zwave-door-window-sensor.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/zwave-door-window-sensor.src/README.md
+++ b/devicetypes/smartthings/zwave-door-window-sensor.src/README.md
@@ -1,0 +1,36 @@
+# Z-Wave Door Window Sensor
+
+Cloud Execution
+
+Works with: 
+
+* [Aeon Labs Door/Window Sensor (Gen 5)](https://www.smartthings.com/works-with-smartthings/aeon-labs/aeon-labs-doorwindow-sensor-gen-5)
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+* [Troubleshooting](#Troubleshooting)
+
+## Capabilities
+
+* **Configuration** - _configure()_ command called when device is installed or device preferences updated
+* **Health Check** - indicates ability to get device health notifications
+* **Sensor** - detects sensor events
+* **Battery** - defines that the device has a battery
+* **Contact Sensor** - allows reading the value of a contact sensor device
+
+## Device Health
+
+Z-Wave Door Window Sensor is a Z-wave sleepy device and checks in every 4 hours.
+Device-Watch allows 2 check-in misses from device plus some lag time. So Check-in interval = (2*4*60 + 2)mins = 482 mins.
+
+* __482min__ checkInterval
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
+Pairing needs to be tried again by placing the device closer to the hub.
+Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following links
+for the different models:
+* [Aeon Labs Door/Window Sensor (Gen 5) Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/211834163-How-to-connect-Aeon-Labs-door-window-sensors)

--- a/devicetypes/smartthings/zwave-door-window-sensor.src/zwave-door-window-sensor.groovy
+++ b/devicetypes/smartthings/zwave-door-window-sensor.src/zwave-door-window-sensor.groovy
@@ -22,12 +22,14 @@ metadata {
 		capability "Sensor"
 		capability "Battery"
 		capability "Configuration"
+		capability "Health Check"
 
 		fingerprint deviceId: "0x2001", inClusters: "0x30,0x80,0x84,0x85,0x86,0x72"
 		fingerprint deviceId: "0x07", inClusters: "0x30"
 		fingerprint deviceId: "0x0701", inClusters: "0x5E,0x98"
 		fingerprint deviceId: "0x0701", inClusters: "0x5E,0x86,0x72,0x98", outClusters: "0x5A,0x82"
 		fingerprint deviceId: "0x0701", inClusters: "0x5E,0x80,0x71,0x85,0x70,0x72,0x86,0x30,0x31,0x84,0x59,0x73,0x5A,0x8F,0x98,0x7A", outClusters:"0x20" // Philio multi+
+		fingerprint mfr:"0086", prod:"0002", model:"001D", deviceJoinName: "Aeon Labs Door/Window Sensor (Gen 5)"
 	}
 
 	// simulator metadata
@@ -78,6 +80,8 @@ def parse(String description) {
 }
 
 def updated() {
+	// Device-Watch simply pings if no device events received for 482min(checkInterval)
+	sendEvent(name: "checkInterval", value: 2 * 4 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 	def cmds = []
 	if (!state.MSR) {
 		cmds = [


### PR DESCRIPTION
1. Added health check for Aeon Door/Window Sensor.
2. 'checkInterval' is kept at 482min.
3. It is a Z-wave sleepy device with 4hr check-in.
4. Added the fingerprint with the manufacturer and product code obtained from the raw description after pairing.
5. We've tested the checkInterval duration and the devices are marked OFFLINE within the stipulated time.
6. Added the README.md file.