### PR TITLE
ICP-4326 Add Health Check to Z-Wave Relay

### DIFF
--- a/devicetypes/smartthings/zwave-relay.src/zwave-relay.groovy
+++ b/devicetypes/smartthings/zwave-relay.src/zwave-relay.groovy
@@ -19,6 +19,7 @@ metadata {
 		capability "Polling"
 		capability "Refresh"
 		capability "Sensor"
+		capability "Health Check"
 		capability "Relay Switch"
 
 		fingerprint deviceId: "0x1001", inClusters: "0x20,0x25,0x27,0x72,0x86,0x70,0x85"
@@ -53,6 +54,7 @@ metadata {
 }
 
 def installed() {
+	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
 	zwave.manufacturerSpecificV1.manufacturerSpecificGet().format()
 }
 
@@ -137,6 +139,10 @@ def off() {
 		zwave.basicV1.basicSet(value: 0x00).format(),
 		zwave.switchBinaryV1.switchBinaryGet().format()
 	])
+}
+
+def ping() {
+	poll()
 }
 
 def poll() {


### PR DESCRIPTION
Doesn't seem to be any particular reason not to have this, other than the age of the DTH