### PR TITLE
ICP-3873 Add ocfDeviceType to Curb Power Meter

### DIFF
--- a/devicetypes/curb/curb-power-meter.src/curb-power-meter.groovy
+++ b/devicetypes/curb/curb-power-meter.src/curb-power-meter.groovy
@@ -15,7 +15,7 @@
  */
 
 metadata {
-    definition(name: "CURB Power Meter", namespace: "curb", author: "Curb") {
+    definition(name: "CURB Power Meter", namespace: "curb", author: "Curb", ocfDeviceType: "x.com.st.energymeter") {
         capability "Power Meter"
         capability "Energy Meter"
     }


### PR DESCRIPTION
After pairing, Curb devices don't have proper icons. This is a fix for that issue.