### PR TITLE
PROB-1673 Don't use defaultValue and required in the preferences block

### DIFF
--- a/devicetypes/smartthings/aeon-siren.src/aeon-siren.groovy
+++ b/devicetypes/smartthings/aeon-siren.src/aeon-siren.groovy
@@ -49,8 +49,9 @@ metadata {
 	}
 
 	preferences {
-		input "sound", "number", title: "Siren sound (1-5)", range: "1..5", defaultValue: 1, required: true//, displayDuringSetup: true  // don't display during setup until defaultValue is shown
-		input "volume", "number", title: "Volume (1-3)", range: "1..3", defaultValue: 3, required: true//, displayDuringSetup: true
+		// PROB-1673 Since there is a bug with how defaultValue and range are handled together, we won't rely on defaultValue and won't set required, but will use the default values in the code below when needed.
+		input "sound", "number", title: "Siren sound (1-5)", range: "1..5" //, defaultValue: 1, required: true//, displayDuringSetup: true  // don't display during setup until defaultValue is shown
+		input "volume", "number", title: "Volume (1-3)", range: "1..3" //, defaultValue: 3, required: true//, displayDuringSetup: true
 	}
 
 	main "alarm"


### PR DESCRIPTION
Since there is a bug with how defaultValue and range are handled together, we won't rely on defaultValue and won't set required, but will use the default values in the code below when needed.