### PR TITLE
IOTEVENT-786 check for null/empty values before sending events

### DIFF
--- a/devicetypes/smartthings/fibaro-rgbw-controller.src/fibaro-rgbw-controller.groovy
+++ b/devicetypes/smartthings/fibaro-rgbw-controller.src/fibaro-rgbw-controller.groovy
@@ -300,15 +300,21 @@ def setColor(value) {
         value.hex = "#${hex(value.red)}${hex(value.green)}${hex(value.blue)}"
     }
 
-	sendEvent(name: "hue", value: value.hue, displayed: false)
-	sendEvent(name: "saturation", value: value.saturation, displayed: false)
-	sendEvent(name: "color", value: value.hex, displayed: false)
-	if (value.level) {
-		sendEvent(name: "level", value: value.level)
-	}
-	if (value.switch) {
-		sendEvent(name: "switch", value: value.switch)
-	}
+    if(value.hue) {
+        sendEvent(name: "hue", value: value.hue, displayed: false)
+    }
+    if(value.saturation) {
+        sendEvent(name: "saturation", value: value.saturation, displayed: false)
+    }
+    if(value.hex?.trim()) {
+        sendEvent(name: "color", value: value.hex, displayed: false)
+    }
+    if (value.level) {
+        sendEvent(name: "level", value: value.level)
+    }
+    if (value.switch?.trim()) {
+        sendEvent(name: "switch", value: value.switch)
+    }
 
     sendRGB(value.rh, value.gh, value.bh)
 }


### PR DESCRIPTION
@twack 
FYI: @workingmonk 
some color, hue, and saturation events (color being the big offender) were being dropped from the event pipeline because they had empty values.

Checking for null/empty values before sending the events.