### PR TITLE
DVCSMP-2885 Smooth battery values for SmartSense devices

### DIFF
--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -275,11 +275,27 @@ private Map getBatteryResult(rawValue) {
 		} else {
 			def minVolts = 2.1
 			def maxVolts = 2.7
-			def pct = (volts - minVolts) / (maxVolts - minVolts)
-			def roundedPct = Math.round(pct * 100)
-			if (roundedPct <= 0)
-				roundedPct = 1
-			result.value = Math.min(100, roundedPct)
+			// Get the current battery percentage as a multiplier 0 - 1
+			def curValVolts = Integer.parseInt(device.currentState("battery")?.value ?: "100") / 100.0
+			// Find the corresponding voltage from our range
+			curValVolts = curValVolts * (maxVolts - minVolts) + minVolts
+			// Round to the nearest 10th of a volt
+			curValVolts = Math.round(10 * curValVolts) / 10.0
+			// Only update the battery reading if we don't have a last reading,
+			// OR we have received the same reading twice in a row
+			// OR we don't currently have a battery reading
+			// OR the value we just received is at least 2 steps off from the last reported value
+			if(state?.lastVolts == null || state?.lastVolts == volts || device.currentState("battery")?.value == null || Math.abs(curValVolts - volts) > 0.1) {
+				def pct = (volts - minVolts) / (maxVolts - minVolts)
+				def roundedPct = Math.round(pct * 100)
+				if (roundedPct <= 0)
+					roundedPct = 1
+				result.value = Math.min(100, roundedPct)
+			} else {
+				// Don't update as we want to smooth the battery values
+				result = null
+			}
+			state.lastVolts = volts
 		}
 	}
 


### PR DESCRIPTION
Since we have been receiving a lot of reports and complaints about the
battery readings on the smartsense devices that received battery
updates (multi and motion), we are adding this code to smooth out the
readings so it doesn't constantly oscillate between two values.  The
basic logic is, only create an event if we have two readings in a row
that are the same, or a reading is more than 100 millivolts off of the
current battery percentage.

@tpmanley @workingmonk 