### PR TITLE
PROB-1869 Zen thermostat connecting with no battery state

### DIFF
--- a/devicetypes/zenwithin/zen-thermostat.src/zen-thermostat.groovy
+++ b/devicetypes/zenwithin/zen-thermostat.src/zen-thermostat.groovy
@@ -250,8 +250,11 @@ def parse(String description) {
             case "001c": // ATTRIBUTE_SYSTEM_MODE
                 // Make sure operating state is in sync
                 map.name = "thermostatMode"
-                map.isStateChange = state.switchMode ?: false  // set to true to force update if switchMode failed and old mode is returned
-                state.switchMode = false
+                if (state.switchMode) {
+                    // set isStateChange to true to force update if switchMode failed and old mode is returned
+                    map.isStateChange = true
+                    state.switchMode = false
+                }
                 map.data = [supportedThermostatModes: supportedModes]
                 map.value = systemModeMap[descMap.value]
                 // in case of refresh, allow heat/cool setpoints to be reported before updating setpoint
@@ -275,8 +278,11 @@ def parse(String description) {
                 // Make sure operating state is in sync
                 ping()
                 map.name = "thermostatFanMode"
-                map.isStateChange = state.switchFanMode ?: false  // set to true to force update if switchMode failed and old mode is returned
-                state.switchFanMode = false
+                if (state.switchFanMode) {
+                    // set isStateChange to true to force update if switchMode failed and old mode is returned
+                    map.isStateChange = true
+                    state.switchFanMode = false
+                }
                 map.data = [supportedThermostatFanModes: state.supportedFanModes]
                 map.value = fanModeMap[descMap.value]
                 break

--- a/devicetypes/zenwithin/zen-thermostat.src/zen-thermostat.groovy
+++ b/devicetypes/zenwithin/zen-thermostat.src/zen-thermostat.groovy
@@ -4,7 +4,7 @@
  *  Author: Zen Within
  *  Date: 2015-02-21
  *  Updated by SmartThings
- *  Date: 2017-09-07
+ *  Date: 2017-10-12
  */
 metadata {
     definition (name: "Zen Thermostat", namespace: "zenwithin", author: "ZenWithin") {
@@ -196,7 +196,6 @@ def parse(String description) {
         def mode = device.currentValue("thermostatMode")
         switch (descMap.attrId) {
             case "0000": // ATTRIBUTE_LOCAL_TEMPERATURE
-                log.debug "LOCAL TEMPERATURE"
                 map.name = "temperature"
                 map.unit = locationScale
                 map.value = getTempInLocalScale(parseTemperature(descMap.value), "C") // Zibee always reports in °C
@@ -251,7 +250,8 @@ def parse(String description) {
             case "001c": // ATTRIBUTE_SYSTEM_MODE
                 // Make sure operating state is in sync
                 map.name = "thermostatMode"
-                map.isStateChange = true  // set to true to force update if switchMode failed and old mode is returned
+                map.isStateChange = state.switchMode ?: false  // set to true to force update if switchMode failed and old mode is returned
+                state.switchMode = false
                 map.data = [supportedThermostatModes: supportedModes]
                 map.value = systemModeMap[descMap.value]
                 // in case of refresh, allow heat/cool setpoints to be reported before updating setpoint
@@ -275,7 +275,8 @@ def parse(String description) {
                 // Make sure operating state is in sync
                 ping()
                 map.name = "thermostatFanMode"
-                map.isStateChange = true  // set to true to force update if switchMode failed and old mode is returned
+                map.isStateChange = state.switchFanMode ?: false  // set to true to force update if switchMode failed and old mode is returned
+                state.switchFanMode = false
                 map.data = [supportedThermostatFanModes: state.supportedFanModes]
                 map.value = fanModeMap[descMap.value]
                 break
@@ -296,7 +297,6 @@ def parse(String description) {
     if (map) {
       result = createEvent(map)
     }
-    log.debug "Parse returned $map, result:$result"
     return result
 }
 
@@ -407,9 +407,9 @@ def updateBatteryStatus(rawValue) {
         // customAttribute in order to change UI icon/label
         def eventMap = [name: "batteryIcon", value: "err_battery", displayed: false]
         def linkText = getLinkText(device)
-        if (volts < 61 && volts != 0 && volts != 255) {
+        if (volts < 62 && volts != 0 && volts != 255) {
             def minVolts = 34  // voltage when device UI starts to die
-            def maxVolts = 60  // 4 batteries at 1.5V
+            def maxVolts = 61  // 4 batteries at 1.5V should be 6.0V, however logs from users show 6,1 as well
             def pct = (volts - minVolts) / (maxVolts - minVolts)
             eventMap.value = Math.min(100, (int) pct * 100)
             // Update capability "Battery"
@@ -664,6 +664,7 @@ def switchToMode(nextMode) {
             def mode = Integer.parseInt(systemModeMap.find { it.value == nextMode }?.key, 16)
             cmds += zigbee.writeAttribute(THERMOSTAT_CLUSTER, ATTRIBUTE_SYSTEM_MODE, typeENUM8, mode)
             sendZigbeeCmds(cmds)
+            state.switchMode = true
         } else {
             log.debug("ThermostatMode $nextMode is not supported by ${device.displayName}")
         }
@@ -712,6 +713,7 @@ def switchToFanMode(nextMode) {
             def mode = fanModeMap.find { it.value == nextMode }?.key
             def cmds = zigbee.writeAttribute(FAN_CONTROL_CLUSTER, ATTRIBUTE_FAN_MODE, typeENUM8, mode)
             sendZigbeeCmds(cmds)
+            state.switchFanMode = true
         } else {
             log.debug("FanMode $nextMode is not supported by ${device.displayName}")
         }


### PR DESCRIPTION
Changing max allowed battery voltage from 6.0 to 6.1 as
logs from a user showed the thermostat reporting 6.1V despite
there's only 4 x 1.5V batteries.
Also made a change so that thermostatMode and fanMode only generate
an event when the mode is changing.