### PR TITLE
ONEAPP-3497 Remove extra parenthesis from SmartPower Outlet DTH

### DIFF
--- a/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
+++ b/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
@@ -15,7 +15,7 @@
  */
 metadata {
 	// Automatically generated. Make future change here.
-	definition(name: "SmartPower Outlet", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.smartplug", runLocally: true, minHubCoreVersion: '000.017.0012', executeCommandsLocally: false, mnmn: "SmartThings", vid: "generic-switch-power") ) {
+	definition(name: "SmartPower Outlet", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.smartplug", runLocally: true, minHubCoreVersion: '000.017.0012', executeCommandsLocally: false, mnmn: "SmartThings", vid: "generic-switch-power") {
 		capability "Actuator"
 		capability "Switch"
 		capability "Power Meter"


### PR DESCRIPTION
Remove extra paren accidentally added in https://github.com/SmartThingsCommunity/SmartThingsPublic/pull/3052