### PR TITLE
Dvcsmp-1437 GE Fan switches don't support configuration

### DIFF
--- a/devicetypes/smartthings/dimmer-switch.src/dimmer-switch.groovy
+++ b/devicetypes/smartthings/dimmer-switch.src/dimmer-switch.groovy
@@ -26,7 +26,6 @@ metadata {
 		fingerprint mfr:"0063", prod:"4457", deviceJoinName: "GE In-Wall Smart Dimmer"
 		fingerprint mfr:"0063", prod:"4944", deviceJoinName: "GE In-Wall Smart Dimmer"
 		fingerprint mfr:"0063", prod:"5044", deviceJoinName: "GE Plug-In Smart Dimmer"
-		fingerprint mfr:"0063", prod:"4944", model:"3034", deviceJoinName: "GE In-Wall Smart Fan Control"
 	}
 
 	simulator {

--- a/devicetypes/smartthings/zwave-dimmer-switch-generic.src/zwave-dimmer-switch-generic.groovy
+++ b/devicetypes/smartthings/zwave-dimmer-switch-generic.src/zwave-dimmer-switch-generic.groovy
@@ -31,6 +31,8 @@ metadata {
 		fingerprint mfr:"001D", prod:"0401", model:"0334", deviceJoinName: "Leviton 600W Incandescent Dimmer"
 		fingerprint mfr:"0111", prod:"8200", model:"0200", deviceJoinName: "Remotec Technology Plug-In Dimmer"
 		fingerprint mfr:"1104", prod:"001D", model:"0501", deviceJoinName: "Leviton 1000W Incandescant Dimmer"
+		fingerprint mfr:"0063", prod:"4944", model:"3034", deviceJoinName: "GE In-Wall Smart Fan Control"
+		fingerprint mfr:"0063", prod:"4944", model:"3031", deviceJoinName: "GE In-Wall Smart Fan Control"
 	}
 
 	simulator {


### PR DESCRIPTION
Upon investigation, these GE fan switches should never have used the GE-specific DTH because one model doesn't even support the configuration command class and the new model I added does, but not for indicator control.