### PR TITLE
[CHF-557] Health Check ZigBee Lock

### DIFF
--- a/devicetypes/smartthings/zigbee-lock.src/.st-ignore
+++ b/devicetypes/smartthings/zigbee-lock.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/zigbee-lock.src/README.md
+++ b/devicetypes/smartthings/zigbee-lock.src/README.md
@@ -1,0 +1,46 @@
+# Zigbee Lock
+
+Cloud Execution
+
+Works with: 
+
+* [Yale Push Button Deadbolt (YRD210-HA)](https://www.smartthings.com/works-with-smartthings/door-locks/yale-push-button-deadbolt-yrd210)
+* [Yale Touchscreen Lever (YRL220-ZB)](https://www.smartthings.com/works-with-smartthings/door-locks/yale-touchscreen-lever-yrl220)
+* [Yale Touchscreen Deadbolt (YRD220-HA))](https://www.smartthings.com/works-with-smartthings/door-locks/yale-touchscreen-deadbolt-yrd220)
+* [Yale Key Free Touchscreen Deadbolt (YRD240-HA)](https://www.smartthings.com/works-with-smartthings/door-locks/yale-key-free-touchscreen-deadbolt-yrd240)
+* [Yale Push Button Lever Lock (YRL210-HA)](https://www.smartthings.com/works-with-smartthings/door-locks/yale-push-button-lever-lock-yrl210)
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+* [Battery](#battery-specification)
+* [Troubleshooting](#troubleshooting)
+
+## Capabilities
+
+* **Actuator** - represents that a Device has commands
+* **Lock** - allows for the control of a lock device
+* **Refresh** - _refresh()_ command for status updates
+* **Sensor** - detects sensor events
+* **Battery** - defines device uses a battery
+* **Configuration** - _configure()_ command called when device is installed or device preferences updated
+* **Health Check** - indicates ability to get device health notifications
+
+## Device Health
+
+Yale Push Button Deadbolt (YRD210-HA) is a Zigbee device and checks in every 1 hour.
+Device-Watch allows 2 check-in misses from device plus some lag time. So Check-in interval = (2*60 + 2)mins = 122 mins.
+
+ * __122min__ checkInterval
+
+## Battery Specification
+
+Four AA 1.5V batteries are required.
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
+Pairing needs to be tried again by placing the device closer to the hub.
+Instructions related to pairing, resetting and removing the sensor from SmartThings can be found in the following link:
+* [Yale Locks Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/205138400)

--- a/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
+++ b/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
@@ -24,6 +24,7 @@ import physicalgraph.zigbee.zcl.DataType
         capability "Sensor"
         capability "Battery"
         capability "Configuration"
+        capability "Health Check"
 
         fingerprint profileId: "0104", inClusters: "0000,0001,0003,0004,0005,0009,0020,0101,0402,0B05,FDBD", outClusters: "000A,0019", manufacturer: "Kwikset", model: "SMARTCODE_DEADBOLT_5", deviceJoinName: "Kwikset 5-Button Deadbolt"
         fingerprint profileId: "0104", inClusters: "0000,0001,0003,0004,0005,0009,0020,0101,0402,0B05,FDBD", outClusters: "000A,0019", manufacturer: "Kwikset", model: "SMARTCODE_LEVER_5", deviceJoinName: "Kwikset 5-Button Lever"
@@ -83,6 +84,9 @@ def uninstalled() {
 }
 
 def configure() {
+    // Device-Watch allows 2 check-in misses from device + ping (plus 2 min lag time)
+    sendEvent(name: "checkInterval", value: 2 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+
     def cmds =
         zigbee.configureReporting(CLUSTER_DOORLOCK, DOORLOCK_ATTR_LOCKSTATE,
                                   DataType.ENUM8, 0, 3600, null) +
@@ -90,6 +94,13 @@ def configure() {
                                   DataType.UINT8, 600, 21600, 0x01)
     log.info "configure() --- cmds: $cmds"
     return refresh() + cmds // send refresh cmds as part of config
+}
+
+/**
+ * PING is used by Device-Watch in attempt to reach the Device
+ * */
+def ping() {
+    zigbee.readAttribute(CLUSTER_DOORLOCK, DOORLOCK_ATTR_LOCKSTATE)
 }
 
 def refresh() {


### PR DESCRIPTION
1. Added health check for Yale Zigbee Locks.
2. 'checkInterval' is kept at 122min.
3. It is a Zigbee device with 1hr check-in.
4. We've tested the checkInterval duration and the devices are marked OFFLINE within the stipulated time.
5. Added the README.md file.
@jackchi @ShunmugaSundar Please check and merge the changes.