### PR TITLE
[CHF-596] Device Health Enrollment Fix

### DIFF
--- a/devicetypes/smartthings/logitech-harmony-hub-c2c.src/logitech-harmony-hub-c2c.groovy
+++ b/devicetypes/smartthings/logitech-harmony-hub-c2c.src/logitech-harmony-hub-c2c.groovy
@@ -1,3 +1,4 @@
+import groovy.json.JsonOutput
 /**
  *  Logitech Harmony Hub
  *


### PR DESCRIPTION
We left off `JsonOutput` therefore the Enrollment event was not getting to Device-Watch

cc @workingmonk @parijatdas 