### PR TITLE
ICP-2151, ICP-2236, ICP-2237 Add Samsung Lock fingerprint to DTH

### DIFF
--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -45,6 +45,7 @@ metadata {
 		fingerprint mfr:"0129", prod:"0004", model:"0000", deviceJoinName: "Yale Push Button Deadbolt Door Lock" // YRD210
 		fingerprint mfr:"0129", prod:"0001", model:"0000", deviceJoinName: "Yale Push Button Lever Door Lock" // YRD210
 		fingerprint mfr:"0129", prod:"8002", model:"0600", deviceJoinName: "Yale Assure Lock with Bluetooth"
+		fingerprint mfr:"022E", prod:"0001", model:"0001", deviceJoinName: "Samsung Digital Lock" // SHP-DS705, SHP-DHP728, SHP-DHP525
 	}
 
 	simulator {


### PR DESCRIPTION
Give generic name to handle different locks with the same fingerprint

This replaces https://github.com/SmartThingsCommunity/SmartThingsPublic/pull/2500 but points the commit to production.