### PR TITLE
[WWST-1134] Adding Ecolink Tilt Sensor fingerprint to generic Z-Wave …

### DIFF
--- a/devicetypes/smartthings/zwave-door-window-sensor.src/zwave-door-window-sensor.groovy
+++ b/devicetypes/smartthings/zwave-door-window-sensor.src/zwave-door-window-sensor.groovy
@@ -35,6 +35,7 @@ metadata {
 		fingerprint mfr: "0086", prod: "0102", model: "0059", deviceJoinName: "Aeotec Recessed Door Sensor"
 		fingerprint mfr: "014A", prod: "0001", model: "0002", deviceJoinName: "Ecolink Door/Window Sensor"
 		fingerprint mfr: "014A", prod: "0001", model: "0003", deviceJoinName: "Ecolink Tilt Sensor"
+		fingerprint mfr: "014A", prod: "0004", model: "0003", deviceJoinName: "Ecolink Tilt Sensor"
 		fingerprint mfr: "011A", prod: "0601", model: "0903", deviceJoinName: "Enerwave Magnetic Door/Window Sensor"
 		fingerprint mfr: "014F", prod: "2001", model: "0102", deviceJoinName: "Nortek GoControl Door/Window Sensor"
 		fingerprint mfr: "0063", prod: "4953", model: "3031", deviceJoinName: "Jasco Hinge Pin Door Sensor"


### PR DESCRIPTION
…Door/Window Sensor DTH.

Both local and cloud versions report open/closed and battery state correct.
Device sends notification when cover is opened. This could be handled as tamper alert, but this DTH already handles this by sending event to the cloud without reporting tamper alert.

It seems previous version of Ecolink Tilt Sensor is handled by this generic DTH already, so I used the same Device Join Name.