### PR TITLE
[ICP-5416, ICP-5419] Move ZLL 5000k bulb to cloud

### DIFF
--- a/devicetypes/smartthings/zll-white-color-temperature-bulb-5000k.src/zll-white-color-temperature-bulb-5000k.groovy
+++ b/devicetypes/smartthings/zll-white-color-temperature-bulb-5000k.src/zll-white-color-temperature-bulb-5000k.groovy
@@ -13,7 +13,7 @@
  */
 
 metadata {
-    definition (name: "ZLL White Color Temperature Bulb 5000K", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.light", runLocally: true, minHubCoreVersion: '000.021.00001', executeCommandsLocally: true) {
+    definition (name: "ZLL White Color Temperature Bulb 5000K", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.light", runLocally: true, minHubCoreVersion: '000.023.00001', executeCommandsLocally: true) {
 
         capability "Actuator"
         capability "Color Temperature"


### PR DESCRIPTION
This move the "ZLL White Color Temperature Bulb 5000k" DTH to execute in
the cloud until 23.  This is because in the current local implementation
there isn't a read after a delay causing us to be out of sync
temporarily.

This addresses: https://smartthings.atlassian.net/browse/ICP-5419
This addresses: https://smartthings.atlassian.net/browse/ICP-5416