### PR TITLE
SmartThings Health Check issues

### DIFF
--- a/devicetypes/erocm123/inovelli-2-channel-smart-plug.src/inovelli-2-channel-smart-plug.groovy
+++ b/devicetypes/erocm123/inovelli-2-channel-smart-plug.src/inovelli-2-channel-smart-plug.groovy
@@ -25,7 +25,7 @@ metadata {
 		capability "Switch"
 		capability "Polling"
 		capability "Refresh"
-		capability "Health Check"
+		//capability "Health Check"
 
 		fingerprint manufacturer: "015D", prod: "0221", model: "251C", deviceJoinName: "Show Home 2-Channel Smart Plug"
 		fingerprint manufacturer: "0312", prod: "0221", model: "251C", deviceJoinName: "Inovelli 2-Channel Smart Plug"


### PR DESCRIPTION
For the last several days, health check has been marking this device as offline, even though it is working correctly. This is causing a lot of confusion with users of the device.