### PR TITLE
Update smartsense-multi-sensor.groovy

### DIFF
--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -273,10 +273,10 @@ private Map getBatteryResult(rawValue) {
 			def pct = batteryMap[volts]
 			result.value = pct
 		} else {
-			def minVolts = 2.1
-			def maxVolts = 2.7
+			def minVolts = 2.5
+			def maxVolts = 3.0
 			// Get the current battery percentage as a multiplier 0 - 1
-			def curValVolts = Integer.parseInt(device.currentState("battery")?.value ?: "100") / 100.0
+			def curValVolts = Integer.parseInt(device.currentState("battery")?.value, 10) / 100.0
 			// Find the corresponding voltage from our range
 			curValVolts = curValVolts * (maxVolts - minVolts) + minVolts
 			// Round to the nearest 10th of a volt


### PR DESCRIPTION
Line 276 changed from 2.1 to 2.5 for minVolts because at least the CentraLite Model 3321-S stop reporting open/close events at 2.5 volts

Line 277 changed from 2.7 to 3.0 for maxVolts. This more accurately reflects 100% charge on a CR-2450 battery. This also allows for more steps in reported percentages.

Line 279 Changed def curValVolts = Integer.parseInt(device.currentState("battery")?.value, ?:"100") / 100.0 to def curValVolts = Integer.parseInt(device.currentState("battery")?.value, 10) / 100.0 . This brings it on line with the parseInt(string, radix) syntax. This change fixed the constant "100%" battery reporting on the Model 3321-S sensors.

Also in reference to Support Ticket: 412456

See forum links also for additional information:  https://community.smartthings.com/t/st-multi-sensor-battery-reporting-issues/98924
 and:  https://community.smartthings.com/t/help-with-a-line-of-code-in-a-dth-i-cant-figure-out/100870