### PR TITLE
[WWST-1450] Add fingerprint of Kwikset convert to Z-wave lock without codes DTH

### DIFF
--- a/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
+++ b/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
@@ -24,6 +24,7 @@ metadata {
 		capability "Configuration"
 
 		fingerprint mfr: "010E", prod: "0009", model: "0001", deviceJoinName: "Danalock V3 Smart Lock"
+		fingerprint mfr: "0090", prod: "0003", model: "0446", deviceJoinName: "Kwikset Convert Convertible Lock - 99140"
 	}
 
 	simulator {

--- a/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
+++ b/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
@@ -24,7 +24,7 @@ metadata {
 		capability "Configuration"
 
 		fingerprint mfr: "010E", prod: "0009", model: "0001", deviceJoinName: "Danalock V3 Smart Lock"
-		fingerprint mfr: "0090", prod: "0003", model: "0446", deviceJoinName: "Kwikset Convert Convertible Lock - 99140"
+		fingerprint mfr: "0090", prod: "0003", model: "0446", deviceJoinName: "Kwikset Convert Deadbolt Door Lock" //99140
 	}
 
 	simulator {


### PR DESCRIPTION
@greens @MAblewiczS  @DCzarneckaS @MMateusiakS @PKacprowiczS 
 could you review this PR?

This lock does not have keypad, so fingerprint was added to DTH Z-wave lock without codes.