### PR TITLE
Have zigbee setColor honor level settings

### DIFF
--- a/devicetypes/smartthings/zigbee-rgb-bulb.src/zigbee-rgb-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-rgb-bulb.src/zigbee-rgb-bulb.groovy
@@ -156,11 +156,15 @@ private getScaledSaturation(value) {
 
 def setColor(value){
 	log.trace "setColor($value)"
-	zigbee.on() +
-	zigbee.command(COLOR_CONTROL_CLUSTER, MOVE_TO_HUE_AND_SATURATION_COMMAND,
-		getScaledHue(value.hue), getScaledSaturation(value.saturation), "0000") +
-	zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE) +
-	zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION)
+	def cmds = zigbee.on() +
+			zigbee.command(COLOR_CONTROL_CLUSTER, MOVE_TO_HUE_AND_SATURATION_COMMAND,
+					getScaledHue(value.hue), getScaledSaturation(value.saturation), "0000") +
+			zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION) +
+			zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE)
+	if (value?.level != null) {
+		cmds += zigbee.setLevel(value.level)
+	}
+	return cmds
 }
 
 def setHue(value) {

--- a/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
@@ -207,11 +207,15 @@ private getScaledSaturation(value) {
 
 def setColor(value){
     log.trace "setColor($value)"
-    zigbee.on() +
-    zigbee.command(COLOR_CONTROL_CLUSTER, MOVE_TO_HUE_AND_SATURATION_COMMAND,
-    getScaledHue(value.hue), getScaledSaturation(value.saturation), "0000") +
-    zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION) +
-    zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE)
+    def cmds = zigbee.on() +
+            zigbee.command(COLOR_CONTROL_CLUSTER, MOVE_TO_HUE_AND_SATURATION_COMMAND,
+                    getScaledHue(value.hue), getScaledSaturation(value.saturation), "0000") +
+            zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION) +
+            zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE)
+    if (value?.level != null) {
+        cmds += zigbee.setLevel(value.level)
+    }
+    return cmds
 }
 
 def setHue(value) {

--- a/devicetypes/smartthings/zll-rgb-bulb.src/zll-rgb-bulb.groovy
+++ b/devicetypes/smartthings/zll-rgb-bulb.src/zll-rgb-bulb.groovy
@@ -134,11 +134,15 @@ private getScaledSaturation(value) {
 
 def setColor(value){
 	log.trace "setColor($value)"
-	zigbee.on() +
-	zigbee.command(COLOR_CONTROL_CLUSTER, MOVE_TO_HUE_AND_SATURATION_COMMAND,
-		getScaledHue(value.hue), getScaledSaturation(value.saturation), "0000") +
-	zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE) +
-	zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION)
+	def cmds = zigbee.on() +
+			zigbee.command(COLOR_CONTROL_CLUSTER, MOVE_TO_HUE_AND_SATURATION_COMMAND,
+					getScaledHue(value.hue), getScaledSaturation(value.saturation), "0000") +
+			zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION) +
+			zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE)
+	if (value?.level != null) {
+		cmds += zigbee.setLevel(value.level)
+	}
+	return cmds
 }
 
 def setHue(value) {

--- a/devicetypes/smartthings/zll-rgbw-bulb.src/zll-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zll-rgbw-bulb.src/zll-rgbw-bulb.groovy
@@ -155,12 +155,15 @@ private getScaledSaturation(value) {
 
 def setColor(value){
     log.trace "setColor($value)"
-    zigbee.on() +
-    zigbee.command(COLOR_CONTROL_CLUSTER, MOVE_TO_HUE_AND_SATURATION_COMMAND,
-        getScaledHue(value.hue), getScaledSaturation(value.saturation), "0000") +
-    zigbee.onOffRefresh() +
-    zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE) +
-    zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION)
+    def cmds = zigbee.on() +
+            zigbee.command(COLOR_CONTROL_CLUSTER, MOVE_TO_HUE_AND_SATURATION_COMMAND,
+                    getScaledHue(value.hue), getScaledSaturation(value.saturation), "0000") +
+            zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION) +
+            zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE)
+    if (value?.level != null) {
+        cmds += zigbee.setLevel(value.level)
+    }
+    return cmds
 }
 
 def setHue(value) {


### PR DESCRIPTION
The ColorControl.setColor command takes a color map as an argument which
can include a level.  This level was not being honored by most of the
zigbee color bulbs.  This shows up as an issue when using the lighting
automation to set color and level, the level portion is not working.

This resolves: https://smartthings.atlassian.net/browse/DVCSMP-3133

@tpmanley 