### PR TITLE
Update fibaro-rgbw-controller.groovy

### DIFF
--- a/devicetypes/smartthings/fibaro-rgbw-controller.src/fibaro-rgbw-controller.groovy
+++ b/devicetypes/smartthings/fibaro-rgbw-controller.src/fibaro-rgbw-controller.groovy
@@ -730,7 +730,7 @@ def hueToRgb(v1, v2, vh) {
 	if (vh > 1) { vh -= 1 }
 	if ((6 * vh) < 1) { return (v1 + (v2 - v1) * 6 * vh) }
     if ((2 * vh) < 1) { return (v2) }
-    if ((3 * vh) < 2) { return (v1 + (v2 - $v1) * ((2 / 3 - vh) * 6)) }
+    if ((3 * vh) < 2) { return (v1 + (v2 - v1) * ((2 / 3 - vh) * 6)) }
     return (v1)
 }
 


### PR DESCRIPTION
There is a error in the hueToRgb function.  See https://community.smartthings.com/t/device-handler-for-nodemcu-using-mqtt/121076/43 for more information.   The removal of the $ seems to fix it.