### PR TITLE
DVCSMP-2973 CT100/Honeywell Z-wave NullPointerException

### DIFF
--- a/devicetypes/smartthings/ct100-thermostat.src/ct100-thermostat.groovy
+++ b/devicetypes/smartthings/ct100-thermostat.src/ct100-thermostat.groovy
@@ -101,9 +101,8 @@ metadata {
 
 def installed() {
 	// Configure device
-	def cmds = []
-	cmds << new physicalgraph.device.HubAction(zwave.associationV1.associationSet(groupingIdentifier:1, nodeId:[zwaveHubNodeId]).format())
-	cmds << new physicalgraph.device.HubAction(zwave.manufacturerSpecificV2.manufacturerSpecificGet().format())
+	def cmds = [new physicalgraph.device.HubAction(zwave.associationV1.associationSet(groupingIdentifier:1, nodeId:[zwaveHubNodeId]).format()),
+			new physicalgraph.device.HubAction(zwave.manufacturerSpecificV2.manufacturerSpecificGet().format())]
 	sendHubCommand(cmds)
 	runIn(3, "initialize", [overwrite: true])  // Allow configure command to be sent and acknowledged before proceeding
 }
@@ -150,7 +149,6 @@ def parse(String description)
 
 def zwaveEvent(physicalgraph.zwave.commands.multichannelv3.MultiInstanceCmdEncap cmd) {
 	def encapsulatedCommand = cmd.encapsulatedCommand([0x31: 3])
-	log.debug ("multiinstancev1.MultiInstanceCmdEncap: command from instance ${cmd.instance}: ${encapsulatedCommand}")
 	if (encapsulatedCommand) {
 		zwaveEvent(encapsulatedCommand)
 	}
@@ -341,7 +339,7 @@ def zwaveEvent(physicalgraph.zwave.commands.thermostatmodev2.ThermostatModeSuppo
 	if(cmd.auxiliaryemergencyHeat) { supportedModes << "emergency heat" }
 
 	state.supportedModes = supportedModes
-	sendEvent(name: "supportedThermostatModes", value: supportedModes, isStateChange: true, displayed: false)
+	sendEvent(name: "supportedThermostatModes", value: supportedModes, displayed: false)
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.thermostatfanmodev3.ThermostatFanModeSupportedReport cmd) {
@@ -351,7 +349,7 @@ def zwaveEvent(physicalgraph.zwave.commands.thermostatfanmodev3.ThermostatFanMod
 	if(cmd.circulation) { supportedFanModes << "circulate" }
 
 	state.supportedFanModes = supportedFanModes
-	sendEvent(name: "supportedThermostatFanModes", value: supportedFanModes, isStateChange: true, displayed: false)
+	sendEvent(name: "supportedThermostatFanModes", value: supportedFanModes, displayed: false)
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.basicv1.BasicReport cmd) {
@@ -377,7 +375,6 @@ def zwaveEvent(physicalgraph.zwave.Command cmd) {
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.manufacturerspecificv2.ManufacturerSpecificReport cmd) {
-log.debug "ManufacturerSpecificReport ${cmd}: value:${cmd}"
 	if (cmd.manufacturerName) {
 		updateDataValue("manufacturer", cmd.manufacturerName)
 	}
@@ -614,7 +611,7 @@ def updateThermostatSetpoint(setpoint, value) {
  * */
 def ping() {
 	log.debug "ping() called"
-	// Just get Operating State as it is not reported when it chnages and there's no need to flood more commands
+	// Just get Operating State as it is not reported when it changes and there's no need to flood more commands
 	sendHubCommand(new physicalgraph.device.HubAction(zwave.thermostatOperatingStateV1.thermostatOperatingStateGet().format()))
 }
 
@@ -624,7 +621,7 @@ def switchMode() {
 	if (supportedModes) {
 		def next = { supportedModes[supportedModes.indexOf(it) + 1] ?: supportedModes[0] }
 		def nextMode = next(currentMode)
-		runIn(2, "setThermostatMode", [data: [nextMode: nextMode], overwrite: true])
+		runIn(2, "setGetThermostatMode", [data: [nextMode: nextMode], overwrite: true])
 	} else {
 		log.warn "supportedModes not defined"
 		getSupportedModes()
@@ -635,7 +632,7 @@ def switchToMode(nextMode) {
 	def supportedModes = state.supportedModes
 	if (supportedModes) {
 		if (supportedModes.contains(nextMode)) {
-			runIn(2, "setThermostatMode", [data: [nextMode: nextMode], overwrite: true])
+			runIn(2, "setGetThermostatMode", [data: [nextMode: nextMode], overwrite: true])
 		} else {
 			log.debug("ThermostatMode $nextMode is not supported by ${device.displayName}")
 		}
@@ -657,7 +654,7 @@ def switchFanMode() {
 	if (supportedFanModes) {
 		def next = { supportedFanModes[supportedFanModes.indexOf(it) + 1] ?: supportedFanModes[0] }
 		def nextMode = next(currentMode)
-		runIn(2, "setThermostatFanMode", [data: [nextMode: nextMode], overwrite: true])
+		runIn(2, "setGetThermostatFanMode", [data: [nextMode: nextMode], overwrite: true])
 	} else {
 		log.warn "supportedFanModes not defined"
 		getSupportedFanModes()
@@ -668,7 +665,7 @@ def switchToFanMode(nextMode) {
 	def supportedFanModes = state.supportedFanModes
 	if (supportedFanModes) {
 		if (supportedFanModes.contains(nextMode)) {
-			runIn(2, "setThermostatFanMode", [data: [nextMode: nextMode], overwrite: true])
+			runIn(2, "setGetThermostatFanMode", [data: [nextMode: nextMode], overwrite: true])
 		} else {
 			log.debug("FanMode $nextMode is not supported by ${device.displayName}")
 		}
@@ -679,8 +676,7 @@ def switchToFanMode(nextMode) {
 }
 
 def getSupportedFanModes() {
-	def cmds = []
-	cmds << new physicalgraph.device.HubAction(zwave.thermostatFanModeV3.thermostatFanModeSupportedGet().format())
+	def cmds = [new physicalgraph.device.HubAction(zwave.thermostatFanModeV3.thermostatFanModeSupportedGet().format())]
 	sendHubCommand(cmds)
 }
 
@@ -696,10 +692,9 @@ def setThermostatMode(String value) {
 	switchToMode(value)
 }
 
-def setThermostatMode(data) {
-	def cmds = []
-	cmds << new physicalgraph.device.HubAction(zwave.thermostatModeV2.thermostatModeSet(mode: modeMap[data.nextMode]).format())
-	cmds << new physicalgraph.device.HubAction(zwave.thermostatModeV2.thermostatModeGet().format())
+def setGetThermostatMode(data) {
+	def cmds = [new physicalgraph.device.HubAction(zwave.thermostatModeV2.thermostatModeSet(mode: modeMap[data.nextMode]).format()),
+			new physicalgraph.device.HubAction(zwave.thermostatModeV2.thermostatModeGet().format())]
 	sendHubCommand(cmds)
 }
 
@@ -713,10 +708,9 @@ def setThermostatFanMode(String value) {
 	switchToFanMode(value)
 }
 
-def setThermostatFanMode(data) {
-	def cmds = []
-	cmds << new physicalgraph.device.HubAction(zwave.thermostatFanModeV3.thermostatFanModeSet(fanMode: fanModeMap[data.nextMode]).format())
-	cmds << new physicalgraph.device.HubAction(zwave.thermostatFanModeV3.thermostatFanModeGet().format())
+def setGetThermostatFanMode(data) {
+	def cmds = [new physicalgraph.device.HubAction(zwave.thermostatFanModeV3.thermostatFanModeSet(fanMode: fanModeMap[data.nextMode]).format()),
+			new physicalgraph.device.HubAction(zwave.thermostatFanModeV3.thermostatFanModeGet().format())]
 	sendHubCommand(cmds)
 }
 

--- a/devicetypes/smartthings/zwave-thermostat.src/zwave-thermostat.groovy
+++ b/devicetypes/smartthings/zwave-thermostat.src/zwave-thermostat.groovy
@@ -91,7 +91,7 @@ metadata {
 		standardTile("raiseCoolSetpoint", "device.heatingSetpoint", width:2, height:1, inactiveLabel: false, decoration: "flat") {
 			state "heatingSetpoint", action:"raiseCoolSetpoint", icon:"st.thermostat.thermostat-right"
 		}
-		valueTile("thermostatOperatingState", "device.thermostatOperatingState", width: 2, height:1, decoration: "flat") {
+		standardTile("thermostatOperatingState", "device.thermostatOperatingState", width: 2, height:1, decoration: "flat") {
 			state "thermostatOperatingState", label:'${currentValue}', backgroundColor:"#ffffff"
 		}
 		standardTile("refresh", "device.thermostatMode", width:2, height:1, inactiveLabel: false, decoration: "flat") {
@@ -105,9 +105,8 @@ metadata {
 
 def installed() {
 	// Configure device
-	def cmds = []
-	cmds << new physicalgraph.device.HubAction(zwave.associationV1.associationSet(groupingIdentifier:1, nodeId:[zwaveHubNodeId]).format())
-	cmds << new physicalgraph.device.HubAction(zwave.manufacturerSpecificV2.manufacturerSpecificGet().format())
+	def cmds = [new physicalgraph.device.HubAction(zwave.associationV1.associationSet(groupingIdentifier:1, nodeId:[zwaveHubNodeId]).format()),
+			new physicalgraph.device.HubAction(zwave.manufacturerSpecificV2.manufacturerSpecificGet().format())]
 	sendHubCommand(cmds)
 	runIn(3, "initialize", [overwrite: true])  // Allow configure command to be sent and acknowledged before proceeding
 }
@@ -505,7 +504,7 @@ def switchMode() {
 	if (supportedModes) {
 		def next = { supportedModes[supportedModes.indexOf(it) + 1] ?: supportedModes[0] }
 		def nextMode = next(currentMode)
-		runIn(2, "setThermostatMode", [data: [nextMode: nextMode], overwrite: true])
+		runIn(2, "setGetThermostatMode", [data: [nextMode: nextMode], overwrite: true])
 	} else {
 		log.warn "supportedModes not defined"
 		getSupportedModes()
@@ -516,7 +515,7 @@ def switchToMode(nextMode) {
 	def supportedModes = state.supportedModes
 	if (supportedModes) {
 		if (supportedModes.contains(nextMode)) {
-			runIn(2, "setThermostatMode", [data: [nextMode: nextMode], overwrite: true])
+			runIn(2, "setGetThermostatMode", [data: [nextMode: nextMode], overwrite: true])
 		} else {
 			log.debug("ThermostatMode $nextMode is not supported by ${device.displayName}")
 		}
@@ -538,7 +537,7 @@ def switchFanMode() {
 	if (supportedFanModes) {
 		def next = { supportedFanModes[supportedFanModes.indexOf(it) + 1] ?: supportedFanModes[0] }
 		def nextMode = next(currentMode)
-		runIn(2, "setThermostatFanMode", [data: [nextMode: nextMode], overwrite: true])
+		runIn(2, "setGetThermostatFanMode", [data: [nextMode: nextMode], overwrite: true])
 	} else {
 		log.warn "supportedFanModes not defined"
 		getSupportedFanModes()
@@ -549,7 +548,7 @@ def switchToFanMode(nextMode) {
 	def supportedFanModes = state.supportedFanModes
 	if (supportedFanModes) {
 		if (supportedFanModes.contains(nextMode)) {
-			runIn(2, "setThermostatFanMode", [data: [nextMode: nextMode], overwrite: true])
+			runIn(2, "setGetThermostatFanMode", [data: [nextMode: nextMode], overwrite: true])
 		} else {
 			log.debug("FanMode $nextMode is not supported by ${device.displayName}")
 		}
@@ -560,8 +559,7 @@ def switchToFanMode(nextMode) {
 }
 
 def getSupportedFanModes() {
-	def cmds = []
-	cmds << new physicalgraph.device.HubAction(zwave.thermostatFanModeV3.thermostatFanModeSupportedGet().format())
+	def cmds = [new physicalgraph.device.HubAction(zwave.thermostatFanModeV3.thermostatFanModeSupportedGet().format())]
 	sendHubCommand(cmds)
 }
 
@@ -577,10 +575,9 @@ def setThermostatMode(String value) {
 	switchToMode(value)
 }
 
-def setThermostatMode(data) {
-	def cmds = []
-	cmds << new physicalgraph.device.HubAction(zwave.thermostatModeV2.thermostatModeSet(mode: modeMap[data.nextMode]).format())
-	cmds << new physicalgraph.device.HubAction(zwave.thermostatModeV2.thermostatModeGet().format())
+def setGetThermostatMode(data) {
+	def cmds = [new physicalgraph.device.HubAction(zwave.thermostatModeV2.thermostatModeSet(mode: modeMap[data.nextMode]).format()),
+			new physicalgraph.device.HubAction(zwave.thermostatModeV2.thermostatModeGet().format())]
 	sendHubCommand(cmds)
 }
 
@@ -594,10 +591,9 @@ def setThermostatFanMode(String value) {
 	switchToFanMode(value)
 }
 
-def setThermostatFanMode(data) {
-	def cmds = []
-	cmds << new physicalgraph.device.HubAction(zwave.thermostatFanModeV3.thermostatFanModeSet(fanMode: fanModeMap[data.nextMode]).format())
-	cmds << new physicalgraph.device.HubAction(zwave.thermostatFanModeV3.thermostatFanModeGet().format())
+def setGetThermostatFanMode(data) {
+	def cmds = [new physicalgraph.device.HubAction(zwave.thermostatFanModeV3.thermostatFanModeSet(fanMode: fanModeMap[data.nextMode]).format()),
+			new physicalgraph.device.HubAction(zwave.thermostatFanModeV3.thermostatFanModeGet().format())]
 	sendHubCommand(cmds)
 }
 
@@ -663,7 +659,7 @@ def getTempInDeviceScale(temp, scale) {
 	if (temp && scale) {
 		def deviceScale = (state.scale == 1) ? "F" : "C"
 		return (deviceScale == scale) ? temp :
-				(deviceScale == "F" ? celsiusToFahrenheit(temp) : roundC(fahrenheitToCelsius(temp)))
+				(deviceScale == "F" ? celsiusToFahrenheit(temp).toDouble().round(0).toInteger() : roundC(fahrenheitToCelsius(temp)))
 	}
 	return 0
 }


### PR DESCRIPTION
CT100/Honeywell Z-wave NullPointerException when changing mode
Changed name of private method setThermostatMode(data) to setGetThermostatMode(data)
and method setThermostatFanMode(data) to setGetThermostatFanMode(data) so that platform
calls the exposed methods setThermostatMode(String value) setThermostatFanMode(String value)
as these validates the argument against the supported modes and then calls the private methods.
Also removed some of the leftshift operators that showed errors in Sumo logs.