### PR TITLE
[DVCSMP-2612] Unschedule execution for Left It Open when door is closed

### DIFF
--- a/smartapps/smartthings/left-it-open.src/left-it-open.groovy
+++ b/smartapps/smartthings/left-it-open.src/left-it-open.groovy
@@ -27,84 +27,82 @@ definition(
 
 preferences {
 
-	section("Monitor this door or window") {
-		input "contact", "capability.contactSensor"
-	}
-	section("And notify me if it's open for more than this many minutes (default 10)") {
-		input "openThreshold", "number", description: "Number of minutes", required: false
-	}
-    section("Delay between notifications (default 10 minutes") {
-        input "frequency", "number", title: "Number of minutes", description: "", required: false
+  section("Monitor this door or window") {
+    input "contact", "capability.contactSensor"
+  }
+
+  section("And notify me if it's open for more than this many minutes (default 10)") {
+    input "openThreshold", "number", description: "Number of minutes", required: false
+  }
+
+  section("Delay between notifications (default 10 minutes") {
+    input "frequency", "number", title: "Number of minutes", description: "", required: false
+  }
+
+  section("Via text message at this number (or via push notification if not specified") {
+    input("recipients", "contact", title: "Send notifications to") {
+      input "phone", "phone", title: "Phone number (optional)", required: false
     }
-	section("Via text message at this number (or via push notification if not specified") {
-        input("recipients", "contact", title: "Send notifications to") {
-            input "phone", "phone", title: "Phone number (optional)", required: false
-        }
-	}
+  }
 }
 
 def installed() {
-	log.trace "installed()"
-	subscribe()
+  log.trace "installed()"
+  subscribe()
 }
 
 def updated() {
-	log.trace "updated()"
-	unsubscribe()
-	subscribe()
+  log.trace "updated()"
+  unsubscribe()
+  subscribe()
 }
 
 def subscribe() {
-	subscribe(contact, "contact.open", doorOpen)
-	subscribe(contact, "contact.closed", doorClosed)
+  subscribe(contact, "contact.open", doorOpen)
+  subscribe(contact, "contact.closed", doorClosed)
 }
 
-def doorOpen(evt)
-{
-	log.trace "doorOpen($evt.name: $evt.value)"
-	def t0 = now()
-	def delay = (openThreshold != null && openThreshold != "") ? openThreshold * 60 : 600
-	runIn(delay, doorOpenTooLong, [overwrite: false])
-	log.debug "scheduled doorOpenTooLong in ${now() - t0} msec"
+def doorOpen(evt) {
+  log.trace "doorOpen($evt.name: $evt.value)"
+  def delay = (openThreshold != null && openThreshold != "") ? openThreshold * 60 : 600
+  runIn(delay, doorOpenTooLong, [overwrite: true])
 }
 
-def doorClosed(evt)
-{
-	log.trace "doorClosed($evt.name: $evt.value)"
+def doorClosed(evt) {
+  log.trace "doorClosed($evt.name: $evt.value)"
+  unschedule(doorOpenTooLong)
 }
 
 def doorOpenTooLong() {
-	def contactState = contact.currentState("contact")
-    def freq = (frequency != null && frequency != "") ? frequency * 60 : 600
+  def contactState = contact.currentState("contact")
+  def freq = (frequency != null && frequency != "") ? frequency * 60 : 600
 
-	if (contactState.value == "open") {
-		def elapsed = now() - contactState.rawDateCreated.time
-		def threshold = ((openThreshold != null && openThreshold != "") ? openThreshold * 60000 : 60000) - 1000
-		if (elapsed >= threshold) {
-			log.debug "Contact has stayed open long enough since last check ($elapsed ms):  calling sendMessage()"
-			sendMessage()
-            runIn(freq, doorOpenTooLong, [overwrite: false])
-		} else {
-			log.debug "Contact has not stayed open long enough since last check ($elapsed ms):  doing nothing"
-		}
-	} else {
-		log.warn "doorOpenTooLong() called but contact is closed:  doing nothing"
-	}
+  if (contactState.value == "open") {
+    def elapsed = now() - contactState.rawDateCreated.time
+    def threshold = ((openThreshold != null && openThreshold != "") ? openThreshold * 60000 : 60000) - 1000
+    if (elapsed >= threshold) {
+      log.debug "Contact has stayed open long enough since last check ($elapsed ms):  calling sendMessage()"
+      sendMessage()
+      runIn(freq, doorOpenTooLong, [overwrite: false])
+    } else {
+      log.debug "Contact has not stayed open long enough since last check ($elapsed ms):  doing nothing"
+    }
+  } else {
+    log.warn "doorOpenTooLong() called but contact is closed:  doing nothing"
+  }
 }
 
-void sendMessage()
-{
-	def minutes = (openThreshold != null && openThreshold != "") ? openThreshold : 10
-	def msg = "${contact.displayName} has been left open for ${minutes} minutes."
-	log.info msg
-    if (location.contactBookEnabled) {
-        sendNotificationToContacts(msg, recipients)
+void sendMessage() {
+  def minutes = (openThreshold != null && openThreshold != "") ? openThreshold : 10
+  def msg = "${contact.displayName} has been left open for ${minutes} minutes."
+  log.info msg
+  if (location.contactBookEnabled) {
+    sendNotificationToContacts(msg, recipients)
+  } else {
+    if (phone) {
+      sendSms phone, msg
+    } else {
+      sendPush msg
     }
-    else {
-        if (phone) {
-            sendSms phone, msg
-        } else {
-            sendPush msg
-        }
-    }
+  }
 }


### PR DESCRIPTION
Right now when the "Left It Open" SmartApp detects that the contact sensor is closed, it logs a debug message and exits. This changes it to unschedule the future execution of the SmartApp so we avoid unnecessary executions. It also overwrites the future scheduled execution when it does detect that it opened so we are not violating the scheduled executions limit. 