### PR TITLE
ICP-1827 Yale Assure Lock device join name fix

### DIFF
--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -48,7 +48,7 @@ metadata {
 		fingerprint mfr:"0129", prod:"0004", model:"0800", deviceJoinName: "Yale Push Button Deadbolt Door Lock" // YRD110
 		fingerprint mfr:"0129", prod:"0004", model:"0000", deviceJoinName: "Yale Push Button Deadbolt Door Lock" // YRD210
 		fingerprint mfr:"0129", prod:"0001", model:"0000", deviceJoinName: "Yale Push Button Lever Door Lock" // YRD210
-		fingerprint mfr:"0129", prod:"8002", model:"0600", deviceJoinName: "Yale Assure Lock with Bluetooth" //YRD416, YRD426, YRD446
+		fingerprint mfr:"0129", prod:"8002", model:"0600", deviceJoinName: "Yale Assure Lock" //YRD416, YRD426, YRD446
 		fingerprint mfr:"0129", prod:"0007", model:"0001", deviceJoinName: "Yale Keyless Connected Smart Door Lock"
 		fingerprint mfr:"0129", prod:"8004", model:"0600", deviceJoinName: "Yale Assure Lock Push Button Deadbolt" //YRD216
 		// Samsung


### PR DESCRIPTION
The two models of Yale Assure Lock (w/ and w/o BT) are indistinguishable based on ZWave info. This makes the name applicable to both models.