### PR TITLE
Add capability Battery for tilt sensor reporting

### DIFF
--- a/devicetypes/smartthings/zwave-garage-door-opener.src/zwave-garage-door-opener.groovy
+++ b/devicetypes/smartthings/zwave-garage-door-opener.src/zwave-garage-door-opener.groovy
@@ -22,6 +22,7 @@ metadata {
 		capability "Contact Sensor"
 		capability "Refresh"
 		capability "Sensor"
+		capability "Battery"
 
 		fingerprint deviceId: "0x4007", inClusters: "0x98"
 		fingerprint deviceId: "0x4006", inClusters: "0x98"


### PR DESCRIPTION
this device has a battery and reports low status.

Some other deaths support this (but do not run locally).  They also add a reset to put battery back to 100%