### PR TITLE
[CHF-559] Health Check everspring-flood-sensor

### DIFF
--- a/devicetypes/smartthings/everspring-flood-sensor.src/.st-ignore
+++ b/devicetypes/smartthings/everspring-flood-sensor.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/everspring-flood-sensor.src/README.md
+++ b/devicetypes/smartthings/everspring-flood-sensor.src/README.md
@@ -1,0 +1,40 @@
+# Everspring Flood Sensor
+
+Cloud Execution
+
+Works with: 
+
+* [Everspring Water Detector](https://www.smartthings.com/works-with-smartthings/sensors/everspring-water-detector)
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+* [Battery](#battery-specification)
+* [Troubleshooting](#troubleshooting)
+
+## Capabilities
+
+* **Water Sensor** - can detect presence of water (dry or wet)
+* **Configuration** - _configure()_ command called when device is installed or device preferences updated
+* **Sensor** - detects sensor events
+* **Battery** - defines device uses a battery
+* **Health Check** - indicates ability to get device health notifications
+
+## Device Health
+
+Everspring Water Detector is a Z-wave sleepy device and wakes up every 4 hours.
+Device-Watch allows 2 check-in misses from device plus some lag time. So Check-in interval = (2*4*60 + 2)mins = 482 mins.
+
+* __482min__ checkInterval
+
+## Battery Specification
+
+Three AA 1.5V batteries are required.
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
+Pairing needs to be tried again by placing the device closer to the hub.
+Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following link:
+* [Everspring Water Detector Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/202088304-Everspring-Water-Detector)

--- a/devicetypes/smartthings/everspring-flood-sensor.src/everspring-flood-sensor.groovy
+++ b/devicetypes/smartthings/everspring-flood-sensor.src/everspring-flood-sensor.groovy
@@ -17,6 +17,7 @@ metadata {
 		capability "Configuration"
 		capability "Sensor"
 		capability "Battery"
+		capability "Health Check"
 
 		fingerprint deviceId: "0xA102", inClusters: "0x86,0x72,0x85,0x84,0x80,0x70,0x9C,0x20,0x71"
 	}
@@ -138,6 +139,8 @@ def zwaveEvent(physicalgraph.zwave.Command cmd)
 
 def configure()
 {
+	// Device wakes up every 4 hours, this interval allows us to miss one wakeup notification before marking offline
+	sendEvent(name: "checkInterval", value: 8 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 	if (!device.currentState("battery")) {
 		sendEvent(name: "battery", value:100, unit:"%", descriptionText:"(Default battery event)", displayed:false)
 	}


### PR DESCRIPTION
1. Added health check for Everspring Flood Sensor.
2. 'checkInterval' is kept at 482min.
3. It is a Z-wave sleepy device with a wake up interval of 4hours.
4. We've tested the checkInterval duration and the devices are marked OFFLINE within the stipulated time.
5. Added the README.md file.
@jackchi @ShunmugaSundar Please check and merge the changes.