### PR TITLE
Show state of sensor instead of ---

### DIFF
--- a/devicetypes/smartthings/everspring-flood-sensor.src/everspring-flood-sensor.groovy
+++ b/devicetypes/smartthings/everspring-flood-sensor.src/everspring-flood-sensor.groovy
@@ -32,8 +32,8 @@ metadata {
 	tiles(scale: 2) {
 		multiAttributeTile(name:"water", type: "generic", width: 6, height: 4){
 			tileAttribute ("device.water", key: "PRIMARY_CONTROL") {
-				attributeState "dry", icon:"st.alarm.water.dry", backgroundColor:"#ffffff"
-				attributeState "wet", icon:"st.alarm.water.wet", backgroundColor:"#53a7c0"
+				attributeState "dry", label:'\n${name}', icon:"st.alarm.water.dry", backgroundColor:"#ffffff"
+				attributeState "wet", label:'\n${name}', icon:"st.alarm.water.wet", backgroundColor:"#53a7c0"
 			}
 		}
 		valueTile("battery", "device.battery", decoration: "flat", inactiveLabel: false, width: 2, height: 2) {


### PR DESCRIPTION
The way the ST app currently works it renders differently on Android and iOS, with iOS it doesn't show the state of the sensor unless the label is explicitly included. This setup works fine on both iOS and Android ST apps version 2.4.0