### PR TITLE
[CHF-564] Health Check zwave-motion-sensor

### DIFF
--- a/devicetypes/smartthings/zwave-motion-sensor.src/.st-ignore
+++ b/devicetypes/smartthings/zwave-motion-sensor.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/zwave-motion-sensor.src/README.md
+++ b/devicetypes/smartthings/zwave-motion-sensor.src/README.md
@@ -1,0 +1,39 @@
+# Z-wave Motion Sensor
+
+Cloud Execution
+
+Works with: 
+
+* [Ecolink PIR Motion Detector with Pet Immunity](https://www.smartthings.com/works-with-smartthings/sensors/ecolink-pir-motion-detector-with-pet-immunity)
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+* [Battery](#battery-specification)
+* [Troubleshooting](#troubleshooting)
+
+## Capabilities
+
+* **Motion Sensor** - can detect motion
+* **Sensor** - detects sensor events
+* **Battery** - defines device uses a battery
+* **Health Check** - indicates ability to get device health notifications
+
+## Device Health
+
+Ecolink PIR Motion Detector with Pet Immunity is a Z-wave sleepy device and wakes up every 4 hours.
+Device-Watch allows 2 check-in misses from device plus some lag time. So Check-in interval = (2*4*60 + 2)mins = 482 mins.
+
+* __482min__ checkInterval
+
+## Battery Specification
+
+One CR123A Lithium 3V battery is required.
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
+Pairing needs to be tried again by placing the device closer to the hub.
+Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following link:
+* [Ecolink PIR Motion Detector with Pet Immunity Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/202294400-Ecolink-PIR-Motion-Detector-PIRZWAVE2-ECO-)

--- a/devicetypes/smartthings/zwave-motion-sensor.src/zwave-motion-sensor.groovy
+++ b/devicetypes/smartthings/zwave-motion-sensor.src/zwave-motion-sensor.groovy
@@ -21,6 +21,7 @@ metadata {
 		capability "Motion Sensor"
 		capability "Sensor"
 		capability "Battery"
+		capability "Health Check"
 
 		fingerprint mfr: "011F", prod: "0001", model: "0001", deviceJoinName: "Schlage Motion Sensor"  // Schlage motion
 		fingerprint mfr: "014A", prod: "0001", model: "0001", deviceJoinName: "Ecolink Motion Sensor"  // Ecolink motion
@@ -48,6 +49,11 @@ metadata {
 		main "motion"
 		details(["motion", "battery"])
 	}
+}
+
+def updated(){
+// Device wakes up every 4 hours, this interval allows us to miss one wakeup notification before marking offline
+	sendEvent(name: "checkInterval", value: 8 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 }
 
 def parse(String description) {


### PR DESCRIPTION
1. Added health check for Ecolink PIR Motion Detector (PIRZWAVE2-ECO).
2. 'checkInterval' is kept at 482min.
3. It is a Z-wave sleepy device with a wake up interval of 4hours.
4. We've tested the checkInterval duration and the devices are marked OFFLINE within the stipulated time.
5. Added the README.md file.
@jackchi @ShunmugaSundar Please check and merge the changes.