### PR TITLE
DVCSMP-3163: Fix problem setting color temperature on Sengled Element Plus

### DIFF
--- a/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
@@ -147,12 +147,19 @@ def configure() {
 
 def setColorTemperature(value) {
     setGenericName(value)
-	value = value as Integer
+    value = value as Integer
     def tempInMired = (1000000 / value) as Integer
     def finalHex = zigbee.swapEndianHex(zigbee.convertToHexString(tempInMired, 4))
 
-    zigbee.command(COLOR_CONTROL_CLUSTER, MOVE_TO_COLOR_TEMPERATURE_COMMAND, "$finalHex 0000") +
-    zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_COLOR_TEMPERATURE)
+    List cmds = []
+    if (device.getDataValue("manufacturer") == "sengled" && device.getDataValue("model") == "Z01-A19NAE26") {
+        // Sengled Element Plus will ignore the command if the transition time is 0x0000
+        cmds << zigbee.command(COLOR_CONTROL_CLUSTER, MOVE_TO_COLOR_TEMPERATURE_COMMAND, "$finalHex 0100")
+    } else {
+        cmds << zigbee.command(COLOR_CONTROL_CLUSTER, MOVE_TO_COLOR_TEMPERATURE_COMMAND, "$finalHex 0000")
+    }
+    cmds << zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_COLOR_TEMPERATURE)
+    cmds
 }
 
 //Naming based on the wiki article here: http://en.wikipedia.org/wiki/Color_temperature


### PR DESCRIPTION
The Sengled Element Plus seems to ignore the Move to Color Temperature command when the transition time is 0x0000 but will execute the command correctly when the value is 0x0001 or greater. The `setColorTemperature` command now checks the mfg/model and uses a transition time of 0x0001 for the Sengled Element Plus (value in code is in little endian byte format) and continues to use a value of 0x0000 for everything else.

https://smartthings.atlassian.net/browse/DVCSMP-3163