### PR TITLE
[CHF-561] Health Check Plant Link Sensor

### DIFF
--- a/devicetypes/smartthings/plant-link.src/.st-ignore
+++ b/devicetypes/smartthings/plant-link.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/plant-link.src/README.md
+++ b/devicetypes/smartthings/plant-link.src/README.md
@@ -1,0 +1,35 @@
+# Plant Link
+
+Cloud Execution
+
+Works with: 
+
+* [OSO Technologies PlantLink Soil Moisture Sensor](https://www.smartthings.com/works-with-smartthings/oso-technologies/oso-technologies-plantlink-soil-moisture-sensor)
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+* [Troubleshooting](#troubleshooting)
+
+## Capabilities
+
+* **Relative Humidity Measurement** - allows reading the relative humidity from devices that support it
+* **Sensor** - detects sensor events
+* **Battery** - defines device uses a battery
+* **Health Check** - indicates ability to get device health notifications
+
+## Device Health
+
+Plant Link sensor is a Z-wave sleepy device and checks in every 15 minutes.
+Device-Watch allows 2 check-in misses from device plus some lag time. So Check-in interval = (2*15 + 2)mins = 32 mins.
+
+* __122min__ checkInterval
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the sensor is out of range.
+Pairing needs to be tried again by placing the sensor closer to the hub.
+Instructions related to pairing, resetting and removing the different motion sensors from SmartThings can be found in the following links
+for the different models:
+* [OSO Technologies PlantLink Soil Moisture Sensor Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/206868986-PlantLink-Soil-Moisture-Sensor)

--- a/devicetypes/smartthings/plant-link.src/plant-link.groovy
+++ b/devicetypes/smartthings/plant-link.src/plant-link.groovy
@@ -21,8 +21,10 @@ metadata {
 		capability "Relative Humidity Measurement"
 		capability "Battery"
 		capability "Sensor"
+		capability "Health Check"
 
 		fingerprint profileId: "0104", inClusters: "0000,0003,0405,FC08", outClusters: "0003"
+		fingerprint endpoint: "1", profileId: "0104", inClusters: "0000,0001,0003,0B04", outClusters: "0003", manufacturer: "", model: "", deviceJoinName: "OSO Technologies PlantLink Soil Moisture Sensor"
 	}
 
 	tiles {
@@ -46,6 +48,11 @@ metadata {
 		main(["humidity", "battery"])
 		details(["humidity", "battery"])
 	}
+}
+
+def updated() {
+	// Device-Watch allows 2 check-in misses from device
+	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
 }
 
 // Parse incoming device messages to generate events


### PR DESCRIPTION
1. Added health check for OSO Technologies PlantLink Soil Moisture Sensor.
2. 'checkInterval' is kept at 32min.
3. It is a Z-wave sleepy device with 15min check-in.
4. Added the fingerprint with the manufacturer and product code obtained from the raw description after pairing.
5. We've tested the checkInterval duration and the devices are marked OFFLINE within the stipulated time.
6. Added the README.md file.

@jackchi @ShunmugaSundar Please check and merge the changes.