### PR TITLE
To Wattvision power metering Sensor DTH, added Capability "Sensor"

### DIFF
--- a/devicetypes/smartthings/wattvision.src/wattvision.groovy
+++ b/devicetypes/smartthings/wattvision.src/wattvision.groovy
@@ -20,6 +20,7 @@ metadata {
 	definition(name: "Wattvision", namespace: "smartthings", author: "Steve Vlaminck") {
 		capability "Power Meter"
 		capability "Refresh"
+		capability "Sensor"
 		attribute "powerContent", "string"
 	}
 


### PR DESCRIPTION
There are some integrations (SmartApps) out there using the "Actuator" and "Sensor" Capabilities and instances of this Wattvision energy Sensor Device (and perhaps more) do not show up for them. _Example_ SmartApp "ActionTiles".
- Ref Docs: http://docs.smartthings.com/en/latest/device-type-developers-guide/overview.html?highlight=sensor%20actuator#actuator-and-sensor
- Ref Issue #1058.
- Ref @tslagle13 for more info regarding **ActionTiles**'s use of these standard Capabilities as device authorization input filters.
- Internal Ref: [`ActionTiles's Topic #1263`](http://support.actiontiles.com/topics/1263-wattvision-integration/).

**CC:** @tylerlange , @workingmonk 

_Thank-you!_