### PR TITLE
Missing import for Logitech

### DIFF
--- a/devicetypes/smartthings/harmony-activity.src/harmony-activity.groovy
+++ b/devicetypes/smartthings/harmony-activity.src/harmony-activity.groovy
@@ -13,6 +13,9 @@
  *  for the specific language governing permissions and limitations under the License.
  *
  */
+
+import groovy.json.JsonOutput
+
 metadata {
         definition (name: "Harmony Activity", namespace: "smartthings", author: "Juan Risso") {
         capability "Switch"


### PR DESCRIPTION
also, for other integration, they don't get auto migrated to the new system. When I manually moved them, the exception came up.

cc @juano2310 @marstorp 