### PR TITLE
ICP-5963 Add "Configuration" capability to zwave motion/light

### DIFF
--- a/devicetypes/smartthings/zwave-motion-light-sensor.src/zwave-motion-light-sensor.groovy
+++ b/devicetypes/smartthings/zwave-motion-light-sensor.src/zwave-motion-light-sensor.groovy
@@ -23,6 +23,7 @@ metadata {
 		capability "Battery"
 		capability "Sensor"
 		capability "Health Check"
+		capability "Configuration"
 
 		//zw:S type:0701 mfr:021F prod:0003 model:0083 ver:3.92 zwv:4.05 lib:06 cc:5E,86,72,5A,73,80,31,71,30,70,85,59,84 role:06 ff:8C07 ui:8C07
 		fingerprint mfr: "021F", prod: "0003", model: "0083", deviceJoinName: "Dome Motion/Light Sensor"


### PR DESCRIPTION
Having this missing was preventing the checkInterval from being set in instances where updated() was not called. Updated was not being called in OneApp unless the "rename" button was pressed.