### PR TITLE
[CHAD-1746] Remove Simulated devices from running locally

### DIFF
--- a/devicetypes/smartthings/testing/simulated-dimmer-switch.src/simulated-dimmer-switch.groovy
+++ b/devicetypes/smartthings/testing/simulated-dimmer-switch.src/simulated-dimmer-switch.groovy
@@ -14,7 +14,7 @@
  *
  */
 metadata {
-    definition (name: "Simulated Dimmer Switch", namespace: "smartthings/testing", author: "SmartThings", runLocally: true, minHubCoreVersion: '000.020.00008', executeCommandsLocally: true) {
+    definition (name: "Simulated Dimmer Switch", namespace: "smartthings/testing", author: "SmartThings", runLocally: false) {
         capability "Actuator"
         capability "Sensor"
 

--- a/devicetypes/smartthings/testing/simulated-switch.src/simulated-switch.groovy
+++ b/devicetypes/smartthings/testing/simulated-switch.src/simulated-switch.groovy
@@ -13,7 +13,7 @@
  */
 metadata {
 
-    definition (name: "Simulated Switch", namespace: "smartthings/testing", author: "bob", runLocally: true, minHubCoreVersion: '000.020.00008', executeCommandsLocally: true) {
+    definition (name: "Simulated Switch", namespace: "smartthings/testing", author: "bob", runLocally: false) {
         capability "Switch"
         capability "Relay Switch"
         capability "Sensor"


### PR DESCRIPTION
As a part of the customer beta we ran into a number of different issues
with regards to simulated switches running locally.  We have decided to
remove them from running locally in 20.X and target 21.X which may use
this, or a different DTH after discussing options.

@tpmanley @gausnes @workingmonk 