### PR TITLE
[DEVC-596] Add implementation for Bosh Radion ZigBee Multisensor RFMS-ZBMS-3 to generic ZigBee open close sensor DTH.

### DIFF
--- a/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
@@ -27,12 +27,12 @@ metadata {
 
 		command "enrollResponse"
 
-
 		fingerprint inClusters: "0000,0001,0003,0402,0500,0020,0B05", outClusters: "0019", manufacturer: "CentraLite", model: "3300-S"
 		fingerprint inClusters: "0000,0001,0003,0402,0500,0020,0B05", outClusters: "0019", manufacturer: "CentraLite", model: "3300"
 		fingerprint inClusters: "0000,0001,0003,0020,0402,0500,0B05", outClusters: "0019", manufacturer: "CentraLite", model: "3320-L", deviceJoinName: "Iris Contact Sensor"
 		fingerprint inClusters: "0000,0001,0003,0020,0402,0500,0B05", outClusters: "0019", manufacturer: "CentraLite", model: "3323-G", deviceJoinName: "Centralite Micro Door Sensor"
 		fingerprint inClusters: "0000,0001,0003,0402,0500,0020,0B05", outClusters: "0019", manufacturer: "Visonic", model: "MCT-340 E", deviceJoinName: "Visonic Door/Window Sensor"
+		fingerprint inClusters: "0000,0001,0003,0402,0500,0020,0B05", outClusters: "0019", manufacturer: "Bosch", model: "RFMS-ZBMS", deviceJoinName: "Bosch multi-sensor"
 	}
 
 	simulator {
@@ -97,6 +97,14 @@ def parse(String description) {
 					sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
 				} else {
 					log.warn "TEMP REPORTING CONFIG FAILED- error code: ${descMap.data[0]}"
+				}
+			} else if (descMap?.clusterInt == 0x0500 && descMap.attrInt == 0x0001 && device.getDataValue("model") == "RFMS-ZBMS") {
+				if (Integer.parseInt(descMap.value, 16) == 0x0015) {
+					//multi-sensor is in contact or tilt detector mode - both act as contact sensor so no action is necessary
+				} else if (Integer.parseInt(descMap.value, 16) == 0x002A) {
+					//multi-sensor is in water detector mode, DTH should be changed to water sensor DTH
+					log.debug "SmartSense Moisture Sensor"
+					setDeviceType("SmartSense Moisture Sensor")
 				}
 			}
 		}
@@ -182,5 +190,10 @@ def configure() {
 
 	// temperature minReportTime 30 seconds, maxReportTime 5 min. Reporting interval if no activity
 	// battery minReport 30 seconds, maxReportTime 6 hrs by default
-	return refresh() + zigbee.batteryConfig() + zigbee.temperatureConfig(30, 300) // send refresh cmds as part of config
+	def commands = refresh() + zigbee.batteryConfig() + zigbee.temperatureConfig(30, 300)
+	// send refresh cmds as part of config
+	if (device.getDataValue("manufacturer") == "Bosch") {
+		commands += zigbee.readAttribute(zigbee.IAS_ZONE_CLUSTER, 0x0001)
+	}
+	return commands
 }


### PR DESCRIPTION
DTH works correctly for both contact and water detector modes. I tested it with both cloud and local execution.

There are problems with Samsung SmartThings apk for water detector mode only.

Are there any known issues with OneApp not supporting dynamic DTH changes or with SmartSense Moisture Sensor Metadata?