### PR TITLE
ICP-4139 Aeon Multisensor not getting initial state when added on bat…

### DIFF
--- a/devicetypes/smartthings/aeon-multisensor-6.src/aeon-multisensor-6.groovy
+++ b/devicetypes/smartthings/aeon-multisensor-6.src/aeon-multisensor-6.groovy
@@ -445,7 +445,7 @@ private isConfigured() {
 }
 
 private command(physicalgraph.zwave.Command cmd) {
-	if (state.sec) {
+	if (state.sec || (zwaveInfo.zw && !zwaveInfo.zw.contains("s"))) {
 		zwave.securityV1.securityMessageEncapsulation().encapsulate(cmd).format()
 	} else {
 		cmd.format()


### PR DESCRIPTION
…tery

- Removes cruft around old 'powerSupply' implementation that should have been removed
- Updates 'batteryStatus' when power source is updated, since battery is parsed locally now
- Updates 'batteryStatus' whenever we receive a command and the device is on battery power. This should be done locally, but it's a weird hybrid attribute so that seems unlikely.
- Runs configure despite power supply on the initial 'updated()' call, since even sleepy devices will still be awake and we need to get that initial state