### PR TITLE
DVCSMP-1524 Remove polling capability from hub-polled devices

### DIFF
--- a/devicetypes/smartthings/aeon-illuminator-module.src/aeon-illuminator-module.groovy
+++ b/devicetypes/smartthings/aeon-illuminator-module.src/aeon-illuminator-module.groovy
@@ -18,7 +18,6 @@ metadata {
 		capability "Actuator"
 		capability "Switch"
 		capability "Configuration"
-		capability "Polling"
 		capability "Refresh"
 		capability "Sensor"
 
@@ -165,10 +164,6 @@ def setLevel(value) {
 def setLevel(value, duration) {
 	def dimmingDuration = duration < 128 ? duration : 128 + Math.round(duration / 60)
 	zwave.switchMultilevelV2.switchMultilevelSet(value: value, dimmingDuration: dimmingDuration).format()
-}
-
-def poll() {
-	zwave.switchMultilevelV1.switchMultilevelGet().format()
 }
 
 def refresh() {

--- a/devicetypes/smartthings/aeon-outlet.src/aeon-outlet.groovy
+++ b/devicetypes/smartthings/aeon-outlet.src/aeon-outlet.groovy
@@ -17,7 +17,6 @@ metadata {
 		capability "Actuator"
 		capability "Switch"
 		capability "Configuration"
-		capability "Polling"
 		capability "Refresh"
 		capability "Sensor"
 
@@ -119,13 +118,6 @@ def off() {
 	delayBetween([
 		zwave.basicV1.basicSet(value: 0x00).format(),
 		zwave.switchBinaryV1.switchBinaryGet().format()
-	])
-}
-
-def poll() {
-	delayBetween([
-		zwave.switchBinaryV1.switchBinaryGet().format(),
-		zwave.meterV2.meterGet().format()
 	])
 }
 

--- a/devicetypes/smartthings/dimmer-switch.src/dimmer-switch.groovy
+++ b/devicetypes/smartthings/dimmer-switch.src/dimmer-switch.groovy
@@ -17,7 +17,6 @@ metadata {
 		capability "Actuator"
 		capability "Indicator"
 		capability "Switch"
-		capability "Polling"
 		capability "Refresh"
 		capability "Sensor"
 		capability "Health Check"
@@ -240,10 +239,6 @@ def setLevel(value, duration) {
 	def getStatusDelay = duration < 128 ? (duration*1000)+2000 : (Math.round(duration / 60)*60*1000)+2000
 	delayBetween ([zwave.switchMultilevelV2.switchMultilevelSet(value: level, dimmingDuration: dimmingDuration).format(),
 				   zwave.switchMultilevelV1.switchMultilevelGet().format()], getStatusDelay)
-}
-
-def poll() {
-	zwave.switchMultilevelV1.switchMultilevelGet().format()
 }
 
 /**

--- a/devicetypes/smartthings/zwave-metering-switch.src/zwave-metering-switch.groovy
+++ b/devicetypes/smartthings/zwave-metering-switch.src/zwave-metering-switch.groovy
@@ -17,7 +17,6 @@ metadata {
 		capability "Actuator"
 		capability "Switch"
 		capability "Power Meter"
-		capability "Polling"
 		capability "Refresh"
 		capability "Configuration"
 		capability "Sensor"
@@ -199,14 +198,6 @@ def off() {
 		"delay 3000",
 		zwave.meterV2.meterGet(scale: 2).format()
 	]
-}
-
-def poll() {
-	delayBetween([
-		zwave.switchBinaryV1.switchBinaryGet().format(),
-		zwave.meterV2.meterGet(scale: 0).format(),
-		zwave.meterV2.meterGet(scale: 2).format()
-	])
 }
 
 /**

--- a/devicetypes/smartthings/zwave-switch.src/zwave-switch.groovy
+++ b/devicetypes/smartthings/zwave-switch.src/zwave-switch.groovy
@@ -16,7 +16,6 @@ metadata {
 		capability "Actuator"
 		capability "Indicator"
  		capability "Switch"
-		capability "Polling"
 		capability "Refresh"
 		capability "Sensor"
 		capability "Health Check"
@@ -174,13 +173,6 @@ def off() {
 	delayBetween([
 		zwave.basicV1.basicSet(value: 0x00).format(),
 		zwave.switchBinaryV1.switchBinaryGet().format()
-	])
-}
-
-def poll() {
-	delayBetween([
-		zwave.switchBinaryV1.switchBinaryGet().format(),
-		zwave.manufacturerSpecificV1.manufacturerSpecificGet().format()
 	])
 }
 


### PR DESCRIPTION
Removes the deprecated polling capability from these devices which are polled by the hub directly.