### PR TITLE
[CHF-558] Health Check ZigBee Switch

### DIFF
--- a/devicetypes/keen-home/keen-home-smart-vent.src/README.md
+++ b/devicetypes/keen-home/keen-home-smart-vent.src/README.md
@@ -25,10 +25,10 @@ Works with:
 
 ## Device Health
 
-Keen Home Smart Vent with reporting interval of 5 mins.
+Keen Home Smart Vent with reporting interval of 10 mins.
 SmartThings platform will ping the device after `checkInterval` seconds of inactivity in last attempt to reach the device before marking it `OFFLINE` 
 
-* __12min__ checkInterval
+* __22min__ checkInterval
 
 ## Troubleshooting
 

--- a/devicetypes/smartthings/zigbee-switch.src/.st-ignore
+++ b/devicetypes/smartthings/zigbee-switch.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/zigbee-switch.src/README.md
+++ b/devicetypes/smartthings/zigbee-switch.src/README.md
@@ -1,0 +1,35 @@
+# Leviton Switch (ZigBee)
+
+Cloud Execution
+
+Works with:
+
+* [Leviton Switch (ZigBee)](https://www.smartthings.com/works-with-smartthings/leviton/leviton-switch)
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+* [Troubleshooting](#Troubleshooting)
+
+## Capabilities
+
+* **Actuator** - represents that a Device has commands
+* **Configuration** - _configure()_ command called when device is installed or device preferences updated
+* **Refresh** - _refresh()_ command for status updates
+* **Switch** - can detect state (possible values: on/off)
+* **Health Check** - indicates ability to get device health notifications
+
+## Device Health
+
+A Zigbee Switch with reporting interval of 10 mins.
+SmartThings platform will ping the device after `checkInterval` seconds of inactivity in last attempt to reach the device before marking it `OFFLINE` 
+
+* __22min__ checkInterval
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
+Pairing needs to be tried again by placing the device closer to the hub.
+Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following link:
+* [Leviton Switch Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/209686003-How-to-connect-Leviton-ZigBee-devices)

--- a/devicetypes/smartthings/zigbee-switch.src/zigbee-switch.groovy
+++ b/devicetypes/smartthings/zigbee-switch.src/zigbee-switch.groovy
@@ -18,6 +18,7 @@ metadata {
         capability "Configuration"
         capability "Refresh"
         capability "Switch"
+        capability "Health Check"
 
         fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006"
         fingerprint profileId: "0104", inClusters: "0000, 0003, 0006", outClusters: "0003, 0006, 0019, 0406", manufacturer: "Leviton", model: "ZSS-10", deviceJoinName: "Leviton Switch"
@@ -75,11 +76,20 @@ def on() {
     zigbee.on()
 }
 
+/**
+ * PING is used by Device-Watch in attempt to reach the Device
+ * */
+def ping() {
+    return refresh()
+}
+
 def refresh() {
     zigbee.onOffRefresh() + zigbee.onOffConfig()
 }
 
 def configure() {
+    // Device-Watch allows 2 check-in misses from device + ping (plus 2 min lag time)
+    sendEvent(name: "checkInterval", value: 2 * 10 * 60 + 2 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
     log.debug "Configuring Reporting and Bindings."
     zigbee.onOffRefresh() + zigbee.onOffConfig()
 }


### PR DESCRIPTION
1. Added health check for Leviton Switch.
2. 'checkInterval' is kept at 22min.
3. It is a ZigBee reporting device with 10min check-in.
4. We've tested the checkInterval duration and the devices are marked OFFLINE within the stipulated time.
5. Added the README.md file.
6. Modified Typo changes for Keen Home Smart Vent.

@jackchi @ShunmugaSundar Please check and merge the changes.