### PR TITLE
[DHF-16] ZigBee Button Device Health Update

### DIFF
--- a/devicetypes/smartthings/zigbee-button.src/README.md
+++ b/devicetypes/smartthings/zigbee-button.src/README.md
@@ -28,9 +28,8 @@ Works with:
 
 ## Device Health
 
-SmartThings platform will ping the device after `checkInterval` seconds of inactivity in last attempt to reach the device before marking it `OFFLINE` 
+ZigBee Button is marked offline only in the case when Hub is offline.
 
-* __722min__ checkInterval
 
 ## Troubleshooting
 

--- a/devicetypes/smartthings/zigbee-button.src/zigbee-button.groovy
+++ b/devicetypes/smartthings/zigbee-button.src/zigbee-button.groovy
@@ -13,6 +13,8 @@
  *  for the specific language governing permissions and limitations under the License.
  *
  */
+
+import groovy.json.JsonOutput
 import physicalgraph.zigbee.zcl.DataType
 
 metadata {
@@ -183,13 +185,6 @@ private Map parseNonIasButtonMessage(Map descMap){
     }
 }
 
-/**
- * PING is used by Device-Watch in attempt to reach the Device
- * */
-def ping() {
-    refresh()
-}
-
 def refresh() {
     log.debug "Refreshing Battery"
 
@@ -198,8 +193,6 @@ def refresh() {
 }
 
 def configure() {
-    // Device-Watch allows 2 check-in misses from device (plus 2 mins lag time)
-    sendEvent(name: "checkInterval", value: 2 * 6 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
     log.debug "Configuring Reporting, IAS CIE, and Bindings."
     def cmds = []
     if (device.getDataValue("model") == "3450-L") {
@@ -259,6 +252,8 @@ def updated() {
 }
 
 def initialize() {
+    // Arrival sensors only goes OFFLINE when Hub is off
+    sendEvent(name: "DeviceWatch-Enroll", value: JsonOutput.toJson([protocol: "zigbee", scheme:"untracked"]), displayed: false)
     if ((device.getDataValue("manufacturer") == "OSRAM") && (device.getDataValue("model") == "LIGHTIFY Dimming Switch")) {
         sendEvent(name: "numberOfButtons", value: 2)
     }


### PR DESCRIPTION
`ZigBee Button` devices do not report in on a configured interval. Changing this device to go `OFFLINE` only during HUB_OFFLINE
