### PR TITLE
ICP-5372 Coolcam light switch and child device have different icons i…

### DIFF
--- a/devicetypes/smartthings/zwave-dual-switch.src/zwave-dual-switch.groovy
+++ b/devicetypes/smartthings/zwave-dual-switch.src/zwave-dual-switch.groovy
@@ -15,7 +15,6 @@ metadata {
 	definition(name: "Z-Wave Dual Switch", namespace: "smartthings", author: "SmartThings", mnmn: "SmartThings", vid: "generic-switch") {
 		capability "Actuator"
 		capability "Health Check"
-		capability "Light"
 		capability "Refresh"
 		capability "Sensor"
 		capability "Switch"


### PR DESCRIPTION
…n OneApp

The light capability affects the icon in OneApp