### PR TITLE
SAPLAT-108 Added UI metadata and OCF device type to Zooz power strip

### DIFF
--- a/devicetypes/smartthings/zooz-power-strip-outlet.src/zooz-power-strip-outlet.groovy
+++ b/devicetypes/smartthings/zooz-power-strip-outlet.src/zooz-power-strip-outlet.groovy
@@ -14,7 +14,7 @@
  *
  */
 metadata {
-	definition (name: "Zooz Power Strip Outlet", namespace: "smartthings", author: "SmartThings") {
+	definition (name: "Zooz Power Strip Outlet", namespace: "smartthings", author: "SmartThings", mnmn: "SmartThings", vid: "generic-switch", ocfDeviceType: "oic.d.smartplug") {
 		capability "Switch"
 		capability "Actuator"
 		capability "Sensor"

--- a/devicetypes/smartthings/zooz-power-strip.src/zooz-power-strip.groovy
+++ b/devicetypes/smartthings/zooz-power-strip.src/zooz-power-strip.groovy
@@ -20,7 +20,7 @@
  *
  */
 metadata {
-	definition (name: "Zooz Power Strip", namespace: "smartthings", author: "SmartThings") {
+	definition (name: "Zooz Power Strip", namespace: "smartthings", author: "SmartThings", mnmn: "SmartThings", vid: "generic-switch", ocfDeviceType: "oic.d.smartplug") {
 		capability "Switch"
 		capability "Refresh"
 		capability "Actuator"


### PR DESCRIPTION
Allows device to work properly in new ST app