### PR TITLE
ICP-4701 Initial state for Aeotec door window

### DIFF
--- a/devicetypes/smartthings/zwave-door-window-sensor.src/zwave-door-window-sensor.groovy
+++ b/devicetypes/smartthings/zwave-door-window-sensor.src/zwave-door-window-sensor.groovy
@@ -100,6 +100,9 @@ def parse(String description) {
 def installed() {
 	// Device-Watch simply pings if no device events received for 482min(checkInterval)
 	sendEvent(name: "checkInterval", value: 2 * 4 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
+	// this is the nuclear option because the device often goes to sleep before we can poll it
+	sendEvent(name: "contact", value: "open", descriptionText: "$device.displayName is open")
+	sendEvent(name: "battery", unit: "%", value: 100)
 	response(initialPoll())
 }
 


### PR DESCRIPTION
This is kind of the nuclear option, but in the case that the device goes to sleep before we can poll it, there's not much else we can do. The "bad" state only remains for 4 hours until the next wakeup.