### PR TITLE
DVCSMP-3277 Set Aeon Minimote Child buttons hub

### DIFF
--- a/devicetypes/smartthings/aeon-minimote.src/aeon-minimote.groovy
+++ b/devicetypes/smartthings/aeon-minimote.src/aeon-minimote.groovy
@@ -148,7 +148,7 @@ def initialize() {
 private void createChildDevices() {
 	state.oldLabel = device.label
 	for (i in 1..4) {
-		addChildDevice("Child Button", "${device.deviceNetworkId}/${i}", null,
+		addChildDevice("Child Button", "${device.deviceNetworkId}/${i}", device.hubId,
 				[completedSetup: true, label: "${device.displayName} button ${i}",
 				 isComponent: true, componentName: "button$i", componentLabel: "Button $i"])
 	}


### PR DESCRIPTION
Previously these child devices were not associated with a hub.  As a
result the information about the child devices weren't synced locally.
This prevented us from being able to generate events for those child
devices.

This is a part of: https://smartthings.atlassian.net/browse/DVCSMP-3277