### PR TITLE
[CHF-590] Health Check smartalert-siren

### DIFF
--- a/devicetypes/smartthings/smartalert-siren.src/.st-ignore
+++ b/devicetypes/smartthings/smartalert-siren.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/smartalert-siren.src/README.md
+++ b/devicetypes/smartthings/smartalert-siren.src/README.md
@@ -1,0 +1,39 @@
+# Smartalert Siren
+
+Cloud Execution
+
+Works with:
+
+* [FortrezZ Siren Strobe Alarm](https://www.smartthings.com/works-with-smartthings/other/fortrezz-water-valve)
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+* [Troubleshooting](#troubleshooting)
+
+## Capabilities
+
+* **Actuator** - represents that a Device has commands
+* **Switch** - can detect state (possible values: on/off)
+* **Sensor** - detects sensor events
+* **Alarm** - allows for interacting with devices that serve as alarms
+* **Health Check** - indicates ability to get device health notifications
+
+## Device Health
+
+FortrezZ Siren Strobe Alarm is polled by the hub.
+As of hubCore version 0.14.38 the hub sends up reports every 15 minutes regardless of whether the state changed.
+Device-Watch allows 2 check-in misses from device plus some lag time. So Check-in interval = (2*15 + 2)mins = 32 mins.
+Not to mention after going OFFLINE when the device is plugged back in, it might take a considerable amount of time for
+the device to appear as ONLINE again. This is because if this listening device does not respond to two poll requests in a row,
+it is not polled for 5 minutes by the hub. This can delay up the process of being marked ONLINE by quite some time.
+
+* __32min__ checkInterval
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
+Pairing needs to be tried again by placing the device closer to the hub.
+Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following link:
+* [FortrezZ Siren Strobe Alarm Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/202294760-FortrezZ-Siren-Strobe-Alarm)

--- a/devicetypes/smartthings/smartalert-siren.src/smartalert-siren.groovy
+++ b/devicetypes/smartthings/smartalert-siren.src/smartalert-siren.groovy
@@ -21,10 +21,12 @@ metadata {
 		capability "Switch"
 		capability "Sensor"
 		capability "Alarm"
+		capability "Health Check"
 
 		command "test"
 
 		fingerprint deviceId: "0x1100", inClusters: "0x26,0x71"
+		fingerprint mfr:"0084", prod:"0313", model:"010B", deviceJoinName: "FortrezZ Siren Strobe Alarm"
 	}
 
 	simulator {
@@ -66,6 +68,16 @@ metadata {
 		main "alarm"
 		details(["alarm","strobe","siren","test","off"])
 	}
+}
+
+def installed() {
+// Device-Watch simply pings if no device events received for 32min(checkInterval)
+	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
+}
+
+def updated() {
+// Device-Watch simply pings if no device events received for 32min(checkInterval)
+	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 }
 
 def on() {
@@ -148,4 +160,11 @@ def createEvents(physicalgraph.zwave.commands.basicv1.BasicReport cmd)
 
 def zwaveEvent(physicalgraph.zwave.Command cmd) {
 	log.warn "UNEXPECTED COMMAND: $cmd"
+}
+
+/**
+ * PING is used by Device-Watch in attempt to reach the Device
+ * */
+def ping() {
+	secure(zwave.basicV1.basicGet())
 }


### PR DESCRIPTION
1. Added health check for FortrezZ Siren Strobe Alarm.
2. 'checkInterval' is kept at 32min.
3. Ping is implemented using refresh().
4. Added the fingerprint of the FortrezZ Siren Strobe Alarm with the manufacturer and product code obtained from the raw description after pairing.
5. Added the README.md file.
6. Physical device to be tested with changes as it is not available currently in SRI-B.
@jackchi @ShunmugaSundar Please check and merge the code changes.