### PR TITLE
Report correct status when locked via keypad

### DIFF
--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -406,6 +406,7 @@ private def handleAccessAlarmReport(cmd) {
 			} else {
 				// locked by pressing the Schlage button
 				map.descriptionText = "Locked manually"
+				map.data = [ method: "keypad" ]
 			}
 			break
 		case 6: // Unlocked with keypad


### PR DESCRIPTION
Schlage and Yale, with One Touch locking enabled are locked manually from the keypad, report the status correct to differentiate manual locking and keypad locking