### PR TITLE
[CHAD-1633] Mark 0.20.X devices to run locally

### DIFF
--- a/devicetypes/smartthings/aeon-multisensor-6.src/aeon-multisensor-6.groovy
+++ b/devicetypes/smartthings/aeon-multisensor-6.src/aeon-multisensor-6.groovy
@@ -13,7 +13,7 @@
  */
 
 metadata {
-	definition (name: "Aeon Multisensor 6", namespace: "smartthings", author: "SmartThings") {
+	definition (name: "Aeon Multisensor 6", namespace: "smartthings", author: "SmartThings", runLocally: true, minHubCoreVersion: '000.020.00008', executeCommandsLocally: true) {
 		capability "Motion Sensor"
 		capability "Temperature Measurement"
 		capability "Relative Humidity Measurement"

--- a/devicetypes/smartthings/testing/simulated-dimmer-switch.src/simulated-dimmer-switch.groovy
+++ b/devicetypes/smartthings/testing/simulated-dimmer-switch.src/simulated-dimmer-switch.groovy
@@ -14,7 +14,7 @@
  *
  */
 metadata {
-    definition (name: "Simulated Dimmer Switch", namespace: "smartthings/testing", author: "SmartThings") {
+    definition (name: "Simulated Dimmer Switch", namespace: "smartthings/testing", author: "SmartThings", runLocally: true, minHubCoreVersion: '000.020.00008', executeCommandsLocally: true) {
         capability "Actuator"
         capability "Sensor"
 

--- a/devicetypes/smartthings/testing/simulated-switch.src/simulated-switch.groovy
+++ b/devicetypes/smartthings/testing/simulated-switch.src/simulated-switch.groovy
@@ -13,7 +13,7 @@
  */
 metadata {
 
-    definition (name: "Simulated Switch", namespace: "smartthings/testing", author: "bob") {
+    definition (name: "Simulated Switch", namespace: "smartthings/testing", author: "bob", runLocally: true, minHubCoreVersion: '000.020.00008', executeCommandsLocally: true) {
         capability "Switch"
         capability "Relay Switch"
         capability "Sensor"

--- a/devicetypes/smartthings/zwave-plus-door-window-sensor.src/zwave-plus-door-window-sensor.groovy
+++ b/devicetypes/smartthings/zwave-plus-door-window-sensor.src/zwave-plus-door-window-sensor.groovy
@@ -16,7 +16,7 @@
 */
 
 metadata {
-	definition (name: "Z-Wave Plus Door/Window Sensor", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "x.com.st.d.sensor.contact") {
+	definition (name: "Z-Wave Plus Door/Window Sensor", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "x.com.st.d.sensor.contact", runLocally: true, minHubCoreVersion: '000.020.00008', executeCommandsLocally: true) {
 		capability "Contact Sensor"
 		capability "Configuration"
 		capability "Battery"


### PR DESCRIPTION
This is marking the hubcore 0.20.X newly supported devices to run
locally.

This resolves: https://smartthings.atlassian.net/browse/CHAD-1633

@tpmanley @workingmonk 