### PR TITLE
Fix for handler sending incorrect basic set values

### DIFF
--- a/devicetypes/smartthings/secure-dimmer.src/secure-dimmer.groovy
+++ b/devicetypes/smartthings/secure-dimmer.src/secure-dimmer.groovy
@@ -144,15 +144,19 @@ def off() {
 }
 
 def setLevel(value) {
+	def valueaux = value as Integer
+	def level = Math.max(Math.min(valueaux, 99), 0)
 	secureSequence([
-		zwave.basicV1.basicSet(value: value),
+		zwave.basicV1.basicSet(value: level),
 		zwave.switchMultilevelV1.switchMultilevelGet()
 	])
 }
 
 def setLevel(value, duration) {
+	def valueaux = value as Integer
+	def level = Math.max(Math.min(valueaux, 99), 0)
 	def dimmingDuration = duration < 128 ? duration : 128 + Math.round(duration / 60)
-	secure(zwave.switchMultilevelV2.switchMultilevelSet(value: value, dimmingDuration: dimmingDuration))
+	secure(zwave.switchMultilevelV2.switchMultilevelSet(value: level, dimmingDuration: dimmingDuration))
 }
 
 def refresh() {


### PR DESCRIPTION
According to Z-Wave documentation Basic Set and MultiLevel set accept values with the range of 0,1..99 (0x01..0x63), & 255. The slider in this handler can be set to 100 and there was no input checking in the setLevel method. This is causing the handler to send an invalid value of 100 to the device and several devices are not responding to the command.

This change is code taken from the SmartThings "Dimmer Switch" device handler. It merely checks the setLevel input value to make sure it is a valid value. If it is less than 0 it sends 0 if it is greater than 99 it sends 99.