### PR TITLE
Rolling up master to staging

### DIFF
--- a/devicetypes/smartthings/dimmer-switch.src/dimmer-switch.groovy
+++ b/devicetypes/smartthings/dimmer-switch.src/dimmer-switch.groovy
@@ -226,7 +226,6 @@ def setLevel(value) {
 	} else {
 		sendEvent(name: "switch", value: "off")
 	}
-	sendEvent(name: "level", value: level == 99 ? 100 : level)
 	delayBetween ([zwave.basicV1.basicSet(value: level).format(), zwave.switchMultilevelV1.switchMultilevelGet().format()], 5000)
 }
 

--- a/devicetypes/smartthings/zwave-dimmer-switch-generic.src/zwave-dimmer-switch-generic.groovy
+++ b/devicetypes/smartthings/zwave-dimmer-switch-generic.src/zwave-dimmer-switch-generic.groovy
@@ -228,7 +228,6 @@ def setLevel(value) {
 	} else {
 		sendEvent(name: "switch", value: "off")
 	}
-	sendEvent(name: "level", value: level == 99 ? 100 : level)
 	delayBetween([zwave.basicV1.basicSet(value: level).format(), zwave.switchMultilevelV1.switchMultilevelGet().format()], 5000)
 }
 


### PR DESCRIPTION
…#3104)

We were going to rely on the duplication filter but have shown that
is not going to be a viable solution. The best way to handle this
will just be to remove the event creation from the cloud DTH's
command side. The event will be generated by the hub when a
report event is recieved from the device.