### PR TITLE
ICP-1040 ocf-update-aeon-key-fob

### DIFF
--- a/devicetypes/smartthings/aeon-key-fob.src/aeon-key-fob.groovy
+++ b/devicetypes/smartthings/aeon-key-fob.src/aeon-key-fob.groovy
@@ -12,7 +12,7 @@
  *
  */
 metadata {
-	definition (name: "Aeon Key Fob", namespace: "smartthings", author: "SmartThings") {
+	definition (name: "Aeon Key Fob", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "x.com.st.d.remotecontroller") {
 		capability "Actuator"
 		capability "Button"
 		capability "Holdable Button"


### PR DESCRIPTION
@marstorp please review this one minor change to the Aeon Key Fob. Added ocf device type remote control.