### PR TITLE
Add more features to the virtual device creator

### DIFF
--- a/smartapps/smartthings/virtual-device-creator.src/virtual-device-creator.groovy
+++ b/smartapps/smartthings/virtual-device-creator.src/virtual-device-creator.groovy
@@ -1,5 +1,5 @@
 /**
- *  Virtual Device Manager
+ *  Virtual Device Creator
  *
  *  Copyright 2015 Bob Florian/SmartThings
  *
@@ -15,15 +15,15 @@
  */
 
 definition(
-    name: "Virtual Device Creator",
-    namespace: "smartthings",
-    author: "SmartThings",
-    description: "Creates virtual devices",
-    iconUrl: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience.png",
-    iconX2Url: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience@2x.png",
-    iconX3Url: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience@2x.png",
-    singleInstance: true,
-    pausable: false
+        name: "Virtual Device Creator",
+        namespace: "smartthings",
+        author: "SmartThings",
+        description: "Creates virtual devices",
+        iconUrl: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience.png",
+        iconX2Url: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience@2x.png",
+        iconX3Url: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience@2x.png",
+        singleInstance: true,
+        pausable: false
 )
 
 
@@ -33,18 +33,33 @@ preferences {
 
 def mainPage() {
     dynamicPage(name: "mainPage") {
-        section {
-            paragraph "You have created ${state.nextDni? state.nextDni - 1 : 0} virtual devices through this app"
+        section ("New Device") {
             input "virtualDeviceType", "enum", title: "Which type of virtual device do you want to create?", multiple: false, required: true, options: ["Virtual Switch", "Virtual Dimmer Switch"]
             input "theHub", "hub", title: "Select the hub (required for local execution) (Optional)", multiple: false, required: false
         }
-        remove("Remove All Virtual Devices", "This will remove all virtual devices created through this app.")
+        section("Device Name") {
+            input "deviceName", title: "Enter device name", defaultValue: defaultLabel(), required: true
+        }
+        section("Devices Created") {
+            paragraph "${getAllChildDevices().inject("") {result, i -> result + (i.label + "\n")} ?: ""}"
+        }
+        remove("Remove (Includes Devices)", "This will remove all virtual devices created through this app.")
     }
+}
+
+def defaultLabel() {
+    "Virtual Device ${state.nextDni ?: 1}"
 }
 
 def installed() {
     log.debug "Installed with settings: ${settings}"
     state.nextDni = 1
+}
+
+def uninstalled() {
+    getAllChildDevices().each {
+        deleteChildDevice(it.deviceNetworkId, true)
+    }
 }
 
 def updated() {
@@ -55,7 +70,7 @@ def updated() {
 def initialize() {
     def latestDni = state.nextDni
     if (virtualDeviceType) {
-        def d = addChildDevice("smartthings", virtualDeviceType, "virtual-$latestDni", theHub?.id, [completedSetup: true, label: "$virtualDeviceType $latestDni"])
+        def d = addChildDevice("smartthings", virtualDeviceType, "virtual-$latestDni", theHub?.id, [completedSetup: true, label: deviceName])
         latestDni++
         state.nextDni = latestDni
     } else {


### PR DESCRIPTION
This adds the ability to name the device being created, and also adds a
list of the devices created with the app.

I have this pointed at production because that is where the changes to this are current.  After next weeks roll down to staging, we can point this at staging with the aim to get it out the week after that.  I don't think there is any hurry to get this out, and we may get some beta feedback between now, and the week after next that we want to incorporate.