### PR TITLE
ONEAPP-6639 Update Refresh method as workaround for Utilitech Siren (…

### DIFF
--- a/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
+++ b/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
@@ -187,10 +187,10 @@ def ping() {
 
 def refresh() {
 	log.debug "sending battery refresh command"
-	[
+	delayBetween([
 		zwave.basicV1.basicGet().format(),
 		zwave.batteryV1.batteryGet().format()
-	]
+	], 2000)
 }
 
 def parse(String description) {


### PR DESCRIPTION
…#3440)

This siren is too dumb to handle more than one get at a time. It will respond to two quickly subsequent requests using the correct payload, but the incorrect command class.