### PR TITLE
WWST-1402: Update zen-thermostat.groovy by splitting Thermostat capability.

### DIFF
--- a/devicetypes/zenwithin/zen-thermostat.src/zen-thermostat.groovy
+++ b/devicetypes/zenwithin/zen-thermostat.src/zen-thermostat.groovy
@@ -14,7 +14,11 @@ metadata {
         capability "Refresh"
         capability "Sensor"
         capability "Temperature Measurement"
-        capability "Thermostat"
+        capability "Thermostat Heating Setpoint"
+        capability "Thermostat Cooling Setpoint"
+        capability "Thermostat Fan Mode"
+        capability "Thermostat Mode"
+        capability "Thermostat Operating State"
 
         command "setpointUp"
         command "setpointDown"


### PR DESCRIPTION
This is a fix for WWST-1402, where the UI wasn't being updated properly due to mismatched href.

cc @tpmanley @workingmonk 