### PR TITLE
Add "Switch" capability to Springs Window Fashions Shade DH

### DIFF
--- a/devicetypes/smartthings/springs-window-fashions-shade.src/springs-window-fashions-shade.groovy
+++ b/devicetypes/smartthings/springs-window-fashions-shade.src/springs-window-fashions-shade.groovy
@@ -19,6 +19,7 @@ metadata {
         capability "Health Check"
         capability "Actuator"
         capability "Sensor"
+        capability "Switch"
 
         command "stop"
 
@@ -226,6 +227,14 @@ def close() {
     def level = switchDirection ? 99 : 0
     zwave.basicV1.basicSet(value: level).format()
     //zwave.basicV1.basicSet(value: 0).format()
+}
+
+def on() {
+    open()
+}
+
+def off() {
+    close()   
 }
 
 def setLevel(value, duration = null) {


### PR DESCRIPTION
Added the "Switch" capability along with the required on() and off() methods. This in conjunction with the "Switch Level" capability allows SmartApps that control switches and dimmers to also control devices that use this DH.