### PR TITLE
ICP-5448 Fibaro US Wall Plug Child device not coming back online

### DIFF
--- a/devicetypes/fibargroup/fibaro-wall-plug-usb.src/fibaro-wall-plug-usb.groovy
+++ b/devicetypes/fibargroup/fibaro-wall-plug-usb.src/fibaro-wall-plug-usb.groovy
@@ -52,3 +52,7 @@ def reset() {
 def refresh() {
 	parent.childRefresh()
 }
+
+def ping() {
+	parent.childRefresh()
+}


### PR DESCRIPTION
If the parent device comes back online via unsolicited report and not via ping, we don't ping the child and so the child does not come back online.