### PR TITLE
ICP-3812 Update Door Knocker to prepare for Pabal support

### DIFF
--- a/smartapps/imbrianj/door-knocker.src/door-knocker.groovy
+++ b/smartapps/imbrianj/door-knocker.src/door-knocker.groovy
@@ -73,9 +73,9 @@ def doorClosed(evt) {
 def doorKnock() {
   if((openSensor.latestValue("contact") == "closed") &&
     (now() - (60 * 1000) > state.lastClosed)) {
-	def kSensor = knockSensor.label ?: knockSensor.name
+    def kSensor = knockSensor.label ?: knockSensor.name
     log.debug("${kSensor} detected a knock.")
-    send(localization.translate("{{kSensor}} detected a knock.", [kSensor: kSensor]))
+    send(kSensor)
   }
 
   else {
@@ -88,16 +88,35 @@ def handleEvent(evt) {
   runIn(delay, "doorKnock")
 }
 
-private send(msg) {
-  if(sendPushMessage != "No") {
-    log.debug("Sending push message")
-    sendPush(msg)
-  }
+private send(kSensor) {
+  // Pabal translation code and params
+  String code = 'SmartApps_DoorKnocker_V_0001'
+  List params = [
+    [
+      'name': 'knockSensor.label',
+      'value': kSensor
+    ]
+  ]
 
-  if(phone) {
-    log.debug("Sending text message")
-    sendSms(phone, msg)
-  }
+  // Legacy push/SMS message and args
+  String msg = "{{kSensor}} detected a knock."
+  Map msgArgs = [kSensor: kSensor]
 
-  log.debug(msg)
+  Map options = [
+    code: code,
+    params: params,
+    messageArgs: msgArgs,
+    translatable: true
+  ]
+
+  Boolean pushNotification = (sendPushMessage != "No")
+
+  if (pushNotification || phone) {
+    log.debug "Sending Notification"
+    options += [
+      method: (pushNotification && phone) ? "both" : (pushNotification ? "push" : "sms"),
+      phone: phone
+    ]
+    sendNotification(msg, options)
+  }
 }


### PR DESCRIPTION
With this setup Door Knocker will send the "{{kSensor}} detected a knock." notification through Pabal on accounts in which the service is enabled. Once we have a valid code and param name for the Door Knocker notification string we can swap those in and the app will begin sending with Pabal translations immediately with no extra changes necessary.

Pabal ignores invalid codes and defaults back to the plain Message so this SmartApp will work perfectly fine as is. If we'd rather wait for the code before merging then I can update this PR to swap the code in as soon as we have it.

/cc @bflorian 