### PR TITLE
ICP-3834 Update Flags for legacy locally-executing devices

### DIFF
--- a/devicetypes/smartthings/zwave-relay.src/zwave-relay.groovy
+++ b/devicetypes/smartthings/zwave-relay.src/zwave-relay.groovy
@@ -13,7 +13,7 @@
  */
 metadata {
 
-	definition (name: "Z-Wave Relay", namespace: "smartthings", author: "SmartThings", runLocally: true, minHubCoreVersion: '000.017.0012' {
+	definition (name: "Z-Wave Relay", namespace: "smartthings", author: "SmartThings", runLocally: true, minHubCoreVersion: '000.017.0012') {
 		capability "Actuator"
 		capability "Switch"
 		capability "Polling"


### PR DESCRIPTION
missing paren