### PR TITLE
[DVCSMP-2668] Fix NPE for smartsense multi

### DIFF
--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -178,7 +178,7 @@ private List<Map> handleAcceleration(descMap) {
 			result += parseAxis(descMap.additionalAttrs)
 		}
 	} else if (descMap.clusterInt == 0xFC02 && descMap.attrInt == 0x0012) {
-		def addAttrs = descMap.additionalAttrs
+		def addAttrs = descMap.additionalAttrs ?: []
 		addAttrs << ["attrInt": descMap.attrInt, "value": descMap.value]
 		result += parseAxis(addAttrs)
 	}


### PR DESCRIPTION
There was a common NPE caused by assuming there would be additional
attributes reported with one acceleration value.  This corrects it to
instead properly handle the case where there weren't additional
attributes.

This resolves: https://smartthings.atlassian.net/browse/DVCSMP-2668

@tpmanley @workingmonk 