### PR TITLE
ICP-4613 Add GE polling setup in installed

### DIFF
--- a/devicetypes/smartthings/zwave-metering-switch.src/zwave-metering-switch.groovy
+++ b/devicetypes/smartthings/zwave-metering-switch.src/zwave-metering-switch.groovy
@@ -84,14 +84,17 @@ metadata {
 def installed() {
 	// Device-Watch simply pings if no device events received for 32min(checkInterval)
 	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
+	if (zwaveInfo?.mfr?.equals("0063")) { // These old GE devices have to be polled
+		runEvery15Minutes("poll", [forceForLocallyExecuting: true])
+	}
 }
 
 def updated() {
 	// Device-Watch simply pings if no device events received for 32min(checkInterval)
 	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 	if (zwaveInfo?.mfr?.equals("0063")) { // These old GE devices have to be polled
-		unschedule("poll")
-		runEvery15Minutes("poll")
+		unschedule("poll", [forceForLocallyExecuting: true])
+		runEvery15Minutes("poll", [forceForLocallyExecuting: true])
 	}
 	try {
 		if (!state.MSR) {


### PR DESCRIPTION
There is a chance that when adding a device updated() isn't called. We can safely set up polling in configure() as well. This will ensure that it is called either way.