### PR TITLE
DVCSMP-2573: Acceleration axis validation (Multi sensor DTH)

### DIFF
--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -192,6 +192,10 @@ private List<Map> parseAxis(List<Map> attrData) {
 	def y = hexToSignedInt(attrData.find { it.attrInt == 0x0013 }?.value)
 	def z = hexToSignedInt(attrData.find { it.attrInt == 0x0014 }?.value)
 
+	if ([x, y ,z].any { it == null }) {
+		return []
+	}
+
 	def xyzResults = [:]
 	if (device.getDataValue("manufacturer") == "SmartThings") {
 		// This mapping matches the current behavior of the Device Handler for the Centralite sensors
@@ -372,6 +376,10 @@ def updated() {
 }
 
 private hexToSignedInt(hexVal) {
+	if (!hexVal) {
+		return null
+	}
+
 	def unsignedVal = hexToInt(hexVal)
 	unsignedVal > 32767 ? unsignedVal - 65536 : unsignedVal
 }


### PR DESCRIPTION
In certain cases the SmartSense Multi Sensors are
missing the Y and Z axis, causing an exception
during .parseAxis(). This change checks that all
3 axis are present before processing the rest of
the message.