### PR TITLE
PROB-1941 Smart Care apps missing Save button on iOS

### DIFF
--- a/smartapps/smartthings/smart-care-daily-routine.src/smart-care-daily-routine.groovy
+++ b/smartapps/smartthings/smart-care-daily-routine.src/smart-care-daily-routine.groovy
@@ -31,7 +31,7 @@ definition(
 )
 
 preferences {
-	page(name: "configuration", title:"", content: "disclaimerPage", uninstall: true)
+	page(name: "configuration", title:"", content: "disclaimerPage", install: true, uninstall: true)
 }
 
 def disclaimerPage() {
@@ -60,11 +60,11 @@ def disclaimerPage() {
 			"or use of content on the app. SMARTTHINGS INC., ITS OFFICERS, " +
 			"EMPLOYEES AND AGENTS DO NOT ACCEPT LIABILITY HOWEVER ARISING, INCLUDING LIABILITY FOR NEGLIGENCE, " +
 			"FOR ANY LOSS RESULTING FROM THE USE OF OR RELIANCE UPON THE INFORMATION AND/OR SERVICES AT ANY TIME."
-	
+
 	if (disclaimerResponse && disclaimerResponse == "I agree to these terms") {
 		configurationPage()
 	} else {
-		dynamicPage(name: "configuration", nextPage:null, uninstall: true) {
+		dynamicPage(name: "configuration") {
 			section(disclaimerText){
 				input "disclaimerResponse", "enum", title: "Accept terms", required: true,
 						options: ["I agree to these terms", "I do not agree to these terms"],
@@ -75,7 +75,7 @@ def disclaimerPage() {
 }
 
 def configurationPage(){
-	dynamicPage(name: "configuration", install: true, uninstall:true, nextPage: "configuration") {
+	dynamicPage(name: "configuration") {
 		section("Who are you checking on?") {
 			input "person1", "text", title: "Name?"
 		}

--- a/smartapps/smartthings/smart-care-detect-motion.src/smart-care-detect-motion.groovy
+++ b/smartapps/smartthings/smart-care-detect-motion.src/smart-care-detect-motion.groovy
@@ -4,17 +4,17 @@
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  *  in compliance with the License. You may obtain a copy of the License at:
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
  *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  *  for the specific language governing permissions and limitations under the License.
  *
- *  Elder Care: Slip & Fall
+ *  Smart Care - Detect Motion
  *
  *  Author: SmartThings
  *  Date: 2013-04-07
- * 
+ *
  */
 
 definition(
@@ -28,7 +28,7 @@ definition(
 	pausable: true
 )
 preferences {
-	page(name: "configuration", title:"", content: "disclaimerPage", uninstall: true)
+	page(name: "configuration", title:"", content: "disclaimerPage", install: true, uninstall: true)
 }
 
 def disclaimerPage() {
@@ -57,11 +57,11 @@ def disclaimerPage() {
 			"or use of content on the app. SMARTTHINGS INC., ITS OFFICERS, " +
 			"EMPLOYEES AND AGENTS DO NOT ACCEPT LIABILITY HOWEVER ARISING, INCLUDING LIABILITY FOR NEGLIGENCE, " +
 			"FOR ANY LOSS RESULTING FROM THE USE OF OR RELIANCE UPON THE INFORMATION AND/OR SERVICES AT ANY TIME."
-	
+
 	if (disclaimerResponse && disclaimerResponse == "I agree to these terms") {
 		configurationPage()
 	} else {
-		dynamicPage(name: "configuration", nextPage:null, uninstall:false) {
+		dynamicPage(name: "configuration") {
 			section(disclaimerText){
 				input "disclaimerResponse", "enum", title: "Accept terms", required: true,
 						options: ["I agree to these terms", "I do not agree to these terms"],
@@ -72,7 +72,7 @@ def disclaimerPage() {
 }
 
 def configurationPage(){
-	dynamicPage(name: "configuration", install: true, uninstall:true, nextPage: "configuration") {
+	dynamicPage(name: "configuration") {
 		section("Bedroom motion detector(s)") {
 			input "bedroomMotion", "capability.motionSensor", multiple: true
 		}
@@ -95,7 +95,7 @@ def configurationPage(){
 			}
 		}
 	}
-} 
+}
 
 def installed() {
 	log.debug "Installed with settings: ${settings}"


### PR DESCRIPTION
The definition for the page in the preferences section did not specify
'install: true', instead this was specified in the declaration for the
dynamicPage. However, it seems changing the definition in the
dynamic page declaration doesn't matter as in iOS it always uses
the first declaration found.

Fixing this issue by adding 'install: true' to the preference declaration
and removing the page definition from dynamicPage.