### PR TITLE
PROB-1904 Adding changeable icons back to zwave-relay and momentary-button-tile 

### DIFF
--- a/devicetypes/smartthings/momentary-button-tile.src/momentary-button-tile.groovy
+++ b/devicetypes/smartthings/momentary-button-tile.src/momentary-button-tile.groovy
@@ -30,7 +30,7 @@ metadata {
 
 	// UI tile definitions
 	tiles(scale: 2){
-		multiAttributeTile(name:"switch", type: "generic", width: 6, height: 4){
+		multiAttributeTile(name:"switch", type: "generic", width: 6, height: 4, canChangeIcon: true){
 			tileAttribute("device.switch", key: "PRIMARY_CONTROL") {
 				attributeState("off", label: 'Push', action: "momentary.push", backgroundColor: "#ffffff", nextState: "on")
 				attributeState("on", label: 'Push', action: "momentary.push", backgroundColor: "#00a0dc")

--- a/devicetypes/smartthings/zwave-relay.src/zwave-relay.groovy
+++ b/devicetypes/smartthings/zwave-relay.src/zwave-relay.groovy
@@ -37,7 +37,7 @@ metadata {
 
 	// tile definitions
 	tiles(scale: 2){
-		multiAttributeTile(name:"switch", type: "generic", width: 6, height: 4){
+		multiAttributeTile(name:"switch", type: "generic", width: 6, height: 4, canChangeIcon: true){
 			tileAttribute("device.switch", key: "PRIMARY_CONTROL") {
 				attributeState("on", label: '${name}', action: "switch.off", icon: "st.switches.switch.on", backgroundColor: "#00a0dc")
 				attributeState("off", label: '${name}', action: "switch.on", icon: "st.switches.switch.off", backgroundColor: "#ffffff")


### PR DESCRIPTION
In a recent update to change these DTHs to use multi-attribute tiles the option to change the device icon for them was lost. This has caused a few users to not be able to change icons on devices that they could before (PROB-1904). This change adds back the ability to change the icons for these two device types.