### PR TITLE
ICP-3135 Wrong icon type for smart plug in SC

### DIFF
--- a/devicetypes/smartthings/zwave-metering-switch-secure.src/zwave-metering-switch-secure.groovy
+++ b/devicetypes/smartthings/zwave-metering-switch-secure.src/zwave-metering-switch-secure.groovy
@@ -12,7 +12,7 @@
  *
  */
 metadata {
-	definition (name: "Z-Wave Metering Switch Secure", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.switch") {
+	definition (name: "Z-Wave Metering Switch Secure", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.smartplug") {
 		capability "Actuator"
 		capability "Configuration"
 		capability "Energy Meter"


### PR DESCRIPTION
the switch device type gets a switch icon, but this is a plug so it needs the plug icon