### PR TITLE
[ICP-1824] Zero is displayed in Temperature and Battery state field after paired Fibaro Smoke Sensor

### DIFF
--- a/devicetypes/smartthings/fibaro-smoke-sensor.src/fibaro-smoke-sensor.groovy
+++ b/devicetypes/smartthings/fibaro-smoke-sensor.src/fibaro-smoke-sensor.groovy
@@ -364,6 +364,7 @@ def configure() {
     //making the default state as "clear"
     sendEvent(name: "smoke", value: "clear", displayed: false)
 // This sensor joins as a secure device if you tripple-click the button to include it
+    setSecured()
     log.debug "configure() >> isSecured() : ${isSecured()}"
     if (!isSecured()) {
         log.debug "Fibaro smoke sensor not sending configure until secure"


### PR DESCRIPTION
@jackchi 
Changing the default value of `secured` as true, so that the device report its battery and temperature value on pairing. Earlier the device was suppose to report battery status only when the user manually presses the B-button. 
Please review.
