### PR TITLE
run evaluate() when user changes the settings.

### DIFF
--- a/smartapps/smartthings/virtual-thermostat.src/virtual-thermostat.groovy
+++ b/smartapps/smartthings/virtual-thermostat.src/virtual-thermostat.groovy
@@ -61,7 +61,7 @@ def installed()
 		here in the installed() function body takes care of updating the control loop when the user changes the setpoint.
 		 */
 		def currentTemperature = sensor.currentTemperature
-    		if (currentTemperature != null) {
+    	if (currentTemperature != null) {
 			evaluate(currentTemperature, setpoint)
 		}
 	}

--- a/smartapps/smartthings/virtual-thermostat.src/virtual-thermostat.groovy
+++ b/smartapps/smartthings/virtual-thermostat.src/virtual-thermostat.groovy
@@ -54,16 +54,23 @@ def installed()
 	subscribe(sensor, "temperature", temperatureHandler)
 	if (motion) {
 		subscribe(motion, "motion", motionHandler)
+	} else {
+		/* update the control loop immediately.  The control loop needs to be updated whenever
+		the temperature sensor reading changes or when the user changes the setpoint.  The temperatureHandler()
+		event handler takes care of updating the control loop when the sensor reading changes.  Running evaluate()
+		here in the installed() function body takes care of updating the control loop when the user changes the setpoint.
+		 */
+		def currentTemperature = sensor.currentTemperature
+    		if (currentTemperature != null) {
+			evaluate(currentTemperature, setpoint)
+		}
 	}
 }
 
 def updated()
 {
 	unsubscribe()
-	subscribe(sensor, "temperature", temperatureHandler)
-	if (motion) {
-		subscribe(motion, "motion", motionHandler)
-	}
+	installed()
 }
 
 def temperatureHandler(evt)


### PR DESCRIPTION
The control loop needs to be updated whenever the temperature sensor reading changes or when the user changes the setpoint.  The temperatureHandler() event handler takes care of updating the control loop when the sensor reading changes, but we need to also update the control loop when the user changes the setpoint.  Running evaluate() in the installed() function body takes care of updating the control loop when the user changes the setpoint.