### PR TITLE
Update ocfDeviceType for CURB to x.com.st.d.energymeter

### DIFF
--- a/devicetypes/curb/curb-power-meter.src/curb-power-meter.groovy
+++ b/devicetypes/curb/curb-power-meter.src/curb-power-meter.groovy
@@ -15,7 +15,7 @@
  */
 
 metadata {
-    definition(name: "CURB Power Meter", namespace: "curb", author: "Curb", ocfDeviceType: "x.com.st.energymeter") {
+    definition(name: "CURB Power Meter", namespace: "curb", author: "Curb", ocfDeviceType: "x.com.st.d.energymeter") {
         capability "Power Meter"
         capability "Energy Meter"
     }


### PR DESCRIPTION
In PR #3040 the off device type was not the right one. This PR fixes the issue and has the right device type for OCF.