### PR TITLE
ICP-987 added child device components to Aeon Minimote

### DIFF
--- a/devicetypes/smartthings/aeon-minimote.src/aeon-minimote.groovy
+++ b/devicetypes/smartthings/aeon-minimote.src/aeon-minimote.groovy
@@ -1,4 +1,6 @@
 import groovy.json.JsonOutput
+import groovy.json.JsonOutput
+
 /**
  *  Copyright 2015 SmartThings
  *
@@ -36,12 +38,13 @@ metadata {
 		status "button 4 held":  "command: 2001, payload: 8D"
 		status "wakeup":  "command: 8407, payload: "
 	}
-	tiles {
-		standardTile("button", "device.button", width: 2, height: 2) {
-			state "default", label: "", icon: "st.unknown.zwave.remote-controller", backgroundColor: "#ffffff"
+	tiles(scale: 2) {
+		multiAttributeTile(name: "rich-control") {
+			tileAttribute("device.button", key: "PRIMARY_CONTROL") {
+				attributeState "default", label: ' ', action: "", icon: "st.unknown.zwave.remote-controller", backgroundColor: "#ffffff"
+			}
 		}
-		main "button"
-		details(["button"])
+		childDeviceTiles("outlets")
 	}
 }
 
@@ -54,7 +57,6 @@ def parse(String description) {
 		if(cmd) results += zwaveEvent(cmd)
 		if(!results) results = [ descriptionText: cmd, displayed: false ]
 	}
-	// log.debug("Parsed '$description' to $results")
 	return results
 }
 
@@ -69,9 +71,16 @@ def zwaveEvent(physicalgraph.zwave.commands.wakeupv1.WakeUpNotification cmd) {
 
 def buttonEvent(button, held) {
 	button = button as Integer
+	String childDni = "${device.deviceNetworkId}/${button}"
+	def child = childDevices.find{it.deviceNetworkId == childDni}
+	if (!child) {
+		log.error "Child device $childDni not found"
+	}
 	if (held) {
+		child?.sendEvent(name: "button", value: "held", data: [buttonNumber: 1], descriptionText: "$child.displayName was held", isStateChange: true)
 		createEvent(name: "button", value: "held", data: [buttonNumber: button], descriptionText: "$device.displayName button $button was held", isStateChange: true)
 	} else {
+		child?.sendEvent(name: "button", value: "pushed", data: [buttonNumber: 1], descriptionText: "$child.displayName was pushed", isStateChange: true)
 		createEvent(name: "button", value: "pushed", data: [buttonNumber: button], descriptionText: "$device.displayName button $button was pushed", isStateChange: true)
 	}
 }
@@ -113,14 +122,34 @@ def configure() {
 
 def installed() {
 	initialize()
+	createChildDevices()
 }
 
 def updated() {
 	initialize()
+	if (!childDevices) {
+		createChildDevices()
+	}
+	else if (device.label != state.oldLabel) {
+		childDevices.each {
+			def segs = it.deviceNetworkId.split("/")
+			def newLabel = "${device.displayName} button ${segs[-1]}"
+			it.setLabel(newLabel)
+		}
+		state.oldLabel = device.label
+	}
 }
 
 def initialize() {
-	// Device only goes OFFLINE when Hub is off
-	sendEvent(name: "DeviceWatch-Enroll", value: JsonOutput.toJson([protocol: "zwave", scheme:"untracked"]), displayed: false)
 	sendEvent(name: "numberOfButtons", value: 4)
+	sendEvent(name: "DeviceWatch-Enroll", value: JsonOutput.toJson([protocol: "zwave", scheme:"untracked"]), displayed: false)
+}
+
+private void createChildDevices() {
+	state.oldLabel = device.label
+	for (i in 1..4) {
+		addChildDevice("Child Button", "${device.deviceNetworkId}/${i}", null,
+				[completedSetup: true, label: "${device.displayName} button ${i}",
+				 isComponent: true, componentName: "button$i", componentLabel: "Button $i"])
+	}
 }

--- a/devicetypes/smartthings/child-button.src/child-button.groovy
+++ b/devicetypes/smartthings/child-button.src/child-button.groovy
@@ -1,0 +1,34 @@
+/**
+ *  Child Button
+ *
+ *  Copyright 2017 SmartThings
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ *  for the specific language governing permissions and limitations under the License.
+ *
+ */
+metadata {
+	definition (name: "Child Button", namespace: "smartthings", author: "SmartThings") {
+		capability "Button"
+		capability "Holdable Button"
+		capability "Sensor"
+	}
+
+	tiles(scale: 2) {
+		multiAttributeTile(name: "rich-control") {
+			tileAttribute("device.button", key: "PRIMARY_CONTROL") {
+				attributeState "default", label: ' ', action: "", icon: "st.unknown.zwave.remote-controller", backgroundColor: "#ffffff"
+			}
+		}
+	}
+}
+
+def installed() {
+	sendEvent(name: "numberOfButtons", value: 1)
+}


### PR DESCRIPTION
Creates 4 child component devices on installation (or update of previously installed device) representing the 4 buttons of the Minimote. This approach allows each button to be individually selected by any SmartApp or rule builder without having the check the button number data field as is required when the primary device is selected.

Preserves functionality of the primary devices so that existing installations and the SmartApps using them will not break. 