### PR TITLE
DVCSMP-2665 Prevent 'Smart Nightlight' from over scheduling

### DIFF
--- a/smartapps/smartthings/smart-nightlight.src/smart-nightlight.groovy
+++ b/smartapps/smartthings/smart-nightlight.src/smart-nightlight.groovy
@@ -98,7 +98,7 @@ def motionHandler(evt) {
 	else {
 		state.motionStopTime = now()
 		if(delayMinutes) {
-			runIn(delayMinutes*60, turnOffMotionAfterDelay, [overwrite: false])
+			runIn(delayMinutes*60, turnOffMotionAfterDelay, [overwrite: true])
 		} else {
 			turnOffMotionAfterDelay()
 		}


### PR DESCRIPTION
The 'Smart Nightlight' SmartApp currently schedules executions each time motion is sensed. If a motion sensor sees a lot of activity the app will execute no-op runs effectively wasting time and resources. This should be changed to overwrite the future execution each time motion is sensed.