### PR TITLE
[DVCSMP-2808] Onboard Fibaro Smoke Sensor

### DIFF
--- a/devicetypes/smartthings/fibaro-smoke-sensor.src/fibaro-smoke-sensor.groovy
+++ b/devicetypes/smartthings/fibaro-smoke-sensor.src/fibaro-smoke-sensor.groovy
@@ -18,6 +18,7 @@ metadata {
         capability "Sensor"
         capability "Smoke Detector" //attributes: smoke ("detected","clear","tested")
         capability "Temperature Measurement" //attributes: temperature
+        capability "Health Check"
         attribute "tamper", "enum", ["detected", "clear"]
         attribute "heatAlarm", "enum", ["overheat detected", "clear", "rapid temperature rise", "underheat detected"]
         fingerprint deviceId: "0x0701", inClusters: "0x5E, 0x86, 0x72, 0x5A, 0x59, 0x85, 0x73, 0x84, 0x80, 0x71, 0x56, 0x70, 0x31, 0x8E, 0x22, 0x9C, 0x98, 0x7A", outClusters: "0x20, 0x8B"
@@ -339,6 +340,8 @@ def zwaveEvent(physicalgraph.zwave.Command cmd) {
 }
 
 def configure() {
+    // Device wakes up every 4 hours, this interval allows us to miss one wakeup notification before marking offline
+    sendEvent(name: "checkInterval", value: 8 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 // This sensor joins as a secure device if you tripple-click the button to include it
     log.debug "configure() >> isSecured() : ${isSecured()}"
     if (!isSecured()) {


### PR DESCRIPTION
1. Health Check capability has been added for Fibaro Smoke Sensor.
2. `checkInterval` is kept at 482 mins since the `wakeUpInterval` is of 4 hours.
3. All the capabilities excluding "**smoke detecto**r" has been tested and verified both in ST and in Samsung Connect App.
4. Device goes **OFFLINE** within stipulated time.

@jackchi @ShunmugaSundar Please review and merge the changes.