### PR TITLE
WWST-159 WWST-155 WWST-164 WWST-157 WWST-166 WWST-158 WWST-156 WWST-165 WWST-160 WWST-167 Move Honeywell Switch fingerprints

### DIFF
--- a/devicetypes/smartthings/zwave-switch-generic.src/zwave-switch-generic.groovy
+++ b/devicetypes/smartthings/zwave-switch-generic.src/zwave-switch-generic.groovy
@@ -31,6 +31,12 @@ metadata {
 		fingerprint mfr:"001D", prod:"1603", model:"0334", deviceJoinName: "Leviton 15A Split Duplex Receptacle"
 		fingerprint mfr:"011A", prod:"0101", model:"0102", deviceJoinName: "Enerwave On/Off Switch"
 		fingerprint mfr:"011A", prod:"0101", model:"0603", deviceJoinName: "Enerwave Duplex Receptacle"
+		fingerprint mfr:"0039", prod:"5052", model:"3038", deviceJoinName: "Honeywell Z-Wave Plug-in Switch"
+		fingerprint mfr:"0039", prod:"5052", model:"3033", deviceJoinName: "Honeywell Z-Wave Plug-in Switch (Dual Outlet)"
+		fingerprint mfr:"0039", prod:"4F50", model:"3032", deviceJoinName: "Honeywell Z-Wave Plug-in Outdoor Smart Switch"
+		fingerprint mfr:"0039", prod:"4952", model:"3036", deviceJoinName: "Honeywell Z-Wave In-Wall Smart Switch"
+		fingerprint mfr:"0039", prod:"4952", model:"3037", deviceJoinName: "Honeywell Z-Wave In-Wall Smart Toggle Switch"
+		fingerprint mfr:"0039", prod:"4952", model:"3133", deviceJoinName: "Honeywell Z-Wave In-Wall Tamper Resistant Duplex Receptacle"
 	}
 
 	// simulator metadata

--- a/devicetypes/smartthings/zwave-switch.src/zwave-switch.groovy
+++ b/devicetypes/smartthings/zwave-switch.src/zwave-switch.groovy
@@ -25,12 +25,6 @@ metadata {
 		fingerprint mfr:"0063", prod:"5257", deviceJoinName: "GE Wall Switch"
 		fingerprint mfr:"0063", prod:"5052", deviceJoinName: "GE Plug-In Switch"
 		fingerprint mfr:"0113", prod:"5257", deviceJoinName: "Z-Wave Wall Switch"
-		fingerprint mfr:"0039", prod:"5052", model:"3038", deviceJoinName: "Honeywell Z-Wave Plug-in Switch"
-		fingerprint mfr:"0039", prod:"5052", model:"3033", deviceJoinName: "Honeywell Z-Wave Plug-in Switch (Dual Outlet)"
-		fingerprint mfr:"0039", prod:"4F50", model:"3032", deviceJoinName: "Honeywell Z-Wave Plug-in Outdoor Smart Switch"
-		fingerprint mfr:"0039", prod:"4952", model:"3036", deviceJoinName: "Honeywell Z-Wave In-Wall Smart Switch"
-		fingerprint mfr:"0039", prod:"4952", model:"3037", deviceJoinName: "Honeywell Z-Wave In-Wall Smart Toggle Switch"
-		fingerprint mfr:"0039", prod:"4952", model:"3133", deviceJoinName: "Honeywell Z-Wave In-Wall Tamper Resistant Duplex Receptacle"
 	}
 
 	// simulator metadata


### PR DESCRIPTION
…65 WWST-160 WWST-167

Honeywell binary switches were put in the wrong DTH. Should go in the generic one instead of the one meant for GE devices.