### PR TITLE
DVCSMP-2568 Arrival-sensor-ha Read battery level on join

### DIFF
--- a/devicetypes/smartthings/arrival-sensor-ha.src/arrival-sensor-ha.groovy
+++ b/devicetypes/smartthings/arrival-sensor-ha.src/arrival-sensor-ha.groovy
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2016 SmartThings
+ *  Copyright 2017 SmartThings
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  *  in compliance with the License. You may obtain a copy of the License at:
@@ -59,7 +59,7 @@ def updated() {
 }
 
 def configure() {
-    def cmds = zigbee.batteryConfig(20, 20, 0x01)
+    def cmds = zigbee.readAttribute(zigbee.POWER_CONFIGURATION_CLUSTER, 0x0020) + zigbee.batteryConfig(20, 20, 0x01)
     log.debug "configure -- cmds: ${cmds}"
     return cmds
 }


### PR DESCRIPTION
In configure we were setting up the battery level to be reported every
20 seconds but we weren't reading the attribute so it would take 20
seconds before the battery level was reported. Now we read it during
configure so it is updated right away after join.

https://smartthings.atlassian.net/browse/DVCSMP-2568