### PR TITLE
Update zigbee-button.groovy

### DIFF
--- a/devicetypes/smartthings/zigbee-button.src/zigbee-button.groovy
+++ b/devicetypes/smartthings/zigbee-button.src/zigbee-button.groovy
@@ -217,7 +217,8 @@ private Map getButtonResult(buttonState, buttonNumber = 1) {
         log.info "holdp1 : $holdPreference"
         holdPreference = (holdPreference as int) * 1000
         log.info "holdp2 : $holdPreference"
-        if (timeDiff > 10000) {         //timeDiff>10sec check for refresh sending release value causing actions to be executed
+        // Disabled below because it caused some presses to be skipped. The device driver can not use atomicState, but uses State which is unreliable for this driver.
+        if (false && (timeDiff > 10000)) {         //timeDiff>10sec check for refresh sending release value causing actions to be executed
             return [:]
         }
         else {


### PR DESCRIPTION
Fixed for several missed button presses. The code to determine for pressing 2nd time too soon should be in the app level, not in device driver because of unsupported atomicState in device drivers that would have accurate time stamps if supported.  This code uses  State which is not stored until exiting driver. The timeDiff coding is not reliable. Now I have triggerings on every presses :)