### PR TITLE
ICP-5255 Fibaro Smoke: Temp measurement not shown in App

### DIFF
--- a/devicetypes/smartthings/fibaro-smoke-sensor.src/fibaro-smoke-sensor.groovy
+++ b/devicetypes/smartthings/fibaro-smoke-sensor.src/fibaro-smoke-sensor.groovy
@@ -12,7 +12,7 @@
  *
  */
 metadata {
-	definition (name: "Fibaro Smoke Sensor", namespace: "smartthings", author: "SmartThings", mnmn: "SmartThings", vid:"generic-smoke") {
+	definition (name: "Fibaro Smoke Sensor", namespace: "smartthings", author: "SmartThings") {
 		capability "Battery" //attributes: battery
 		capability "Configuration"	//commands: configure()
 		capability "Sensor"


### PR DESCRIPTION
This device already has specific ui-metadata. The generic metadata that was here lacks the temperature measurement capability.