### PR TITLE
DVCSMP-2973 CT100/Honeywell Z-wave NullPointerException

### DIFF
--- a/devicetypes/smartthings/ct100-thermostat.src/ct100-thermostat.groovy
+++ b/devicetypes/smartthings/ct100-thermostat.src/ct100-thermostat.groovy
@@ -625,7 +625,7 @@ def switchMode() {
 	def currentMode = device.currentValue("thermostatMode")
 	def supportedModes = state.supportedModes
 	// Old version of supportedModes was as string, make sure it gets updated
-	if (supportedModes && supportedModes[0].size() > 1) {
+	if (supportedModes && supportedModes.size() && supportedModes[0].size() > 1) {
 		def next = { supportedModes[supportedModes.indexOf(it) + 1] ?: supportedModes[0] }
 		def nextMode = next(currentMode)
 		runIn(2, "setGetThermostatMode", [data: [nextMode: nextMode], overwrite: true])
@@ -638,7 +638,7 @@ def switchMode() {
 def switchToMode(nextMode) {
 	def supportedModes = state.supportedModes
 	// Old version of supportedModes was as string, make sure it gets updated
-	if (supportedModes && supportedModes[0].size() > 1) {
+	if (supportedModes && supportedModes.size() && supportedModes[0].size() > 1) {
 		if (supportedModes.contains(nextMode)) {
 			runIn(2, "setGetThermostatMode", [data: [nextMode: nextMode], overwrite: true])
 		} else {
@@ -660,7 +660,7 @@ def switchFanMode() {
 	def currentMode = device.currentValue("thermostatFanMode")
 	def supportedFanModes = state.supportedFanModes
 	// Old version of supportedFanModes was as string, make sure it gets updated
-	if (supportedFanModes && supportedFanModes[0].size() > 1) {
+	if (supportedFanModes && supportedFanModes.size() && supportedFanModes[0].size() > 1) {
 		def next = { supportedFanModes[supportedFanModes.indexOf(it) + 1] ?: supportedFanModes[0] }
 		def nextMode = next(currentMode)
 		runIn(2, "setGetThermostatFanMode", [data: [nextMode: nextMode], overwrite: true])
@@ -673,7 +673,7 @@ def switchFanMode() {
 def switchToFanMode(nextMode) {
 	def supportedFanModes = state.supportedFanModes
 	// Old version of supportedFanModes was as string, make sure it gets updated
-	if (supportedFanModes && supportedFanModes[0].size() > 1) {
+	if (supportedFanModes && supportedFanModes.size() && supportedFanModes[0].size() > 1) {
 		if (supportedFanModes.contains(nextMode)) {
 			runIn(2, "setGetThermostatFanMode", [data: [nextMode: nextMode], overwrite: true])
 		} else {

--- a/devicetypes/smartthings/ct100-thermostat.src/ct100-thermostat.groovy
+++ b/devicetypes/smartthings/ct100-thermostat.src/ct100-thermostat.groovy
@@ -624,7 +624,8 @@ def ping() {
 def switchMode() {
 	def currentMode = device.currentValue("thermostatMode")
 	def supportedModes = state.supportedModes
-	if (supportedModes) {
+	// Old version of supportedModes was as string, make sure it gets updated
+	if (supportedModes && supportedModes[0].size() > 1) {
 		def next = { supportedModes[supportedModes.indexOf(it) + 1] ?: supportedModes[0] }
 		def nextMode = next(currentMode)
 		runIn(2, "setGetThermostatMode", [data: [nextMode: nextMode], overwrite: true])
@@ -636,7 +637,8 @@ def switchMode() {
 
 def switchToMode(nextMode) {
 	def supportedModes = state.supportedModes
-	if (supportedModes) {
+	// Old version of supportedModes was as string, make sure it gets updated
+	if (supportedModes && supportedModes[0].size() > 1) {
 		if (supportedModes.contains(nextMode)) {
 			runIn(2, "setGetThermostatMode", [data: [nextMode: nextMode], overwrite: true])
 		} else {
@@ -657,7 +659,8 @@ def getSupportedModes() {
 def switchFanMode() {
 	def currentMode = device.currentValue("thermostatFanMode")
 	def supportedFanModes = state.supportedFanModes
-	if (supportedFanModes) {
+	// Old version of supportedFanModes was as string, make sure it gets updated
+	if (supportedFanModes && supportedFanModes[0].size() > 1) {
 		def next = { supportedFanModes[supportedFanModes.indexOf(it) + 1] ?: supportedFanModes[0] }
 		def nextMode = next(currentMode)
 		runIn(2, "setGetThermostatFanMode", [data: [nextMode: nextMode], overwrite: true])
@@ -669,7 +672,8 @@ def switchFanMode() {
 
 def switchToFanMode(nextMode) {
 	def supportedFanModes = state.supportedFanModes
-	if (supportedFanModes) {
+	// Old version of supportedFanModes was as string, make sure it gets updated
+	if (supportedFanModes && supportedFanModes[0].size() > 1) {
 		if (supportedFanModes.contains(nextMode)) {
 			runIn(2, "setGetThermostatFanMode", [data: [nextMode: nextMode], overwrite: true])
 		} else {

--- a/devicetypes/smartthings/zwave-thermostat.src/zwave-thermostat.groovy
+++ b/devicetypes/smartthings/zwave-thermostat.src/zwave-thermostat.groovy
@@ -507,7 +507,8 @@ def ping() {
 def switchMode() {
 	def currentMode = device.currentValue("thermostatMode")
 	def supportedModes = state.supportedModes
-	if (supportedModes) {
+	// Old version of supportedModes was as string, make sure it gets updated
+	if (supportedModes && supportedModes[0].size() > 1) {
 		def next = { supportedModes[supportedModes.indexOf(it) + 1] ?: supportedModes[0] }
 		def nextMode = next(currentMode)
 		runIn(2, "setGetThermostatMode", [data: [nextMode: nextMode], overwrite: true])
@@ -519,7 +520,8 @@ def switchMode() {
 
 def switchToMode(nextMode) {
 	def supportedModes = state.supportedModes
-	if (supportedModes) {
+	// Old version of supportedModes was as string, make sure it gets updated
+	if (supportedModes && supportedModes[0].size() > 1) {
 		if (supportedModes.contains(nextMode)) {
 			runIn(2, "setGetThermostatMode", [data: [nextMode: nextMode], overwrite: true])
 		} else {
@@ -540,7 +542,8 @@ def getSupportedModes() {
 def switchFanMode() {
 	def currentMode = device.currentValue("thermostatFanMode")
 	def supportedFanModes = state.supportedFanModes
-	if (supportedFanModes) {
+	// Old version of supportedFanModes was as string, make sure it gets updated
+	if (supportedFanModes && supportedFanModes[0].size() > 1) {
 		def next = { supportedFanModes[supportedFanModes.indexOf(it) + 1] ?: supportedFanModes[0] }
 		def nextMode = next(currentMode)
 		runIn(2, "setGetThermostatFanMode", [data: [nextMode: nextMode], overwrite: true])
@@ -552,7 +555,8 @@ def switchFanMode() {
 
 def switchToFanMode(nextMode) {
 	def supportedFanModes = state.supportedFanModes
-	if (supportedFanModes) {
+	// Old version of supportedFanModes was as string, make sure it gets updated
+	if (supportedFanModes && supportedFanModes[0].size() > 1) {
 		if (supportedFanModes.contains(nextMode)) {
 			runIn(2, "setGetThermostatFanMode", [data: [nextMode: nextMode], overwrite: true])
 		} else {

--- a/devicetypes/smartthings/zwave-thermostat.src/zwave-thermostat.groovy
+++ b/devicetypes/smartthings/zwave-thermostat.src/zwave-thermostat.groovy
@@ -508,7 +508,7 @@ def switchMode() {
 	def currentMode = device.currentValue("thermostatMode")
 	def supportedModes = state.supportedModes
 	// Old version of supportedModes was as string, make sure it gets updated
-	if (supportedModes && supportedModes[0].size() > 1) {
+	if (supportedModes && supportedModes.size() && supportedModes[0].size() > 1) {
 		def next = { supportedModes[supportedModes.indexOf(it) + 1] ?: supportedModes[0] }
 		def nextMode = next(currentMode)
 		runIn(2, "setGetThermostatMode", [data: [nextMode: nextMode], overwrite: true])
@@ -521,7 +521,7 @@ def switchMode() {
 def switchToMode(nextMode) {
 	def supportedModes = state.supportedModes
 	// Old version of supportedModes was as string, make sure it gets updated
-	if (supportedModes && supportedModes[0].size() > 1) {
+	if (supportedModes && supportedModes.size() && supportedModes[0].size() > 1) {
 		if (supportedModes.contains(nextMode)) {
 			runIn(2, "setGetThermostatMode", [data: [nextMode: nextMode], overwrite: true])
 		} else {
@@ -543,7 +543,7 @@ def switchFanMode() {
 	def currentMode = device.currentValue("thermostatFanMode")
 	def supportedFanModes = state.supportedFanModes
 	// Old version of supportedFanModes was as string, make sure it gets updated
-	if (supportedFanModes && supportedFanModes[0].size() > 1) {
+	if (supportedFanModes && supportedFanModes.size() && supportedFanModes[0].size() > 1) {
 		def next = { supportedFanModes[supportedFanModes.indexOf(it) + 1] ?: supportedFanModes[0] }
 		def nextMode = next(currentMode)
 		runIn(2, "setGetThermostatFanMode", [data: [nextMode: nextMode], overwrite: true])
@@ -556,7 +556,7 @@ def switchFanMode() {
 def switchToFanMode(nextMode) {
 	def supportedFanModes = state.supportedFanModes
 	// Old version of supportedFanModes was as string, make sure it gets updated
-	if (supportedFanModes && supportedFanModes[0].size() > 1) {
+	if (supportedFanModes && supportedFanModes.size() && supportedFanModes[0].size() > 1) {
 		if (supportedFanModes.contains(nextMode)) {
 			runIn(2, "setGetThermostatFanMode", [data: [nextMode: nextMode], overwrite: true])
 		} else {


### PR DESCRIPTION
CT100/Honeywell Z-wave NullPointerException when changing mode
In the event supportedModes and supportedFanModes hasn't been updated from a string to a list the mode isn't validated properly.
Adding check for string and if so updating the supported modes.