### PR TITLE
ONEAPP-7061 Add Light capability to the GE Link Bulb DTH

### DIFF
--- a/devicetypes/smartthings/ge-link-bulb.src/ge-link-bulb.groovy
+++ b/devicetypes/smartthings/ge-link-bulb.src/ge-link-bulb.groovy
@@ -51,6 +51,7 @@ metadata {
         capability "Switch"
         capability "Switch Level"
         capability "Polling"
+        capability "Light"
 
         fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0008,1000", outClusters: "0019", manufacturer: "GE_Appliances", model: "ZLL Light", deviceJoinName: "GE Link Bulb"
         fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0008,1000", outClusters: "0019", manufacturer: "GE", model: "SoftWhite", deviceJoinName: "GE Link Soft White Bulb"


### PR DESCRIPTION
This is being done so that GE Link bulbs are available alert targets for SHM.

https://smartthings.atlassian.net/browse/ONEAPP-7061