### PR TITLE
[DVCSMP-2597] Fix sengled use of FF for max level

### DIFF
--- a/devicetypes/smartthings/zigbee-dimmer-power.src/zigbee-dimmer-power.groovy
+++ b/devicetypes/smartthings/zigbee-dimmer-power.src/zigbee-dimmer-power.groovy
@@ -70,19 +70,27 @@ def parse(String description) {
         else {
             sendEvent(event)
         }
-    }
-    else {
-        def cluster = zigbee.parse(description)
-        if (cluster && cluster.clusterId == 0x0006 && cluster.command == 0x07) {
-            if (cluster.data[0] == 0x00){
+    } else {
+        def descMap = zigbee.parseDescriptionAsMap(description)
+        if (descMap && descMap.clusterInt == 0x0006 && descMap.commandInt == 0x07) {
+            if (descMap.data[0] == "00") {
                 log.debug "ON/OFF REPORTING CONFIG RESPONSE: " + cluster
                 sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
-            }
-            else {
+            } else {
                 log.warn "ON/OFF REPORTING CONFIG FAILED- error code:${cluster.data[0]}"
             }
-        }
-        else {
+        } else if (device.getDataValue("manufacturer") == "sengled" && descMap && descMap.clusterInt == 0x0008 && descMap.attrInt == 0x0000) {
+            // This is being done because the sengled element touch incorrectly uses the value 0xFF for the max level.
+            // Per the ZCL spec for the UINT8 data type 0xFF is an invalid value, and 0xFE should be the max.  Here we
+            // manually handle the invalid attribute value since it will be ignored by getEvent as an invalid value.
+            // We also set the level of the bulb to 0xFE so future level reports will be 0xFE until it is changed by
+            // something else.
+            if (descMap.value.toUpperCase() == "FF") {
+                descMap.value = "FE"
+            }
+            sendHubCommand(zigbee.command(zigbee.LEVEL_CONTROL_CLUSTER, 0x00, "FE0000").collect { new physicalgraph.device.HubAction(it) }, 0)
+            sendEvent(zigbee.getEventFromAttrData(descMap.clusterInt, descMap.attrInt, descMap.encoding, descMap.value))
+        } else {
             log.warn "DID NOT PARSE MESSAGE for description : $description"
             log.debug zigbee.parseDescriptionAsMap(description)
         }


### PR DESCRIPTION
This works around the fact that sengled element touches can get back
into a state of reporting an invalid value (of FF) if the physical
button on the bulb is used to cycle back to the 100% state.  Here we
interpret FF as FE for sengled and then issue a move to level command to
put it in a state where it will report FE until the level is changed
again.

This resolves: https://smartthings.atlassian.net/browse/DVCSMP-2597

@tpmanley @workingmonk 