### PR TITLE
[CHF-561] Health Check Plant Link

### DIFF
--- a/devicetypes/osotech/plantlink.src/.st-ignore
+++ b/devicetypes/osotech/plantlink.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/osotech/plantlink.src/README.md
+++ b/devicetypes/osotech/plantlink.src/README.md
@@ -1,4 +1,4 @@
-# Plant Link
+# Osotech Plant Link
 
 Cloud Execution
 
@@ -14,9 +14,7 @@ Works with:
 
 ## Capabilities
 
-* **Relative Humidity Measurement** - allows reading the relative humidity from devices that support it
 * **Sensor** - detects sensor events
-* **Battery** - defines device uses a battery
 * **Health Check** - indicates ability to get device health notifications
 
 ## Device Health

--- a/devicetypes/osotech/plantlink.src/plantlink.groovy
+++ b/devicetypes/osotech/plantlink.src/plantlink.groovy
@@ -24,6 +24,7 @@ import groovy.json.JsonBuilder
 metadata {
     definition (name: "PlantLink", namespace: "OsoTech", author: "Oso Technologies") {
         capability "Sensor"
+        capability "Health Check"
 
         command "setStatusIcon"
         command "setPlantFuelLevel"
@@ -68,6 +69,16 @@ metadata {
         main "plantStatusTextTile"
         details(['plantStatusTextTile', "plantMoistureTile", "battery", "installSmartApp"])
     }
+}
+
+def updated() {
+    // Device-Watch allows 2 check-in misses from device
+    sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+}
+
+def installed() {
+    // Device-Watch allows 2 check-in misses from device
+    sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
 }
 
 def setStatusIcon(value){

--- a/devicetypes/smartthings/zwave-lock.src/README.md
+++ b/devicetypes/smartthings/zwave-lock.src/README.md
@@ -1,11 +1,10 @@
-# Z-Wave Switch
+# Z-Wave Lock
 
 Cloud Execution
 
 Works with: 
 
 * [Yale Key Free Touchscreen Deadbolt (YRD240)](https://www.smartthings.com/works-with-smartthings/yale/yale-key-free-touchscreen-deadbolt-yrd240)
-
 
 ## Table of contents
 
@@ -41,5 +40,3 @@ If the device doesn't pair when trying from the SmartThings mobile app, it is po
 Pairing needs to be tried again by placing the device closer to the hub.
 Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following link:
 * [General Z-Wave/ZigBee Yale Lock Troubleshooting](https://support.smartthings.com/hc/en-us/articles/205138400-How-to-connect-Yale-locks)
-
-


### PR DESCRIPTION
1. Added health check for OSO Technologies PlantLink Soil Moisture Sensor.
2. 'checkInterval' is kept at 32min.
3. It is a Z-wave sleepy device with 15min check-in.
4. Added the README.md file.
5. Fixed Readme typo for ZWave Lock.

@jackchi @ShunmugaSundar Please check and merge the changes.