### PR TITLE
PROB-1347 Lux values showing as ${unit} in recently tab of Aeon Multipurpose

### DIFF
--- a/devicetypes/smartthings/aeon-multisensor-6.src/aeon-multisensor-6.groovy
+++ b/devicetypes/smartthings/aeon-multisensor-6.src/aeon-multisensor-6.groovy
@@ -103,7 +103,7 @@ metadata {
 		}
 
 		valueTile("illuminance", "device.illuminance", inactiveLabel: false, width: 2, height: 2) {
-			state "illuminance", label:'${currentValue} ${unit}', unit:"lux"
+			state "illuminance", label:'${currentValue} lux', unit:""
 		}
 
 		valueTile("ultravioletIndex", "device.ultravioletIndex", inactiveLabel: false, width: 2, height: 2) {

--- a/devicetypes/smartthings/aeon-multisensor-gen5.src/aeon-multisensor-gen5.groovy
+++ b/devicetypes/smartthings/aeon-multisensor-gen5.src/aeon-multisensor-gen5.groovy
@@ -84,7 +84,7 @@ metadata {
 			state "humidity", label:'${currentValue}% humidity', unit:""
 		}
 		valueTile("illuminance", "device.illuminance", inactiveLabel: false, width: 2, height: 2) {
-			state "luminosity", label:'${currentValue} ${unit}', unit:"lux"
+			state "luminosity", label:'${currentValue} lux', unit:""
 		}
 		valueTile("battery", "device.battery", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
 			state "battery", label:'${currentValue}% battery', unit:""
@@ -264,4 +264,3 @@ private secure(physicalgraph.zwave.Command cmd) {
 private secureSequence(commands, delay=200) {
 	delayBetween(commands.collect{ secure(it) }, delay)
 }
-

--- a/devicetypes/smartthings/aeon-multisensor.src/aeon-multisensor.groovy
+++ b/devicetypes/smartthings/aeon-multisensor.src/aeon-multisensor.groovy
@@ -79,7 +79,7 @@ metadata {
 			state "humidity", label:'${currentValue}% humidity', unit:""
 		}
 		valueTile("illuminance", "device.illuminance", inactiveLabel: false, width: 2, height: 2) {
-			state "luminosity", label:'${currentValue} ${unit}', unit:"lux"
+			state "luminosity", label:'${currentValue} lux', unit:""
 		}
 		valueTile("battery", "device.battery", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
 			state "battery", label:'${currentValue}% battery', unit:""


### PR DESCRIPTION
Replaced  **${unit}', unit:"lux"**  with **lux', unit: ""** to fix issue with seeing ${unit} in the recently tab of Aeon multisensor illuminance values in the App. Tested all three DTHs (Aeon Multisensor, Aeon Multisensor Gen5, and Aeon Multisensor 6) and lux was displayed rather than ${unit}. Tested on iOS and Android 2.3.5. See PROB-1347 for more info on original issue.