### PR TITLE
ICP-4586 ICP-4613 GE Direct-Wire Outdoor Switch

### DIFF
--- a/devicetypes/smartthings/zwave-metering-switch.src/zwave-metering-switch.groovy
+++ b/devicetypes/smartthings/zwave-metering-switch.src/zwave-metering-switch.groovy
@@ -31,6 +31,7 @@ metadata {
 		fingerprint mfr: "0086", prod: "0103", model: "0060", deviceJoinName: "Aeotec Smart Switch 6"
 		fingerprint mfr: "014F", prod: "574F", model: "3535", deviceJoinName: "GoControl Wall-Mounted Outlet"
 		fingerprint mfr: "014F", prod: "5053", model: "3531", deviceJoinName: "GoControl Plug-in Switch"
+		fingerprint mfr: "0063", prod: "4F44", model: "3031", deviceJoinName: "GE Direct-Wire Outdoor Switch"
 	}
 
 	// simulator metadata
@@ -87,6 +88,10 @@ def installed() {
 def updated() {
 	// Device-Watch simply pings if no device events received for 32min(checkInterval)
 	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
+	if (zwaveInfo?.mfr?.equals("0063") { // These old GE devices have to be polled
+		unschedule("poll")
+		runEvery15Minutes("poll")
+	}
 	try {
 		if (!state.MSR) {
 			response(zwave.manufacturerSpecificV2.manufacturerSpecificGet().format())
@@ -210,6 +215,10 @@ def off() {
 def ping() {
 	log.debug "ping() called"
 	refresh()
+}
+
+def poll() {
+	sendHubCommand(refresh())
 }
 
 def refresh() {


### PR DESCRIPTION
Adding device-specific fingerprint for an old device.

Also adding polling logic back since the GE device does not automatically report power/energy usage.