### PR TITLE
[DVCSMP-2590] Switch Initial State SA to use asynchttp

### DIFF
--- a/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
+++ b/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
@@ -18,6 +18,8 @@
  *  Privacy Policy for Initial State can be found here: https://www.initialstate.com/terms
  */
 
+include 'asynchttp_v1'
+
 definition(
     name: "Initial State Event Streamer",
     namespace: "initialstate.events",
@@ -350,27 +352,16 @@ def tryShipEvents(event) {
 		return
 	}
 
-	def eventPost = [
-		uri: "https://${grokerSubdomain}.initialstate.com/api/events",
-		headers: [
-			"Content-Type": "application/json",
-			"X-IS-BucketKey": "${bucketKey}",
-			"X-IS-AccessKey": "${accessKey}",
-			"Accept-Version": "0.0.2"
-		],
-		body: event
-	]
+def eventPost = [
+    uri: "https://${grokerSubdomain}.initialstate.com/api/events",
+    headers: [
+      "Content-Type": "application/json",
+      "X-IS-BucketKey": "${bucketKey}",
+      "X-IS-AccessKey": "${accessKey}",
+      "Accept-Version": "0.0.2"
+    ],
+    body: event
+  ]
 
-	try {
-		// post the events to initial state
-		httpPostJson(eventPost) { resp ->
-			log.debug "shipped events and got ${resp.status}"
-			if (resp.status >= 400) {
-				log.error "shipping failed... ${resp.data}"
-			}
-		}
-	} catch (e) {
-		log.error "shipping events failed: $e"
-	}
-
+  asynchttp_v1.post(null, eventPost)
 }


### PR DESCRIPTION
The "Initial State Event Streamer" SmartApp is currently using the synchronous HTTP client to make API calls. This results in a large amount of compute time spent waiting for requests to complete that could be better utilized. According to Sumo on any given day we are spending several days worth in hours of time blocked on I/O for just this application.

This PR changes the client to use the async client in a fire-and-forget mode (i.e. failures are not handled). I don't have a way of testing this change yet but I want to get it open so people can take a peek and look it over.

This also cannot go out until PRP-511 has been deployed. 