### PR TITLE
ICP-4556 Utilitech Siren WWST Gap

### DIFF
--- a/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
+++ b/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
@@ -29,6 +29,7 @@ metadata {
 		fingerprint inClusters: "0x20,0x25,0x86,0x80,0x85,0x72,0x71"
 		fingerprint mfr: "0258", prod: "0003", model: "0088", deviceJoinName: "Neo Coolcam Siren Alarm"
 		fingerprint mfr: "021F", prod: "0003", model: "0088", deviceJoinName: "Dome Siren"
+		fingerprint mfr: "0060", prod: "000C", model: "0001", deviceJoinName: "Utilitech Siren"
 	}
 
 	simulator {
@@ -68,6 +69,7 @@ def installed() {
 def updated() {
 	// Device-Watch simply pings if no device events received for 122min(checkInterval)
 	sendEvent(name: "checkInterval", value: 2 * 60 * 60 + 2 * 60, isStateChanged: true, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
+	refresh()
 }
 
 def createEvents(physicalgraph.zwave.commands.batteryv1.BatteryReport cmd) {


### PR DESCRIPTION
Utilitech Siren needs to have a device join name under the new integration paradigm.

Also Z-Wave sirens need to poll initial state for OneApp.