### PR TITLE
[DOCS-469] Tile layout changes for Simulated Refrigerator

### DIFF
--- a/devicetypes/smartthings/testing/simulated-refrigerator-door.src/simulated-refrigerator-door.groovy
+++ b/devicetypes/smartthings/testing/simulated-refrigerator-door.src/simulated-refrigerator-door.groovy
@@ -33,9 +33,11 @@ metadata {
 			state("closed", label:'Fridge', icon:"st.contact.contact.closed", backgroundColor:"#79b821")
 			state("open", label:'Fridge', icon:"st.contact.contact.open", backgroundColor:"#ffa81e")
 		}
-		standardTile("control", "device.contact", width: 1, height: 1, decoration: "flat") {
+        
+		standardTile("control", "device.contact", width: 2, height: 2, decoration: "flat") {
 			state("closed", label:'${name}', icon:"st.contact.contact.closed", action: "open")
 			state("open", label:'${name}', icon:"st.contact.contact.open", action: "close")
+           
 		}
 		main "contact"
 		details "contact"

--- a/devicetypes/smartthings/testing/simulated-refrigerator-temperature-control.src/simulated-refrigerator-temperature-control.groovy
+++ b/devicetypes/smartthings/testing/simulated-refrigerator-temperature-control.src/simulated-refrigerator-temperature-control.groovy
@@ -24,9 +24,9 @@ metadata {
 		command "setpointDown"
 	}
 
-	tiles {
+	tiles (scale: 1) {
 		valueTile("refrigerator", "device.temperature", width: 2, height: 2, canChangeBackground: true) {
-			state("temperature", label:'${currentValue}°', unit:"F",
+			state("temperature", label:'RFRG ${currentValue}°', unit:"F",
 					backgroundColors:[
 							[value: 0, color: "#153591"],
 							[value: 40, color: "#1e9cbb"],
@@ -35,7 +35,7 @@ metadata {
 			)
 		}
 		valueTile("freezer", "device.temperature", width: 2, height: 2, canChangeBackground: true) {
-			state("temperature", label:'${currentValue}°', unit:"F",
+			state("temperature", label:'FRZR ${currentValue}°', unit:"F",
 					backgroundColors:[
 							[value: 0, color: "#153591"],
 							[value: 5, color: "#1e9cbb"],
@@ -43,17 +43,19 @@ metadata {
 					]
 			)
 		}
-		valueTile("freezerSetpoint", "device.coolingSetpoint", inactiveLabel: false, decoration: "flat") {
-			state "setpoint", label:'Freezer Set: ${currentValue}°', unit:"F"
-		}
-		valueTile("refrigeratorSetpoint", "device.coolingSetpoint", inactiveLabel: false, decoration: "flat") {
-			state "heat", label:'Fridge Set: ${currentValue}°', unit:"F"
+        // Refrigerator Set Point display
+        valueTile("refrigeratorSetpoint", "device.coolingSetpoint", inactiveLabel: false, decoration: "flat") {
+			state "heat", label:'Set Fridge: ${currentValue}°', unit:"F"
 		}
 		standardTile("tempUp", "device.temperature", inactiveLabel: false, decoration: "flat") {
 			state "default", action:"tempUp", icon:"st.thermostat.thermostat-up"
 		}
 		standardTile("tempDown", "device.temperature", inactiveLabel: false, decoration: "flat") {
 			state "default", action:"tempDown", icon:"st.thermostat.thermostat-down"
+		}
+         // Freezer Set Point display
+		valueTile("freezerSetpoint", "device.coolingSetpoint", inactiveLabel: false, decoration: "flat") {
+			state "setpoint", label:'Set Freezer: ${currentValue}°', unit:"F"
 		}
 		standardTile("setpointUp", "device.coolingSetpoint", inactiveLabel: false, decoration: "flat") {
 			state "default", action:"setpointUp", icon:"st.thermostat.thermostat-up"
@@ -62,6 +64,7 @@ metadata {
 			state "default", action:"setpointDown", icon:"st.thermostat.thermostat-down"
 		}
 	}
+    main "refrigerator"
 }
 
 def installed() {

--- a/devicetypes/smartthings/testing/simulated-refrigerator.src/simulated-refrigerator.groovy
+++ b/devicetypes/smartthings/testing/simulated-refrigerator.src/simulated-refrigerator.groovy
@@ -24,28 +24,53 @@ metadata {
 	}
 
 	tiles(scale: 2) {
-		standardTile("contact", "device.contact", width: 4, height: 4) {
+    	// Row 1: Refrigerator door open/close display
+		standardTile("contact", "device.contact", width: 2, height: 2) {
 			state("closed", label:'${name}', icon:"st.fridge.fridge-closed", backgroundColor:"#79b821")
 			state("open", label:'${name}', icon:"st.fridge.fridge-open", backgroundColor:"#ffa81e")
 		}
-		childDeviceTile("freezerDoor", "freezerDoor", height: 2, width: 2, childTileName: "freezerDoor")
+        // Row 1: Fridge and Freezer Door open/close displays
 		childDeviceTile("mainDoor", "mainDoor", height: 2, width: 2, childTileName: "mainDoor")
-		childDeviceTile("freezer", "freezer", height: 2, width: 2, childTileName: "freezer")
-		childDeviceTile("refrigerator", "refrigerator", height: 2, width: 2, childTileName: "refrigerator")
-		childDeviceTile("freezerSetpoint", "freezer", height: 1, width: 2, childTileName: "freezerSetpoint")
-		childDeviceTile("refrigeratorSetpoint", "refrigerator", height: 1, width: 2, childTileName: "refrigeratorSetpoint")
-
-		// for simulator
+		childDeviceTile("freezerDoor", "freezerDoor", height: 2, width: 2, childTileName: "freezerDoor")
+        
+        // Row 2: Label for Door open/close controls
+        valueTile("doorControlLabel", "device.contact", width: 2, height: 2, decoration: "flat") {
+            state "contact", label:'Door Control'
+    	}
+        // Row 2: Door open/close controls from "Simulated Refrigerator Door" child 
+        childDeviceTile("mainDoorControl", "mainDoor", height: 2, width: 2, childTileName: "control")
+        childDeviceTile("freezerDoorControl", "freezerDoor", height: 2, width: 2, childTileName: "control")
+		
+        // Row 3: Refrigerator and freezer temperature displays from "Simulated Refrigerator Temperature Control" child
+		childDeviceTile("refrigerator", "refrigerator", height: 2, width: 3) //, childTileName: "refrigerator")
+		childDeviceTile("freezer", "freezer", height: 2, width: 3, childTileName: "freezer")
+        
+        // Row 4: Label for up/down temp controls for refrigerator
+        valueTile("fridgUpDownLabel", "device.contact", width: 1, height: 1, decoration: "flat") {
+            state "contact", label:'Fridge'
+    	}
+        // Row 4: Up/down temp controls for the refrigerator
+        childDeviceTile("refrigeratorUp", "refrigerator", height: 1, width: 1, childTileName: "tempUp")
+		childDeviceTile("refrigeratorDown", "refrigerator", height: 1, width: 1, childTileName: "tempDown")
+        // Row 4: Label for up/down temp controls for the freezer
+        valueTile("freezerUpDown", "device.contact", width: 1, height: 1, decoration: "flat") {
+            state "contact", label:'Freezer'
+    	}
+        // Row 4: Up/down temp controls for the freezer
 		childDeviceTile("freezerUp", "freezer", height: 1, width: 1, childTileName: "tempUp")
 		childDeviceTile("freezerDown", "freezer", height: 1, width: 1, childTileName: "tempDown")
-		childDeviceTile("refrigeratorUp", "refrigerator", height: 1, width: 1, childTileName: "tempUp")
-		childDeviceTile("refrigeratorDown", "refrigerator", height: 1, width: 1, childTileName: "tempDown")
-		childDeviceTile("freezerDoorControl", "freezerDoor", height: 1, width: 1, childTileName: "control")
-		childDeviceTile("mainDoorControl", "mainDoor", height: 1, width: 1, childTileName: "control")
-		childDeviceTile("freezerSetpointUp", "freezer", height: 1, width: 1, childTileName: "setpointUp")
-		childDeviceTile("freezerSetpointDown", "freezer", height: 1, width: 1, childTileName: "setpointDown")
-		childDeviceTile("refrigeratorSetpointUp", "refrigerator", height: 1, width: 1, childTileName: "setpointUp")
+       
+       	// Row 5: "Set Fridge:" label and up/down controls display from "Simulated Refrigerator Temperature Control" child
+		childDeviceTile("refrigeratorSetpoint", "refrigerator", height: 1, width: 1, childTileName: "refrigeratorSetpoint")  
+        childDeviceTile("refrigeratorSetpointUp", "refrigerator", height: 1, width: 1, childTileName: "setpointUp")
 		childDeviceTile("refrigeratorSetpointDown", "refrigerator", height: 1, width: 1, childTileName: "setpointDown")
+       
+        // Row 5: "Set Freezer:" label and up/down controls display from "Simulated Refrigerator Temperature Control" child
+		childDeviceTile("freezerSetpoint", "freezer", height: 1, width: 1, childTileName: "freezerSetpoint")
+        childDeviceTile("freezerSetpointUp", "freezer", height: 1, width: 1, childTileName: "setpointUp")
+		childDeviceTile("freezerSetpointDown", "freezer", height: 1, width: 1, childTileName: "setpointDown")
+        
+        main "contact"
 	}
 }
 
@@ -53,6 +78,7 @@ def installed() {
 	state.counter = state.counter ? state.counter + 1 : 1
 	if (state.counter == 1) {
 		addChildDevice(
+        		// Explicitly calling the child Device Handler with the name "Simulated Refrigerator Door" is how it is associated with this parent Device Handler.
 				"Simulated Refrigerator Door",
 				"${device.deviceNetworkId}.1",
 				null,


### PR DESCRIPTION
@bflorian please review. Tile layout changed for the parent Simulated Refrigerator, for better readability in documentation. Also added comments liberally.

Attached screenshot shows new detail layout.
![sim_fridge_detail](https://cloud.githubusercontent.com/assets/22141615/25209410/c3d00088-252f-11e7-9207-ada69d909e9a.png)

Related to https://github.com/SmartThingsCommunity/Documentation/pull/605
/cc @jimmyjames 