### PR TITLE
[CHF-610] Health Check Aeon MultiSensor 6

### DIFF
--- a/devicetypes/smartthings/aeon-multisensor-6.src/.st-ignore
+++ b/devicetypes/smartthings/aeon-multisensor-6.src/.st-ignore
@@ -1,0 +1,2 @@
+.st-ignore
+README.md

--- a/devicetypes/smartthings/aeon-multisensor-6.src/README.md
+++ b/devicetypes/smartthings/aeon-multisensor-6.src/README.md
@@ -1,0 +1,43 @@
+# Aeon Multisensor 6
+
+Cloud Execution
+
+Works with: 
+
+* [Aeon Labs MultiSensor 6](https://www.smartthings.com/products/aeon-labs-multisensor-6)
+
+## Table of contents
+
+* [Capabilities](#capabilities)
+* [Health](#device-health)
+* [Troubleshooting](#troubleshooting)
+
+## Capabilities
+
+* **Motion Sensor** - can detect motion
+* **Temperature Measurement** - defines device measures current temperature
+* **Relative Humidity Measurement** - allow reading the relative humidity from devices that support it
+* **Illuminance Measurement** - gives the illuminance reading from devices that support it
+* **Ultraviolet Index** - gives the ability to get the ultraviolet index from devices that report it
+* **Configuration** - _configure()_ command called when device is installed or device preferences updated
+* **Sensor** - detects sensor events
+* **Battery** - defines device uses a battery
+* **Health Check** - indicates ability to get device health notifications
+
+## Device Health
+
+Aeon Labs MultiSensor 6 is polled by the hub.
+As of hubCore version 0.14.38 the hub sends up reports every 15 minutes regardless of whether the state changed.
+Device-Watch allows 2 check-in misses from device plus some lag time. So Check-in interval = (2*15 + 2)mins = 32 mins.
+Not to mention after going OFFLINE when the device is plugged back in, it might take a considerable amount of time for
+the device to appear as ONLINE again. This is because if this listening device does not respond to two poll requests in a row,
+it is not polled for 5 minutes by the hub. This can delay up the process of being marked ONLINE by quite some time.
+
+* __32min__ checkInterval
+
+## Troubleshooting
+
+If the device doesn't pair when trying from the SmartThings mobile app, it is possible that the device is out of range.
+Pairing needs to be tried again by placing the device closer to the hub.
+Instructions related to pairing, resetting and removing the device from SmartThings can be found in the following link:
+* [Aeon Labs MultiSensor 6 Troubleshooting Tips](https://support.smartthings.com/hc/en-us/articles/206157226)

--- a/devicetypes/smartthings/aeon-multisensor-6.src/aeon-multisensor-6.groovy
+++ b/devicetypes/smartthings/aeon-multisensor-6.src/aeon-multisensor-6.groovy
@@ -22,6 +22,7 @@ metadata {
 		capability "Configuration"
 		capability "Sensor"
 		capability "Battery"
+		capability "Health Check"
 
 		attribute "tamper", "enum", ["detected", "clear"]
 		attribute "batteryStatus", "string"
@@ -29,6 +30,7 @@ metadata {
 
 		fingerprint deviceId: "0x2101", inClusters: "0x5E,0x86,0x72,0x59,0x85,0x73,0x71,0x84,0x80,0x30,0x31,0x70,0x7A", outClusters: "0x5A"
 		fingerprint deviceId: "0x2101", inClusters: "0x5E,0x86,0x72,0x59,0x85,0x73,0x71,0x84,0x80,0x30,0x31,0x70,0x7A,0x5A"
+		fingerprint mfr:"0086", prod:"0102", model:"0064", deviceJoinName: "Aeon Labs MultiSensor 6"
 	}
 
 	simulator {
@@ -127,7 +129,14 @@ metadata {
 	}
 }
 
+def installed(){
+// Device-Watch simply pings if no device events received for 32min(checkInterval)
+	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
+}
+
 def updated() {
+// Device-Watch simply pings if no device events received for 32min(checkInterval)
+	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 	log.debug "Updated with settings: ${settings}"
 	log.debug "${device.displayName} is now ${device.latestValue("powerSupply")}"
 
@@ -324,6 +333,13 @@ def zwaveEvent(physicalgraph.zwave.commands.configurationv2.ConfigurationReport 
 def zwaveEvent(physicalgraph.zwave.Command cmd) {
 	log.debug "General zwaveEvent cmd: ${cmd}"
 	createEvent(descriptionText: cmd.toString(), isStateChange: false)
+}
+
+/**
+ * PING is used by Device-Watch in attempt to reach the Device
+ * */
+def ping() {
+	secure(zwave.batteryV1.batteryGet())
 }
 
 def configure() {


### PR DESCRIPTION
1. Added health check for Aeon MultiSensor 6 (Z-Wave).
2. 'checkInterval' is kept at 32min.
3. Ping is implemented using refresh().
4. Added the fingerprint of Aeon MultiSensor 6 (Z-Wave) with the manufacturer, product code and model number obtained from the raw description after pairing.
5. Modified the deviceJoinName accordingly.
6. We've tested the checkInterval duration and the devices are marked OFFLINE within the stipulated time.
@jackchi @ShunmugaSundar Please check and merge the changes.