### PR TITLE
[ICP-691] Set level on sengled bulbs configure

### DIFF
--- a/devicetypes/smartthings/zigbee-dimmer-power.src/zigbee-dimmer-power.groovy
+++ b/devicetypes/smartthings/zigbee-dimmer-power.src/zigbee-dimmer-power.groovy
@@ -114,9 +114,17 @@ def refresh() {
 
 def configure() {
     log.debug "Configuring Reporting and Bindings."
-
+    def cmds = []
+    if (device.getDataValue("manufacturer") == "sengled") {
+        def startLevel = 0xFE
+        if ((device.currentState("level")?.value != null)) {
+            startLevel = Math.round(Integer.parseInt(device.currentState("level").value) * 0xFE / 100)
+        }
+        // Level Control Cluster, command Move to Level, level start level, transition time 0
+        cmds << zigbee.command(zigbee.LEVEL_CONTROL_CLUSTER, 0x00, sprintf("%02X0000", startLevel))
+    }
     // Device-Watch allows 2 check-in misses from device + ping (plus 1 min lag time)
     // enrolls with default periodic reporting until newer 5 min interval is confirmed
     sendEvent(name: "checkInterval", value: 2 * 60 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
-    refresh()
+    cmds + refresh()
 }


### PR DESCRIPTION
This works around the sengled bulbs not following the ZCL spec and using
the value 0xFF as a valid level (the spec says it should be invalid).
It does this by manually setting the level of the bulb to
0xFE (SmartThings 100%) when it is configured, or if it previously had a
level set, manually setting it to that value.  This avoids the issue of
the bulb reporting 0xFF and having the library ignore it because it is
an invalid value.

This resolves: https://smartthings.atlassian.net/browse/ICP-691

@tpmanley @workingmonk 