### PR TITLE
To Tyco Door-Window Sensor DTH: added Capability Sensor

### DIFF
--- a/devicetypes/smartthings/tyco-door-window-sensor.src/tyco-door-window-sensor.groovy
+++ b/devicetypes/smartthings/tyco-door-window-sensor.src/tyco-door-window-sensor.groovy
@@ -23,6 +23,7 @@ metadata {
 		capability "Refresh"
 		capability "Temperature Measurement"
 		capability "Health Check"
+		capability "Sensor"
 
 		command "enrollResponse"
 


### PR DESCRIPTION
There are some integrations (SmartApps) out there using the "Actuator" and "Sensor" Capabilities and instances of this Tyco Door-Window Sensor Device (and perhaps more) do not show up for them. _Example_ SmartApp "ActionTiles".
- Ref Docs: http://docs.smartthings.com/en/latest/device-type-developers-guide/overview.html?highlight=sensor%20actuator#actuator-and-sensor
- Ref Issue #1058.
- Ref @tslagle13 for more info regarding **ActionTiles**'s use of these standard Capabilities as device authorization input filters.
- Internal Ref: [`ActionTiles's Topic #1216`](http://support.actiontiles.com/topics/1216-tyco-doorwindow-sensor-missing-from-authorizable-things/).

**CC:** @tylerlange , @workingmonk 

_Thank-you!_