### PR TITLE
SMJN-149 Add temporary work-a-round a bug in HubCore < 22

### DIFF
--- a/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-moisture-sensor.src/smartsense-moisture-sensor.groovy
@@ -277,5 +277,5 @@ def configure() {
 	}
 	configCmds += zigbee.temperatureConfig(30, 300)
 
-	return refresh() + configCmds // send refresh cmds as part of config
+	return refresh() + configCmds + refresh() // send refresh cmds as part of config
 }

--- a/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-motion-sensor.src/smartsense-motion-sensor.groovy
@@ -307,7 +307,7 @@ def configure() {
 	}
 	configCmds += zigbee.temperatureConfig(30, 300)
 
-	return refresh() + configCmds // send refresh cmds as part of config
+	return refresh() + configCmds + refresh() // send refresh cmds as part of config
 }
 
 private shouldUseOldBatteryReporting() {

--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -440,7 +440,7 @@ def configure() {
 				zigbee.configureReporting(0xFC02, 0x0014, DataType.INT16, 1, 3600, 0x0001, [mfgCode: manufacturerCode])
 	}
 
-	return refresh() + configCmds
+	return refresh() + configCmds + refresh()
 }
 
 def updated() {


### PR DESCRIPTION
If a sensor is re-discovered immediately following discovery we will likely not receive from the hub the responses to the first refresh().