### PR TITLE
[CHF-569] Health Check zwave-water-valve

### DIFF
--- a/devicetypes/smartthings/zwave-water-valve.src/.st-ignore
+++ b/devicetypes/smartthings/zwave-water-valve.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/zwave-water-valve.src/README.md
+++ b/devicetypes/smartthings/zwave-water-valve.src/README.md
@@ -1,0 +1,38 @@
+# Z-Wave Water Valve
+
+Cloud Execution
+
+Works with: 
+
+* [Leak Intelligence Leak Gopher Water Shutoff Valve](https://www.smartthings.com/works-with-smartthings/other/leak-intelligence-leak-gopher-water-shutoff-valve)
+
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+* [Troubleshooting](#Troubleshooting)
+
+## Capabilities
+
+* **Actuator** - represents that a Device has commands
+* **Health Check** - indicates ability to get device health notifications
+* **Valve** - allows for the control of a valve device
+* **Polling** - represents that poll() can be implemented for the device
+* **Refresh** - _refresh()_ command for status updates
+* **Sensor** - detects sensor events
+
+## Device Health
+
+SmartThings platform will ping the device after `checkInterval` seconds of inactivity in last attempt to reach the device before marking it `OFFLINE`
+
+* __32min__ checkInterval
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
+Pairing needs to be tried again by placing the device closer to the hub.
+Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following link:
+* [Leak Intelligence Leak Gopher Water Shutoff Valve Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/209631423-Leak-Gopher-Z-Wave-Valve-Control)
+
+

--- a/devicetypes/smartthings/zwave-water-valve.src/zwave-water-valve.groovy
+++ b/devicetypes/smartthings/zwave-water-valve.src/zwave-water-valve.groovy
@@ -14,12 +14,14 @@
 metadata {
 	definition (name: "Z-Wave Water Valve", namespace: "smartthings", author: "SmartThings") {
 		capability "Actuator"
+		capability "Health Check"
 		capability "Valve"
 		capability "Polling"
 		capability "Refresh"
 		capability "Sensor"
 
 		fingerprint deviceId: "0x1006", inClusters: "0x25"
+		fingerprint mfr:"0173", prod:"0003", model:"0002", deviceJoinName: "Leak Intelligence Leak Gopher Water Shutoff Valve"
 	}
 
 	// simulator metadata
@@ -53,7 +55,14 @@ metadata {
 
 }
 
+def installed() {
+	// Device-Watch simply pings if no device events received for 32min(checkInterval)
+	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
+}
+
 def updated() {
+	// Device-Watch simply pings if no device events received for 32min(checkInterval)
+	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 	response(refresh())
 }
 
@@ -112,6 +121,13 @@ def close() {
 
 def poll() {
     zwave.switchBinaryV1.switchBinaryGet().format()
+}
+
+/**
+ * PING is used by Device-Watch in attempt to reach the Device
+ * */
+def ping() {
+	refresh()
 }
 
 def refresh() {


### PR DESCRIPTION
1. Added health check for Leak Intelligence Leak Gopher Water Shutoff Valve.
2. 'checkInterval' is kept at 32min.
3. Ping is implemented using refresh().
4. Added the fingerprint of the Leak Intelligence Leak Gopher Water Shutoff Valve with the manufacturer and product code obtained from the raw description after pairing.
5. We've tested the checkInterval duration and the devices are marked OFFLINE within the stipulated time.
6. Added the README.md file.
@jackchi @ShunmugaSundar Please check and merge the changes.