### PR TITLE
DVCSMP-2060 Remove displayed: false from battery events

### DIFF
--- a/devicetypes/smartthings/aeon-multisensor.src/aeon-multisensor.groovy
+++ b/devicetypes/smartthings/aeon-multisensor.src/aeon-multisensor.groovy
@@ -155,7 +155,6 @@ def zwaveEvent(physicalgraph.zwave.commands.batteryv1.BatteryReport cmd) {
 	map.name = "battery"
 	map.value = cmd.batteryLevel > 0 ? cmd.batteryLevel.toString() : 1
 	map.unit = "%"
-	map.displayed = false
 	map
 }
 

--- a/devicetypes/smartthings/everspring-flood-sensor.src/everspring-flood-sensor.groovy
+++ b/devicetypes/smartthings/everspring-flood-sensor.src/everspring-flood-sensor.groovy
@@ -127,7 +127,6 @@ def zwaveEvent(physicalgraph.zwave.commands.batteryv1.BatteryReport cmd) {
 		map.name = "battery"
 		map.value = cmd.batteryLevel > 0 ? cmd.batteryLevel.toString() : 1
 		map.unit = "%"
-		map.displayed = false
 	}
 	[createEvent(map), response(zwave.wakeUpV1.wakeUpNoMoreInformation())]
 }

--- a/devicetypes/smartthings/fibaro-flood-sensor.src/fibaro-flood-sensor.groovy
+++ b/devicetypes/smartthings/fibaro-flood-sensor.src/fibaro-flood-sensor.groovy
@@ -40,7 +40,7 @@ metadata {
 		capability "Configuration"
 		capability "Battery"
 		capability "Health Check"
-    		capability "Sensor"
+		capability "Sensor"
     
 		command    "resetParams2StDefaults"
 		command    "listCurrentParams"
@@ -173,7 +173,6 @@ def zwaveEvent(physicalgraph.zwave.commands.batteryv1.BatteryReport cmd) {
 	map.name = "battery"
 	map.value = cmd.batteryLevel > 0 ? cmd.batteryLevel.toString() : 1
 	map.unit = "%"
-	map.displayed = false
 	createEvent(map)
 }
 

--- a/devicetypes/smartthings/fibaro-motion-sensor.src/fibaro-motion-sensor.groovy
+++ b/devicetypes/smartthings/fibaro-motion-sensor.src/fibaro-motion-sensor.groovy
@@ -260,7 +260,6 @@ log.debug cmd
 	map.name = "battery"
 	map.value = cmd.batteryLevel > 0 ? cmd.batteryLevel.toString() : 1
 	map.unit = "%"
-	map.displayed = false
 	map
 }
 

--- a/devicetypes/smartthings/smartsense-moisture.src/smartsense-moisture.groovy
+++ b/devicetypes/smartthings/smartsense-moisture.src/smartsense-moisture.groovy
@@ -126,7 +126,6 @@ def zwaveEvent(physicalgraph.zwave.commands.batteryv1.BatteryReport cmd) {
 		map.name = "battery"
 		map.value = cmd.batteryLevel > 0 ? cmd.batteryLevel.toString() : 1
 		map.unit = "%"
-		map.displayed = false
 	}
 	map
 }


### PR DESCRIPTION
Old Z-Wave DTHs were forcing their battery events not to be displayed. There's not really a good reason to do this anymore.