### PR TITLE
[ICP-5989] Adding missing fingerprint for Aeon door window sensor (EU)

### DIFF
--- a/devicetypes/smartthings/zwave-door-window-sensor.src/zwave-door-window-sensor.groovy
+++ b/devicetypes/smartthings/zwave-door-window-sensor.src/zwave-door-window-sensor.groovy
@@ -45,6 +45,8 @@ metadata {
 		fingerprint mfr: "021F", prod: "0003", model: "0101", deviceJoinName: "Dome Door/Window Sensor"
 		//zw:S type:0701 mfr:014A prod:0004 model:0002 ver:10.01 zwv:4.05 lib:06 cc:5E,86,72,73,80,71,85,59,84,30,70 ccOut:20 role:06 ff:8C07 ui:8C00
 		fingerprint mfr: "014A", prod: "0004", model: "0002", deviceJoinName: "Ecolink Door/Window Sensor"
+		//zw:Ss type:0701 mfr:0086 prod:0002 model:0059 ver:1.14 zwv:3.92 lib:03 cc:5E,86,72,98,5A ccOut:82 sec:30,80,84,70,85,59,71,7A,73 role:06 ff:8C00 ui:8C00
+		fingerprint mfr: "0086", prod: "0002", model: "0059", deviceJoinName: "Aeon Recessed Door Sensor"
 
 	}
 


### PR DESCRIPTION
@greens @MAblewiczS @DCzarneckaS @PKacprowiczS @MGoralczykS 

The fingerprint for this device has not been added previously. Fixing this.