### PR TITLE
[CHF-560] Health Check Smartsense Moisture

### DIFF
--- a/devicetypes/smartthings/smartsense-moisture.src/.st-ignore
+++ b/devicetypes/smartthings/smartsense-moisture.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/smartsense-moisture.src/README.md
+++ b/devicetypes/smartthings/smartsense-moisture.src/README.md
@@ -1,0 +1,36 @@
+# Smartsense Moisture
+
+Cloud Execution
+
+Works with: 
+
+* [FortrezZ Moisture Sensor](https://www.smartthings.com/works-with-smartthings/fortrezz/fortrezz-moisture-sensor)
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+* [Troubleshooting](#troubleshooting)
+
+## Capabilities
+
+* **Water Sensor** - can detect presence of water (dry or wet)
+* **Sensor** - detects sensor events
+* **Battery** - defines device uses a battery
+* **Temperature Measurement** - represents capability to measure temperature
+* **Health Check** - indicates ability to get device health notifications
+
+## Device Health
+
+Smartsense Moisture is a Z-wave sleepy device type and checks in every 4 hours.
+Device-Watch allows 2 check-in misses from device plus some lag time. So Check-in interval = (2*4*60 + 2)mins = 482 mins.
+
+* __482min__ checkInterval
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the sensor is out of range.
+Pairing needs to be tried again by placing the sensor closer to the hub.
+Instructions related to pairing, resetting and removing the different motion sensors from SmartThings can be found in the following links
+for the different models:
+* [FortrezZ Moisture Sensor Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/200930740-FortrezZ-Moisture-Sensor)

--- a/devicetypes/smartthings/smartsense-moisture.src/smartsense-moisture.groovy
+++ b/devicetypes/smartthings/smartsense-moisture.src/smartsense-moisture.groovy
@@ -17,9 +17,11 @@ metadata {
 		capability "Sensor"
 		capability "Battery"
         capability "Temperature Measurement"
+		capability "Health Check"
 
 		fingerprint deviceId: "0x2001", inClusters: "0x30,0x9C,0x9D,0x85,0x80,0x72,0x31,0x84,0x86"
 		fingerprint deviceId: "0x2101", inClusters: "0x71,0x70,0x85,0x80,0x72,0x31,0x84,0x86"
+		fingerprint mfr:"0084", prod:"0063", model:"010C", deviceJoinName: "FortrezZ Moisture Sensor"
 	}
 
 	simulator {
@@ -87,6 +89,11 @@ def parse(String description) {
 	if(!result) result = [ descriptionText: parsedZwEvent, displayed: false ]
 	log.debug "Parse returned ${result}"
 	return result
+}
+
+def updated() {
+	// Device-Watch simply pings if no device events received for 482min(checkInterval)
+	sendEvent(name: "checkInterval", value: 2 * 4 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.wakeupv1.WakeUpNotification cmd)


### PR DESCRIPTION
1. Added health check for Fortrezz Moisture Sensor.
2. 'checkInterval' is kept at 482min.
3. It is a Z-wave sleepy device with 4hr check-in.
4. Added the fingerprint with the manufacturer and product code obtained from the raw description after pairing.
5. Added the README.md file.

@jackchi @ShunmugaSundar Please check and merge the changes.