### PR TITLE
ICP-1056 ocf-update-fortrezz-siren

### DIFF
--- a/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
+++ b/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
@@ -16,7 +16,7 @@
  *  Date: 2014-07-15
  */
 metadata {
-	definition (name: "Z-Wave Siren", namespace: "smartthings", author: "SmartThings") {
+	definition (name: "Z-Wave Siren", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "x.com.st.d.sensor.smoke") {
 		capability "Actuator"
         capability "Alarm"
         capability "Battery"


### PR DESCRIPTION
Adding ocf -device type declaration for proper device icon