### PR TITLE
[DVCSMP-3262] Remove unnecessary write from GE link poll

### DIFF
--- a/devicetypes/smartthings/ge-link-bulb.src/ge-link-bulb.groovy
+++ b/devicetypes/smartthings/ge-link-bulb.src/ge-link-bulb.groovy
@@ -98,11 +98,7 @@ def parse(String description) {
 }
 
 def poll() {
-    def refreshCmds = [
-        "st wattr 0x${device.deviceNetworkId} 1 8 0x10 0x21 {${state?.dOnOff ?: '0000'}}", "delay 2000"
-    ]
-
-    return refreshCmds + zigbee.onOffRefresh() + zigbee.levelRefresh()
+	return zigbee.onOffRefresh() + zigbee.levelRefresh()
 }
 
 def updated() {
@@ -182,9 +178,7 @@ def updated() {
     	state.dOnOff = "0000"
     }
 
-    "st wattr 0x${device.deviceNetworkId} 1 8 0x10 0x21 {${state.dOnOff}}"
-
-
+	sendHubCommand(new physicalgraph.device.HubAction("st wattr 0x${device.deviceNetworkId} 1 8 0x10 0x21 {${state.dOnOff}}"))
 }
 
 def on() {


### PR DESCRIPTION
The poll method was doing a write of a transition time value. This is not 
needed and can be done only on the updated call (which it is).

@tpmanley @workingmonk 