### PR TITLE
DPROT-263 EBF-1205 DVCSMP-2420 Support config on both temp-humidty firmwares

### DIFF
--- a/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-temp-humidity-sensor.src/smartsense-temp-humidity-sensor.groovy
@@ -135,10 +135,7 @@ def refresh() {
 	return zigbee.readAttribute(0xFC45, 0x0000, ["mfgCode": 0x104E]) +   // New firmware
 			zigbee.readAttribute(0xFC45, 0x0000, ["mfgCode": 0xC2DF]) +   // Original firmware
 			zigbee.readAttribute(zigbee.TEMPERATURE_MEASUREMENT_CLUSTER, 0x0000) +
-			zigbee.readAttribute(zigbee.POWER_CONFIGURATION_CLUSTER, 0x0020) +
-			zigbee.configureReporting(0xFC45, 0x0000, DataType.INT16, 30, 3600, 100) +
-			zigbee.batteryConfig() +
-			zigbee.temperatureConfig(30, 300)
+			zigbee.readAttribute(zigbee.POWER_CONFIGURATION_CLUSTER, 0x0020)
 }
 
 def configure() {
@@ -150,5 +147,10 @@ def configure() {
 
 	// temperature minReportTime 30 seconds, maxReportTime 5 min. Reporting interval if no activity
 	// battery minReport 30 seconds, maxReportTime 6 hrs by default
-	return refresh()
+	return refresh() +
+			zigbee.configureReporting(0xFC45, 0x0000, DataType.UINT16, 30, 3600, 100, ["mfgCode": 0x104E]) +   // New firmware
+			zigbee.configureReporting(0xFC45, 0x0000, DataType.UINT16, 30, 3600, 100, ["mfgCode": 0xC2DF]) +   // Original firmware
+			zigbee.batteryConfig() +
+			zigbee.temperatureConfig(30, 300)
+
 }


### PR DESCRIPTION
This solves an issue with invalid configuration of the reporting for
humidity on the smartsense-temp-humidity-sensor.  This issue was masked
by the fact that the device has a default configuration for reporting
humidity, but the configuration has never been valid as it used an
incorrect dataType for the configuration.

This resolves: https://smartthings.atlassian.net/browse/DPROT-263
This resolves: https://smartthings.atlassian.net/browse/EBF-1205
This resolves: https://smartthings.atlassian.net/browse/DVCSMP-2420

@tpmanley @workingmonk 