### PR TITLE
DVCSMP-4451 Fix for Schlage FE599 and similar locks

### DIFF
--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -643,6 +643,7 @@ private def handleAlarmReportUsingAlarmType(cmd) {
 			if (cmd.alarmLevel != null) {
 				codeID = readCodeSlotId(cmd)
 				codeName = getCodeName(lockCodes, codeID)
+				map.isStateChange = true // Non motorized locks, mark state changed since it can be unlocked multiple times
 				map.descriptionText = "Unlocked by \"$codeName\""
 				map.data = [ codeId: codeID as String, usedCode: codeID, codeName: codeName, method: "keypad" ]
 			}


### PR DESCRIPTION
@greens @workingmonk 
Submitting a patch to fix an issue with non motorized locks which don't report re-locked events.

Can be unsecured multiple times using they keypad, each time it's unsecured using a code a notification should be sent (some locks don't sent re-secured notifications so this unlock event is not passed to SmartApps without this fix)