### PR TITLE
GWWST-139 Inaccuracy in color temp due to unit conversion/rounding

### DIFF
--- a/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
@@ -171,7 +171,7 @@ def configure() {
 def setColorTemperature(value) {
     setGenericName(value)
     value = value as Integer
-    def tempInMired = (1000000 / value) as Integer
+    def tempInMired = Math.round(1000000 / value)
     def finalHex = zigbee.swapEndianHex(zigbee.convertToHexString(tempInMired, 4))
 
     zigbee.command(COLOR_CONTROL_CLUSTER, 0x0A, "$finalHex 0000") +

--- a/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
@@ -94,12 +94,6 @@ def parse(String description) {
         if (event.name=="level" && event.value==0) {}
         else {
             if (event.name=="colorTemperature") {
-                // Because of conversion to and from mireds we get some accuracy loss so in order for UI
-                // elements to match commands, we'll just see if they're within a tolerance
-                if (event.value <= state.lastValue * 1.05 && event.value >= state.lastValue * .95) {
-                    event.value = state.lastValue
-                    state.lastValue = null
-                }
                 setGenericName(event.value)
             }
             sendEvent(event)
@@ -179,8 +173,6 @@ def setColorTemperature(value) {
     value = value as Integer
     def tempInMired = Math.round(1000000 / value)
     def finalHex = zigbee.swapEndianHex(zigbee.convertToHexString(tempInMired, 4))
-
-    state.lastLevel = value
 
     zigbee.command(COLOR_CONTROL_CLUSTER, 0x0A, "$finalHex 0000") +
     zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_COLOR_TEMPERATURE)

--- a/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
@@ -94,6 +94,12 @@ def parse(String description) {
         if (event.name=="level" && event.value==0) {}
         else {
             if (event.name=="colorTemperature") {
+                // Because of conversion to and from mireds we get some accuracy loss so in order for UI
+                // elements to match commands, we'll just see if they're within a tolerance
+                if (event.value <= state.lastValue * 1.05 && event.value >= state.lastValue * .95) {
+                    event.value = state.lastValue
+                    state.lastValue = null
+                }
                 setGenericName(event.value)
             }
             sendEvent(event)
@@ -173,6 +179,8 @@ def setColorTemperature(value) {
     value = value as Integer
     def tempInMired = Math.round(1000000 / value)
     def finalHex = zigbee.swapEndianHex(zigbee.convertToHexString(tempInMired, 4))
+
+    state.lastLevel = value
 
     zigbee.command(COLOR_CONTROL_CLUSTER, 0x0A, "$finalHex 0000") +
     zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_COLOR_TEMPERATURE)

--- a/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
@@ -158,7 +158,7 @@ def configure() {
 def setColorTemperature(value) {
     setGenericName(value)
     value = value as Integer
-    def tempInMired = (1000000 / value) as Integer
+    def tempInMired = Math.round(1000000 / value)
     def finalHex = zigbee.swapEndianHex(zigbee.convertToHexString(tempInMired, 4))
 
     List cmds = []

--- a/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
@@ -94,6 +94,12 @@ def parse(String description) {
         if (event.name=="level" && event.value==0) {}
         else {
             if (event.name=="colorTemperature") {
+                // Because of conversion to and from mireds we get some accuracy loss so in order for UI
+                // elements to match commands, we'll just see if they're within a tolerance
+                if (event.value <= state.lastValue * 1.05 && event.value >= state.lastValue * .95) {
+                    event.value = state.lastValue
+                    state.lastValue = null
+                }
                 setGenericName(event.value)
             }
             sendEvent(event)
@@ -169,6 +175,7 @@ def setColorTemperature(value) {
         cmds << zigbee.command(COLOR_CONTROL_CLUSTER, MOVE_TO_COLOR_TEMPERATURE_COMMAND, "$finalHex 0000")
     }
     cmds << zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_COLOR_TEMPERATURE)
+    state.lastLevel = value
     cmds
 }
 

--- a/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
@@ -94,12 +94,6 @@ def parse(String description) {
         if (event.name=="level" && event.value==0) {}
         else {
             if (event.name=="colorTemperature") {
-                // Because of conversion to and from mireds we get some accuracy loss so in order for UI
-                // elements to match commands, we'll just see if they're within a tolerance
-                if (event.value <= state.lastValue * 1.05 && event.value >= state.lastValue * .95) {
-                    event.value = state.lastValue
-                    state.lastValue = null
-                }
                 setGenericName(event.value)
             }
             sendEvent(event)
@@ -175,7 +169,6 @@ def setColorTemperature(value) {
         cmds << zigbee.command(COLOR_CONTROL_CLUSTER, MOVE_TO_COLOR_TEMPERATURE_COMMAND, "$finalHex 0000")
     }
     cmds << zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_COLOR_TEMPERATURE)
-    state.lastLevel = value
     cmds
 }
 

--- a/devicetypes/smartthings/zll-white-color-temperature-bulb-5000k.src/zll-white-color-temperature-bulb-5000k.groovy
+++ b/devicetypes/smartthings/zll-white-color-temperature-bulb-5000k.src/zll-white-color-temperature-bulb-5000k.groovy
@@ -154,7 +154,7 @@ def updated() {
 def setColorTemperature(value) {
     setGenericName(value)
     value = value as Integer
-    def tempInMired = (1000000 / value) as Integer
+    def tempInMired = Math.round(1000000 / value)
     def finalHex = zigbee.swapEndianHex(zigbee.convertToHexString(tempInMired, 4))
 
     zigbee.command(COLOR_CONTROL_CLUSTER, MOVE_TO_COLOR_TEMPERATURE_COMMAND, "$finalHex 0000") +

--- a/devicetypes/smartthings/zll-white-color-temperature-bulb-5000k.src/zll-white-color-temperature-bulb-5000k.groovy
+++ b/devicetypes/smartthings/zll-white-color-temperature-bulb-5000k.src/zll-white-color-temperature-bulb-5000k.groovy
@@ -78,6 +78,13 @@ def parse(String description) {
     if (event) {
         if (event.name == "colorTemperature") {
             event.unit = "K"
+            // Because of conversion to and from mireds we get some accuracy loss so in order for UI
+            // elements to match commands, we'll just see if they're within a tolerance
+            if (event.value <= state.lastValue * 1.05 && event.value >= state.lastValue * .95) {
+                event.value = state.lastValue
+                state.lastValue = null
+            }
+            setGenericName(event.value)
         }
         sendEvent(event)
     }
@@ -156,6 +163,8 @@ def setColorTemperature(value) {
     value = value as Integer
     def tempInMired = Math.round(1000000 / value)
     def finalHex = zigbee.swapEndianHex(zigbee.convertToHexString(tempInMired, 4))
+
+    state.lastLevel = value
 
     zigbee.command(COLOR_CONTROL_CLUSTER, MOVE_TO_COLOR_TEMPERATURE_COMMAND, "$finalHex 0000") +
     zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_COLOR_TEMPERATURE)

--- a/devicetypes/smartthings/zll-white-color-temperature-bulb-5000k.src/zll-white-color-temperature-bulb-5000k.groovy
+++ b/devicetypes/smartthings/zll-white-color-temperature-bulb-5000k.src/zll-white-color-temperature-bulb-5000k.groovy
@@ -78,13 +78,6 @@ def parse(String description) {
     if (event) {
         if (event.name == "colorTemperature") {
             event.unit = "K"
-            // Because of conversion to and from mireds we get some accuracy loss so in order for UI
-            // elements to match commands, we'll just see if they're within a tolerance
-            if (event.value <= state.lastValue * 1.05 && event.value >= state.lastValue * .95) {
-                event.value = state.lastValue
-                state.lastValue = null
-            }
-            setGenericName(event.value)
         }
         sendEvent(event)
     }
@@ -163,8 +156,6 @@ def setColorTemperature(value) {
     value = value as Integer
     def tempInMired = Math.round(1000000 / value)
     def finalHex = zigbee.swapEndianHex(zigbee.convertToHexString(tempInMired, 4))
-
-    state.lastLevel = value
 
     zigbee.command(COLOR_CONTROL_CLUSTER, MOVE_TO_COLOR_TEMPERATURE_COMMAND, "$finalHex 0000") +
     zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_COLOR_TEMPERATURE)

--- a/devicetypes/smartthings/zll-white-color-temperature-bulb.src/zll-white-color-temperature-bulb.groovy
+++ b/devicetypes/smartthings/zll-white-color-temperature-bulb.src/zll-white-color-temperature-bulb.groovy
@@ -150,7 +150,7 @@ def updated() {
 def setColorTemperature(value) {
     setGenericName(value)
     value = value as Integer
-    def tempInMired = (1000000 / value) as Integer
+    def tempInMired = Math.round(1000000 / value)
     def finalHex = zigbee.swapEndianHex(zigbee.convertToHexString(tempInMired, 4))
 
     zigbee.command(COLOR_CONTROL_CLUSTER, MOVE_TO_COLOR_TEMPERATURE_COMMAND, "$finalHex 0000") +

--- a/devicetypes/smartthings/zll-white-color-temperature-bulb.src/zll-white-color-temperature-bulb.groovy
+++ b/devicetypes/smartthings/zll-white-color-temperature-bulb.src/zll-white-color-temperature-bulb.groovy
@@ -79,15 +79,6 @@ def parse(String description) {
     log.debug "description is $description"
     def event = zigbee.getEvent(description)
     if (event) {
-        if (event.name=="colorTemperature") {
-            // Because of conversion to and from mireds we get some accuracy loss so in order for UI
-            // elements to match commands, we'll just see if they're within a tolerance
-            if (event.value <= state.lastValue * 1.05 && event.value >= state.lastValue * .95) {
-                event.value = state.lastValue
-                state.lastValue = null
-            }
-            setGenericName(event.value)
-        }
         sendEvent(event)
     }
     else {
@@ -161,8 +152,6 @@ def setColorTemperature(value) {
     value = value as Integer
     def tempInMired = Math.round(1000000 / value)
     def finalHex = zigbee.swapEndianHex(zigbee.convertToHexString(tempInMired, 4))
-
-    state.lastLevel = value
 
     zigbee.command(COLOR_CONTROL_CLUSTER, MOVE_TO_COLOR_TEMPERATURE_COMMAND, "$finalHex 0000") +
     zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_COLOR_TEMPERATURE)


### PR DESCRIPTION
This changes the math to round instead of truncate, which mirrors the operation in appengine-zigbee and should get us slightly more accurate numbers.