### PR TITLE
DVCSMP-4083 Supported modes have incorrect data

### DIFF
--- a/devicetypes/smartthings/ecobee-thermostat.src/ecobee-thermostat.groovy
+++ b/devicetypes/smartthings/ecobee-thermostat.src/ecobee-thermostat.groovy
@@ -402,12 +402,12 @@ def setThermostatFanMode(String mode) {
 }
 
 def generateModeEvent(mode) {
-	sendEvent(name: "thermostatMode", value: mode, data:[supportedThermostatModes: device.currentValue("supportedThermostatModes")],
+	sendEvent(name: "thermostatMode", value: mode, data:[supportedThermostatModes: modes()],
 			isStateChange: true, descriptionText: "$device.displayName is in ${mode} mode")
 }
 
 def generateFanModeEvent(fanMode) {
-	sendEvent(name: "thermostatFanMode", value: fanMode, data:[supportedThermostatFanModes: device.currentValue("supportedThermostatFanModes")],
+	sendEvent(name: "thermostatFanMode", value: fanMode, data:[supportedThermostatFanModes: fanModes()],
 			isStateChange: true, descriptionText: "$device.displayName fan is in ${fanMode} mode")
 }
 


### PR DESCRIPTION
Supported modes have incorrect data in events for thermostatMode/thermostatFanMode

Replacing the calls to retrieve the attribute values for supportedThermostatModes/supportedThermostatFanModes with a call to get the supported modes from the DTH state where it is stored in the original type array of strings.