### PR TITLE
DVCSMP-3572 Z-Wave Multilevel devices cannot express 100%

### DIFF
--- a/devicetypes/smartthings/aeon-illuminator-module.src/aeon-illuminator-module.groovy
+++ b/devicetypes/smartthings/aeon-illuminator-module.src/aeon-illuminator-module.groovy
@@ -120,7 +120,7 @@ def doCreateEvent(physicalgraph.zwave.Command cmd, Map item1) {
 	if (cmd.value > 15) {
 		def item2 = new LinkedHashMap(item1)
 		item2.name = "level"
-		item2.value = cmd.value as String
+		item2.value = (cmd.value == 99 ? 100 : cmd.value) as String
 		item2.unit = "%"
 		item2.descriptionText = "${item1.linkText} dimmed ${item2.value} %"
 		item2.canBeCurrentState = true

--- a/devicetypes/smartthings/aeon-illuminator-module.src/aeon-illuminator-module.groovy
+++ b/devicetypes/smartthings/aeon-illuminator-module.src/aeon-illuminator-module.groovy
@@ -51,7 +51,7 @@ metadata {
 			state "turningOn", label:'${name}', icon:"st.switches.switch.on", backgroundColor:"#00A0DC"
 			state "turningOff", label:'${name}', icon:"st.switches.switch.off", backgroundColor:"#ffffff"
 		}
-		controlTile("levelSliderControl", "device.level", "slider", height: 2, width: 1, inactiveLabel: false) {
+		controlTile("levelSliderControl", "device.level", "slider", height: 2, width: 1, inactiveLabel: false, range:"(0..100)") {
 			state "level", action:"switch level.setLevel"
 		}
 		valueTile("energy", "device.energy", decoration: "flat") {

--- a/devicetypes/smartthings/aeon-led-bulb.src/aeon-led-bulb.groovy
+++ b/devicetypes/smartthings/aeon-led-bulb.src/aeon-led-bulb.groovy
@@ -104,7 +104,7 @@ private dimmerEvents(physicalgraph.zwave.Command cmd) {
 	def value = (cmd.value ? "on" : "off")
 	def result = [createEvent(name: "switch", value: value, descriptionText: "$device.displayName was turned $value")]
 	if (cmd.value) {
-		result << createEvent(name: "level", value: cmd.value, unit: "%")
+		result << createEvent(name: "level", value: cmd.value == 99 ? 100 : cmd.value , unit: "%")
 	}
 	return result
 }

--- a/devicetypes/smartthings/dimmer-switch.src/dimmer-switch.groovy
+++ b/devicetypes/smartthings/dimmer-switch.src/dimmer-switch.groovy
@@ -155,7 +155,7 @@ private dimmerEvents(physicalgraph.zwave.Command cmd) {
 	def value = (cmd.value ? "on" : "off")
 	def result = [createEvent(name: "switch", value: value)]
 	if (cmd.value && cmd.value <= 100) {
-		result << createEvent(name: "level", value: cmd.value, unit: "%")
+		result << createEvent(name: "level", value: cmd.value == 99 ? 100 : cmd.value , unit: "%")
 	}
 	return result
 }

--- a/devicetypes/smartthings/econet-vent.src/econet-vent.groovy
+++ b/devicetypes/smartthings/econet-vent.src/econet-vent.groovy
@@ -61,7 +61,7 @@ metadata {
         valueTile("battery", "device.battery", inactiveLabel: false, decoration: "flat") {
 			state "battery", label:'${currentValue}% battery', unit:""
 		}
-		controlTile("levelSliderControl", "device.level", "slider", height: 1, width: 3, inactiveLabel: false) {
+		controlTile("levelSliderControl", "device.level", "slider", height: 1, width: 3, inactiveLabel: false, range:"(0..100)") {
 			state "level", action:"switch level.setLevel"
 		}
 		standardTile("refresh", "device.switch", inactiveLabel: false, decoration: "flat") {

--- a/devicetypes/smartthings/econet-vent.src/econet-vent.groovy
+++ b/devicetypes/smartthings/econet-vent.src/econet-vent.groovy
@@ -123,7 +123,7 @@ def zwaveEvent(physicalgraph.zwave.commands.switchmultilevelv3.SwitchMultilevelR
 def dimmerEvents(physicalgraph.zwave.Command cmd) {
 	def text = "$device.displayName is ${cmd.value ? "open" : "closed"}"
 	def switchEvent = createEvent(name: "switch", value: (cmd.value ? "on" : "off"), descriptionText: text)
-	def levelEvent = createEvent(name:"level", value: cmd.value, unit:"%")
+	def levelEvent = createEvent(name:"level", value: cmd.value == 99 ? 100 : cmd.value , unit:"%")
 	[switchEvent, levelEvent]
 }
 

--- a/devicetypes/smartthings/fibaro-dimmer.src/fibaro-dimmer.groovy
+++ b/devicetypes/smartthings/fibaro-dimmer.src/fibaro-dimmer.groovy
@@ -157,7 +157,7 @@ def doCreateEvent(physicalgraph.zwave.Command cmd, Map item1) {
 	if (cmd.value >= 5) {
 		def item2 = new LinkedHashMap(item1)
 		item2.name = "level"
-		item2.value = cmd.value as String
+		item2.value = (cmd.value == 99 ? 100 : cmd.value) as String
 		item2.unit = "%"
 		item2.descriptionText = "${item1.linkText} dimmed ${item2.value} %"
 		item2.canBeCurrentState = true

--- a/devicetypes/smartthings/fibaro-dimmer.src/fibaro-dimmer.groovy
+++ b/devicetypes/smartthings/fibaro-dimmer.src/fibaro-dimmer.groovy
@@ -64,7 +64,7 @@ metadata {
 		standardTile("refresh", "device.switch", inactiveLabel: false, decoration: "flat") {
 			state "default", label:"", action:"refresh.refresh", icon:"st.secondary.refresh"
 		}
-		controlTile("levelSliderControl", "device.level", "slider", height: 1, width: 3, inactiveLabel: false) {
+		controlTile("levelSliderControl", "device.level", "slider", height: 1, width: 3, inactiveLabel: false, range:"(0..100)") {
 			state "level", action:"switch level.setLevel"
 		}
 

--- a/devicetypes/smartthings/fibaro-rgbw-controller.src/fibaro-rgbw-controller.groovy
+++ b/devicetypes/smartthings/fibaro-rgbw-controller.src/fibaro-rgbw-controller.groovy
@@ -82,7 +82,7 @@
 		controlTile("rgbSelector", "device.color", "color", height: 3, width: 3, inactiveLabel: false) {
             state "color", action:"setAdjustedColor"
 		}
-		controlTile("levelSliderControl", "device.level", "slider", height: 1, width: 2, inactiveLabel: false) {
+		controlTile("levelSliderControl", "device.level", "slider", height: 1, width: 2, inactiveLabel: false, range:"(0..100)") {
 			state "level", action:"switch level.setLevel"
 		}
 		controlTile("whiteSliderControl", "device.whiteLevel", "slider", height: 1, width: 3, inactiveLabel: false) {

--- a/devicetypes/smartthings/fibaro-rgbw-controller.src/fibaro-rgbw-controller.groovy
+++ b/devicetypes/smartthings/fibaro-rgbw-controller.src/fibaro-rgbw-controller.groovy
@@ -532,7 +532,7 @@ def doCreateEvent(physicalgraph.zwave.Command cmd, Map item1) {
      if (cmd.value >= 5) {
           def item2 = new LinkedHashMap(item1)
           item2.name = "level"
-          item2.value = cmd.value as String
+          item2.value = (cmd.value == 99 ? 100 : cmd.value) as String
           item2.unit = "%"
           item2.descriptionText = "${item1.linkText} dimmed ${item2.value} %"
           item2.canBeCurrentState = true

--- a/devicetypes/smartthings/rgbw-light.src/rgbw-light.groovy
+++ b/devicetypes/smartthings/rgbw-light.src/rgbw-light.groovy
@@ -102,7 +102,7 @@ private dimmerEvents(physicalgraph.zwave.Command cmd) {
 	def value = (cmd.value ? "on" : "off")
 	def result = [createEvent(name: "switch", value: value, descriptionText: "$device.displayName was turned $value")]
 	if (cmd.value) {
-		result << createEvent(name: "level", value: cmd.value, unit: "%")
+		result << createEvent(name: "level", value: cmd.value == 99 ? 100 : cmd.value , unit: "%")
 	}
 	return result
 }

--- a/devicetypes/smartthings/secure-dimmer.src/secure-dimmer.groovy
+++ b/devicetypes/smartthings/secure-dimmer.src/secure-dimmer.groovy
@@ -98,7 +98,7 @@ private dimmerEvents(physicalgraph.zwave.Command cmd) {
 	def value = (cmd.value ? "on" : "off")
 	def result = [createEvent(name: "switch", value: value, descriptionText: "$device.displayName was turned $value")]
 	if (cmd.value) {
-		result << createEvent(name: "level", value: cmd.value, unit: "%")
+		result << createEvent(name: "level", value: cmd.value == 99 ? 100 : cmd.value , unit: "%")
 	}
 	return result
 }

--- a/devicetypes/smartthings/secure-dimmer.src/secure-dimmer.groovy
+++ b/devicetypes/smartthings/secure-dimmer.src/secure-dimmer.groovy
@@ -47,7 +47,7 @@ metadata {
 			state "turningOn", label:'${name}', action:"switch.off", icon:"st.switches.switch.on", backgroundColor:"#00A0DC", nextState:"turningOff"
 			state "turningOff", label:'${name}', action:"switch.on", icon:"st.switches.switch.off", backgroundColor:"#ffffff", nextState:"turningOn"
 		}
-		controlTile("levelSliderControl", "device.level", "slider", height: 1, width: 3, inactiveLabel: false) {
+		controlTile("levelSliderControl", "device.level", "slider", height: 1, width: 3, inactiveLabel: false, range:"(0..100)") {
 			state "level", action:"switch level.setLevel"
 		}
 		standardTile("refresh", "device.switch", inactiveLabel: false, decoration: "flat") {

--- a/devicetypes/smartthings/zwave-dimmer-switch-generic.src/zwave-dimmer-switch-generic.groovy
+++ b/devicetypes/smartthings/zwave-dimmer-switch-generic.src/zwave-dimmer-switch-generic.groovy
@@ -151,7 +151,7 @@ private dimmerEvents(physicalgraph.zwave.Command cmd) {
 	def value = (cmd.value ? "on" : "off")
 	def result = [createEvent(name: "switch", value: value)]
 	if (cmd.value && cmd.value <= 100) {
-		result << createEvent(name: "level", value: cmd.value, unit: "%")
+		result << createEvent(name: "level", value: cmd.value == 99 ? 100 : cmd.value , unit: "%")
 	}
 	return result
 }

--- a/devicetypes/smartthings/zwave-metering-dimmer.src/zwave-metering-dimmer.groovy
+++ b/devicetypes/smartthings/zwave-metering-dimmer.src/zwave-metering-dimmer.groovy
@@ -158,7 +158,7 @@ def dimmerEvents(physicalgraph.zwave.Command cmd) {
 	def switchEvent = createEvent(name: "switch", value: value, descriptionText: "$device.displayName was turned $value")
 	result << switchEvent
 	if (cmd.value) {
-		result << createEvent(name: "level", value: cmd.value, unit: "%")
+		result << createEvent(name: "level", value: cmd.value == 99 ? 100 : cmd.value , unit: "%")
 	}
 	if (switchEvent.isStateChange) {
 		result << response(["delay 3000", zwave.meterV2.meterGet(scale: 2).format()])


### PR DESCRIPTION
This just parses a value of 99 as 100. Because of how the Z-Wave spec is written 99=100%, 1<1%, but we were treating it as 1-to-1. This is the least painful fix. Exact mapping would with rounding would mean setting any value over 50 would map to that level + 1. Here that only happens at 99.

This will need to be accompanied by a hubcore fix for LE devices.