### PR TITLE
SMJN-164 Remove the Level Control cluster from the Samjin Outlet fingerprint

### DIFF
--- a/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
+++ b/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
@@ -30,10 +30,7 @@ metadata {
 		fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0B04,0B05", outClusters: "0019", manufacturer: "CentraLite", model: "4257050-RZHAC", deviceJoinName: "Outlet"
 		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 000F, 0B04", outClusters: "0019", manufacturer: "SmartThings", model: "outletv4", deviceJoinName: "Outlet"
 		fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0B04,0B05", outClusters: "0019"
-		fingerprint profileId: "0104", inClusters: "0000,0003,0006,0008,0009,0B04", outClusters: "0019", manufacturer: "Samjin", model: "outlet", deviceJoinName: "Outlet"
-
-			   
-		//01 0104 0101 00 08 0000 0003 0004 0005 0006 0008 0702 0B05 01 0019
+		fingerprint profileId: "0104", inClusters: "0000,0003,0006,0009,0B04", outClusters: "0019", manufacturer: "Samjin", model: "outlet", deviceJoinName: "Outlet"
 		fingerprint profileId: "0010", inClusters: "0000 0003 0004 0005 0006 0008 0702 0B05", outClusters: "0019", manufacturer: "innr", model: "SP 120", deviceJoinName: "Outlet" 
 
 	}


### PR DESCRIPTION
The new firmware is removing the Level Control cluster from the Simple Descriptor since it doesn't actually allow for control over the level of the outlet load. Even so, the correct DTH will still be chosen for devices that have the old firmware with the Level Control cluster or the new firmware
that doesn't have it.

https://smartthings.atlassian.net/browse/SMJN-164