### PR TITLE
CHAD-1752 Allow currently supported Zigbee Buttons to run locally

### DIFF
--- a/devicetypes/smartthings/zigbee-button.src/zigbee-button.groovy
+++ b/devicetypes/smartthings/zigbee-button.src/zigbee-button.groovy
@@ -18,7 +18,7 @@ import groovy.json.JsonOutput
 import physicalgraph.zigbee.zcl.DataType
 
 metadata {
-    definition (name: "ZigBee Button", namespace: "smartthings", author: "Mitch Pond") {
+    definition (name: "ZigBee Button", namespace: "smartthings", author: "Mitch Pond", runLocally: true, minHubCoreVersion: "000.022.0002", executeCommandsLocally: false) {
         capability "Actuator"
         capability "Battery"
         capability "Button"


### PR DESCRIPTION
Set the [currently supported](https://github.com/SmartThingsCommunity/SmartThingsPublic/tree/master/devicetypes/smartthings/zigbee-button.src) zigbee buttons to run locally in 0.22.2 and beyond.