### PR TITLE
[CHF-582] Health Check fibaro-door-window-sensor-zw5

### DIFF
--- a/devicetypes/fibargroup/fibaro-door-window-sensor-zw5.src/.st-ignore
+++ b/devicetypes/fibargroup/fibaro-door-window-sensor-zw5.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/fibargroup/fibaro-door-window-sensor-zw5.src/README.md
+++ b/devicetypes/fibargroup/fibaro-door-window-sensor-zw5.src/README.md
@@ -1,0 +1,41 @@
+# Fibaro Door Window Sensor ZW5
+
+Cloud Execution
+
+Works with: 
+
+* [Fibaro Door/Window Sensor ZW5](https://www.smartthings.com/works-with-smartthings/sensors/fibaro-doorwindow-sensor)
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+* [Battery](#battery-specification)
+* [Troubleshooting](#troubleshooting)
+
+## Capabilities
+
+* **Battery** - defines device uses a battery
+* **Contact Sensor** - can detect contact (possible values: open,closed)
+* **Sensor** - detects sensor events
+* **Tamper Alert** - detects tampers
+* **Configuration** - _configure()_ command called when device is installed or device preferences updated
+* **Health Check** - indicates ability to get device health notifications
+
+## Device Health
+
+Fibaro Door/Window Sensor ZW5 is a Z-wave sleepy device and wakes up every 4 hours.
+Device-Watch allows 2 check-in misses from device plus some lag time. So Check-in interval = (2*4*60 + 2)mins = 482 mins.
+
+* __482min__ checkInterval
+
+## Battery Specification
+
+One 1/2AA 3.6V battery is required.
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
+Pairing needs to be tried again by placing the device closer to the hub.
+Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following link:
+* [Fibaro Door/Window Sensor ZW5 Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/204075194-Fibaro-Door-Window-Sensor)

--- a/devicetypes/fibargroup/fibaro-door-window-sensor-zw5.src/fibaro-door-window-sensor-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-door-window-sensor-zw5.src/fibaro-door-window-sensor-zw5.groovy
@@ -20,6 +20,7 @@ metadata {
 		capability "Sensor"
         capability "Configuration"
         capability "Tamper Alert"
+		capability "Health Check"
 
         fingerprint deviceId: "0x0701", inClusters: "0x5E, 0x85, 0x59, 0x22, 0x20, 0x80, 0x70, 0x56, 0x5A, 0x7A, 0x72, 0x8E, 0x71, 0x73, 0x98, 0x2B, 0x9C, 0x30, 0x86, 0x84", outClusters: ""
 	}
@@ -199,7 +200,9 @@ def zwaveEvent(physicalgraph.zwave.commands.deviceresetlocallyv1.DeviceResetLoca
 
 def configure() {
 	log.debug "Executing 'configure'"
-    
+	// Device wakes up every 4 hours, this interval allows us to miss one wakeup notification before marking offline
+	sendEvent(name: "checkInterval", value: 8 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
+
     def cmds = []
     
     cmds += zwave.wakeUpV2.wakeUpIntervalSet(seconds:21600, nodeid: zwaveHubNodeId)//FGK's default wake up interval


### PR DESCRIPTION
1. Added health check for Fibaro Door Window Sensor ZW5.
2. 'checkInterval' is kept at 482min.
3. It is a Z-wave sleepy device with a wake up interval of 4hours.
4. We've tested the checkInterval duration and the devices are marked OFFLINE within the stipulated time.
5. Added the README.md file.
@jackchi @ShunmugaSundar Please check and merge the changes.