### PR TITLE
Don't suppress code update/unset notifications

### DIFF
--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -773,7 +773,7 @@ def zwaveEvent(UserCodeReport cmd) {
 				result << codeSetEvent(lockCodes, codeID, codeName)
 			} else {
 				map.value = "$codeID changed"
-				map.isStateChange = false
+				map.isStateChange = true
 			}
 			map.descriptionText = "${getStatusForDescription('set')} \"$codeName\""
 			map.data = [ codeName: codeName, lockName: deviceName ]
@@ -805,7 +805,7 @@ def zwaveEvent(UserCodeReport cmd) {
 				result << codeDeletedEvent(lockCodes, codeID)
 			} else {
 				map.value = "$codeID unset"
-				map.isStateChange = false
+				map.isStateChange = true
 				map.data = [ lockName: deviceName ]
 			}
 		}


### PR DESCRIPTION
Required for operation for SmartApps to confirm that all transactions send to lock have been processed by lock, don't suppress the notifications, pass them onto the SmartApps

@tylerlange can this please be reviewed and merged