### PR TITLE
ICP-3154 Locks not responsive in Poland

### DIFF
--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -138,7 +138,7 @@ def updated() {
 			if (!state.fw) {
 				cmds << zwave.versionV1.versionGet().format()
 			}
-			hubAction = response(delayBetween(cmds, 4200))
+			hubAction = response(delayBetween(cmds, 30*1000))
 		}
 	} catch (e) {
 		log.warn "updated() threw $e"


### PR DESCRIPTION
Similar to the battery change a month ago, command backups were causing commands to be sent to quickly to Yale locks, causing them to get wedged.