### PR TITLE
 DVCSMP-2537 Add CRC16 un-encapsulation to Z-Wave switches

### DIFF
--- a/devicetypes/smartthings/dimmer-switch.src/dimmer-switch.groovy
+++ b/devicetypes/smartthings/dimmer-switch.src/dimmer-switch.groovy
@@ -110,7 +110,7 @@ def updated(){
 
 def getCommandClassVersions() {
 	[
-		0x20: 1,  /// Basic
+		0x20: 1,  // Basic
 		0x26: 1,  // SwitchMultilevel
 		0x56: 1,  // Crc16Encap
 		0x70: 1,  // Configuration

--- a/devicetypes/smartthings/dimmer-switch.src/dimmer-switch.groovy
+++ b/devicetypes/smartthings/dimmer-switch.src/dimmer-switch.groovy
@@ -108,11 +108,20 @@ def updated(){
     }
 }
 
+def getCommandClassVersions() {
+	[
+		0x20: 1,  /// Basic
+		0x26: 1,  // SwitchMultilevel
+		0x56: 1,  // Crc16Encap
+		0x70: 1,  // Configuration
+	]
+}
+
 def parse(String description) {
 	def result = null
 	if (description != "updated") {
 		log.debug "parse() >> zwave.parse($description)"
-		def cmd = zwave.parse(description, [0x20: 1, 0x26: 1, 0x70: 1])
+		def cmd = zwave.parse(description, commandClassVersions)
 		if (cmd) {
 			result = zwaveEvent(cmd)
 		}
@@ -177,6 +186,16 @@ def zwaveEvent(physicalgraph.zwave.commands.manufacturerspecificv2.ManufacturerS
 
 def zwaveEvent(physicalgraph.zwave.commands.switchmultilevelv1.SwitchMultilevelStopLevelChange cmd) {
 	[createEvent(name:"switch", value:"on"), response(zwave.switchMultilevelV1.switchMultilevelGet().format())]
+}
+
+def zwaveEvent(physicalgraph.zwave.commands.crc16encapv1.Crc16Encap cmd) {
+	def versions = commandClassVersions
+	def version = versions[cmd.commandClass as Integer]
+	def ccObj = version ? zwave.commandClass(cmd.commandClass, version) : zwave.commandClass(cmd.commandClass)
+	def encapsulatedCommand = ccObj?.command(cmd.command)?.parse(cmd.data)
+	if (encapsulatedCommand) {
+		zwaveEvent(encapsulatedCommand)
+	}
 }
 
 def zwaveEvent(physicalgraph.zwave.Command cmd) {

--- a/devicetypes/smartthings/zwave-dimmer-switch-generic.src/zwave-dimmer-switch-generic.groovy
+++ b/devicetypes/smartthings/zwave-dimmer-switch-generic.src/zwave-dimmer-switch-generic.groovy
@@ -88,11 +88,20 @@ def updated(){
 	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 }
 
+def getCommandClassVersions() {
+	[
+		0x20: 1,  // Basic
+		0x26: 1,  // SwitchMultilevel
+		0x56: 1,  // Crc16Encap
+		0x70: 1,  // Configuration
+	]
+}
+
 def parse(String description) {
 	def result = null
 	if (description != "updated") {
 		log.debug "parse() >> zwave.parse($description)"
-		def cmd = zwave.parse(description, [0x20: 1, 0x26: 1, 0x70: 1])
+		def cmd = zwave.parse(description, commandClassVersions)
 		if (cmd) {
 			result = zwaveEvent(cmd)
 		}
@@ -157,6 +166,16 @@ def zwaveEvent(physicalgraph.zwave.commands.manufacturerspecificv2.ManufacturerS
 
 def zwaveEvent(physicalgraph.zwave.commands.switchmultilevelv1.SwitchMultilevelStopLevelChange cmd) {
 	[createEvent(name:"switch", value:"on"), response(zwave.switchMultilevelV1.switchMultilevelGet().format())]
+}
+
+def zwaveEvent(physicalgraph.zwave.commands.crc16encapv1.Crc16Encap cmd) {
+	def versions = commandClassVersions
+	def version = versions[cmd.commandClass as Integer]
+	def ccObj = version ? zwave.commandClass(cmd.commandClass, version) : zwave.commandClass(cmd.commandClass)
+	def encapsulatedCommand = ccObj?.command(cmd.command)?.parse(cmd.data)
+	if (encapsulatedCommand) {
+		zwaveEvent(encapsulatedCommand)
+	}
 }
 
 def zwaveEvent(physicalgraph.zwave.Command cmd) {

--- a/devicetypes/smartthings/zwave-metering-switch.src/zwave-metering-switch.groovy
+++ b/devicetypes/smartthings/zwave-metering-switch.src/zwave-metering-switch.groovy
@@ -89,10 +89,19 @@ def updated() {
 	} catch (e) { log.debug e }
 }
 
+def getCommandClassVersions() {
+	[
+		0x20: 1,  // Basic
+		0x32: 1,  // SwitchMultilevel
+		0x56: 1,  // Crc16Encap
+		0x72: 2,  // ManufacturerSpecific
+	]
+}
+
 def parse(String description) {
 	def result = null
 	if(description == "updated") return
-	def cmd = zwave.parse(description, [0x20: 1, 0x32: 1, 0x72: 2])
+	def cmd = zwave.parse(description, commandClassVersions)
 	if (cmd) {
 		result = zwaveEvent(cmd)
 	}
@@ -155,6 +164,16 @@ def zwaveEvent(physicalgraph.zwave.commands.manufacturerspecificv2.ManufacturerS
 	}
 
 	result
+}
+
+def zwaveEvent(physicalgraph.zwave.commands.crc16encapv1.Crc16Encap cmd) {
+	def versions = commandClassVersions
+	def version = versions[cmd.commandClass as Integer]
+	def ccObj = version ? zwave.commandClass(cmd.commandClass, version) : zwave.commandClass(cmd.commandClass)
+	def encapsulatedCommand = ccObj?.command(cmd.command)?.parse(cmd.data)
+	if (encapsulatedCommand) {
+		zwaveEvent(encapsulatedCommand)
+	}
 }
 
 def zwaveEvent(physicalgraph.zwave.Command cmd) {

--- a/devicetypes/smartthings/zwave-switch-generic.src/zwave-switch-generic.groovy
+++ b/devicetypes/smartthings/zwave-switch-generic.src/zwave-switch-generic.groovy
@@ -71,9 +71,17 @@ def updated(){
 	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 }
 
+def getCommandClassVersions() {
+	[
+		0x20: 1,  // Basic
+		0x56: 1,  // Crc16Encap
+		0x70: 1,  // Configuration
+	]
+}
+
 def parse(String description) {
 	def result = null
-	def cmd = zwave.parse(description, [0x20: 1, 0x70: 1])
+	def cmd = zwave.parse(description, commandClassVersions)
 	if (cmd) {
 		result = createEvent(zwaveEvent(cmd))
 	}
@@ -120,6 +128,15 @@ def zwaveEvent(physicalgraph.zwave.commands.manufacturerspecificv2.ManufacturerS
 	createEvent([descriptionText: "$device.displayName MSR: $msr", isStateChange: false])
 }
 
+def zwaveEvent(physicalgraph.zwave.commands.crc16encapv1.Crc16Encap cmd) {
+	def versions = commandClassVersions
+	def version = versions[cmd.commandClass as Integer]
+	def ccObj = version ? zwave.commandClass(cmd.commandClass, version) : zwave.commandClass(cmd.commandClass)
+	def encapsulatedCommand = ccObj?.command(cmd.command)?.parse(cmd.data)
+	if (encapsulatedCommand) {
+		zwaveEvent(encapsulatedCommand)
+	}
+}
 
 def zwaveEvent(physicalgraph.zwave.Command cmd) {
 	// Handles all Z-Wave commands we aren't interested in


### PR DESCRIPTION
New GE and Aeon Z-Wave switches support CRC16 encapsulation of messages.  This change adds a `Crc16Encap` event handler to support unwrapping and parsing the contained message.

Fixes DVCSMP-2663 and DVCSMP-2537.