### PR TITLE
CHAD-1353 Z-wave Switch DTH : Local support expansion

### DIFF
--- a/devicetypes/smartthings/zwave-switch.src/zwave-switch.groovy
+++ b/devicetypes/smartthings/zwave-switch.src/zwave-switch.groovy
@@ -87,6 +87,7 @@ def updated(){
             indicatorWhenOn()
             break
     }
+    sendHubCommand(new physicalgraph.device.HubAction(zwave.manufacturerSpecificV1.manufacturerSpecificGet().format()))
 }
 
 def getCommandClassVersions() {
@@ -187,7 +188,7 @@ def poll() {
   * PING is used by Device-Watch in attempt to reach the Device
 **/
 def ping() {
-		refresh()
+    zwave.switchBinaryV1.switchBinaryGet().format()
 }
 
 def refresh() {


### PR DESCRIPTION
The ping command in z-wave switch dth calls refresh() which calls zwave.manufacturerSpecificV1.manufacturerSpecificGet().format()
which generates manufacture specific attribute related events which cannot be executed locally although in 0.18 the z-wave switch dth is marked to run locally.
Thus partial cloud executions are taking place over 1M times a day. To decrease the number of DTH executions in the cloud instead of calling refresh from ping, only zwave.switchBinaryV1.switchBinaryGet().format()  can be called without hampering device health related events.
    
https://smartthings.atlassian.net/browse/CHAD-1353
Tested with GE plug-in switch