### PR TITLE
[CHF-563] Health Check fibaro-door-window-sensor

### DIFF
--- a/devicetypes/smartthings/fibaro-door-window-sensor.src/.st-ignore
+++ b/devicetypes/smartthings/fibaro-door-window-sensor.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/fibaro-door-window-sensor.src/README.md
+++ b/devicetypes/smartthings/fibaro-door-window-sensor.src/README.md
@@ -1,0 +1,40 @@
+# Fibaro Door Window Sensor
+
+Cloud Execution
+
+Works with: 
+
+* [Fibaro Door/Window Sensor](https://www.smartthings.com/works-with-smartthings/sensors/fibaro-doorwindow-sensor)
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+* [Battery](#battery-specification)
+* [Troubleshooting](#troubleshooting)
+
+## Capabilities
+
+* **Contact Sensor** - can detect contact (possible values: open,closed)
+* **Sensor** - detects sensor events
+* **Battery** - defines device uses a battery
+* **Configuration** - _configure()_ command called when device is installed or device preferences updated
+* **Health Check** - indicates ability to get device health notifications
+
+## Device Health
+
+Fibaro Door/Window Sensor is a Z-wave sleepy device and wakes up every 4 hours.
+Device-Watch allows 2 check-in misses from device plus some lag time. So Check-in interval = (2*4*60 + 2)mins = 482 mins.
+
+* __482min__ checkInterval
+
+## Battery Specification
+
+One 1/2AA 3.6V battery is required.
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
+Pairing needs to be tried again by placing the device closer to the hub.
+Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following link:
+* [Fibaro Door/Window Sensor Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/204075194-Fibaro-Door-Window-Sensor)

--- a/devicetypes/smartthings/fibaro-door-window-sensor.src/fibaro-door-window-sensor.groovy
+++ b/devicetypes/smartthings/fibaro-door-window-sensor.src/fibaro-door-window-sensor.groovy
@@ -39,7 +39,8 @@
 		capability 	"Contact Sensor"
 		capability 	"Sensor"
 		capability 	"Battery"
-        capability 	"Configuration"
+		capability 	"Configuration"
+		capability  "Health Check"
         
         command		"resetParams2StDefaults"
         command		"listCurrentParams"
@@ -266,6 +267,9 @@ def zwaveEvent(physicalgraph.zwave.commands.manufacturerspecificv2.ManufacturerS
  */
 def configure() {
 	log.debug "Configuring Device..."
+	// Device wakes up every 4 hours, this interval allows us to miss one wakeup notification before marking offline
+	sendEvent(name: "checkInterval", value: 8 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
+
 	def cmds = []
 	cmds << zwave.configurationV1.configurationSet(configurationValue: [0,0], parameterNumber: 1, size: 2).format()
 	// send associate to group 3 to get sensor data reported only to hub


### PR DESCRIPTION
1. Added health check for Fibaro Door Window Sensor.
2. 'checkInterval' is kept at 482min.
3. It is a Z-wave sleepy device with a wake up interval of 4hours.
4. We've tested the checkInterval duration and the devices are marked OFFLINE within the stipulated time.
5. Added the README.md file.
@jackchi @ShunmugaSundar Please check and merge the changes.