### PR TITLE
Making all runIn callbacks use public methods in the Fibaro DTHs

### DIFF
--- a/devicetypes/fibargroup/fibaro-co-sensor-zw5.src/fibaro-co-sensor-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-co-sensor-zw5.src/fibaro-co-sensor-zw5.groovy
@@ -150,7 +150,7 @@ private syncStart() {
 	}
 }
 
-private syncNext() {
+def syncNext() {
 	logging("${device.displayName} - Executing syncNext()","info")
 	def cmds = []
 	for ( param in parameterMap() ) {
@@ -170,7 +170,7 @@ private syncNext() {
 	}
 }
 
-private syncCheck() {
+def syncCheck() {
 	logging("${device.displayName} - Executing syncCheck()","info")
 	def failed = []
 	def incorrect = []
@@ -210,7 +210,7 @@ def zwaveEvent(physicalgraph.zwave.commands.wakeupv2.WakeUpNotification cmd) {
 
 	cmds << zwave.batteryV1.batteryGet()
 	cmds << zwave.sensorMultilevelV5.sensorMultilevelGet()
-	runIn(1,"syncNext")
+	runIn(1, "syncNext")
 	[response(encapSequence(cmds,1000))]
 }
 

--- a/devicetypes/fibargroup/fibaro-dimmer-2-zw5.src/fibaro-dimmer-2-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-dimmer-2-zw5.src/fibaro-dimmer-2-zw5.groovy
@@ -148,11 +148,11 @@ def configure(){
 def updated() {
 	if ( state.lastUpdated && (now() - state.lastUpdated) < 500 ) return
 	logging("${device.displayName} - Executing updated()","info")
-	runIn(3,"syncStart")
+	runIn(3, "syncStart")
 	state.lastUpdated = now()
 }
 
-private syncStart() {
+def syncStart() {
 	boolean syncNeeded = false
 	parameterMap().each {
 		if(settings."$it.key" != null) {

--- a/devicetypes/fibargroup/fibaro-door-window-sensor-2.src/fibaro-door-window-sensor-2.groovy
+++ b/devicetypes/fibargroup/fibaro-door-window-sensor-2.src/fibaro-door-window-sensor-2.groovy
@@ -199,7 +199,7 @@ private syncStart() {
 	}
 }
 
-private syncNext() {
+def syncNext() {
 	logging("${device.displayName} - Executing syncNext()","debug")
 	def cmds = []
 	for ( param in parameterMap() ) {
@@ -219,7 +219,7 @@ private syncNext() {
 	}
 }
 
-private syncCheck() {
+def syncCheck() {
 	logging("${device.displayName} - Executing syncCheck()","debug")
 	def failed = []
 	def incorrect = []
@@ -264,7 +264,7 @@ def zwaveEvent(physicalgraph.zwave.commands.wakeupv2.WakeUpNotification cmd) {
 	}
 	cmds << zwave.batteryV1.batteryGet()
 	cmds << zwave.sensorMultilevelV5.sensorMultilevelGet(sensorType: 1)
-	runIn(1,"syncNext")
+	runIn(1, "syncNext")
 	[response(encapSequence(cmds,1000))]
 }
 

--- a/devicetypes/fibargroup/fibaro-double-switch-2-zw5.src/fibaro-double-switch-2-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-double-switch-2-zw5.src/fibaro-double-switch-2-zw5.groovy
@@ -157,12 +157,12 @@ def initialize() {
 	if (device.currentValue("numberOfButtons") != 6) { sendEvent(name: "numberOfButtons", value: 6) }
 
 	cmds << zwave.multiChannelAssociationV2.multiChannelAssociationGet(groupingIdentifier: 1) //verify if group 1 association is correct  
-	runIn(3,"syncStart")
+	runIn(3, "syncStart")
 	state.lastUpdated = now()
 	response(encapSequence(cmds,1000))
 }
 
-private syncStart() {
+def syncStart() {
 	boolean syncNeeded = false
 	parameterMap().each {
 		if(settings."$it.key" != null) {
@@ -202,7 +202,7 @@ private syncNext() {
 	}
 }
 
-private syncCheck() {
+def syncCheck() {
 	logging("${device.displayName} - Executing syncCheck()","info")
 	def failed = []
 	def incorrect = []

--- a/devicetypes/fibargroup/fibaro-motion-sensor-zw5.src/fibaro-motion-sensor-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-motion-sensor-zw5.src/fibaro-motion-sensor-zw5.groovy
@@ -406,7 +406,7 @@ private motionEvent(Integer sensorType, value) {
 	}
 }
 
-private axisEvent() {
+def axisEvent() {
 	logging("${device.displayName} - Executing axisEvent() values are: ${device.currentValue("xAxis")}, ${device.currentValue("yAxis")}, ${device.currentValue("zAxis")}", "debug")
 	def xAxis = Math.round((device.currentValue("xAxis") as Float) * 100)
 	def yAxis = Math.round((device.currentValue("yAxis") as Float) * 100)
@@ -445,7 +445,7 @@ private syncStart() {
 	}
 }
 
-private syncNext() {
+def syncNext() {
 	logging("${device.displayName} - Executing syncNext()", "debug")
 	def cmds = []
 	for (param in parameterMap()) {
@@ -465,7 +465,7 @@ private syncNext() {
 	}
 }
 
-private syncCheck() {
+def syncCheck() {
 	logging("${device.displayName} - Executing syncCheck()", "debug")
 	def failed = []
 	def incorrect = []

--- a/devicetypes/fibargroup/fibaro-single-switch-2-zw5.src/fibaro-single-switch-2-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-single-switch-2-zw5.src/fibaro-single-switch-2-zw5.groovy
@@ -175,7 +175,7 @@ private syncNext() {
     }
 }
 
-private syncCheck() {
+def syncCheck() {
     logging("Executing syncCheck()","info")
     def failed = []
     def incorrect = []

--- a/devicetypes/fibargroup/fibaro-wall-plug-eu-zw5.src/fibaro-wall-plug-eu-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-wall-plug-eu-zw5.src/fibaro-wall-plug-eu-zw5.groovy
@@ -167,7 +167,7 @@ private syncNext() {
 	}
 }
 
-private syncCheck() {
+def syncCheck() {
 	logging("Executing syncCheck()","info")
 	def failed = []
 	def incorrect = []

--- a/devicetypes/fibargroup/fibaro-wall-plug-us-zw5.src/fibaro-wall-plug-us-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-wall-plug-us-zw5.src/fibaro-wall-plug-us-zw5.groovy
@@ -210,7 +210,7 @@ private syncNext() {
 	}
 }
 
-private syncCheck() {
+def syncCheck() {
 	logging("Executing syncCheck()","info")
 	def failed = []
 	def incorrect = []

--- a/devicetypes/smartthings/testing/simulated-thermostat.src/simulated-thermostat.groovy
+++ b/devicetypes/smartthings/testing/simulated-thermostat.src/simulated-thermostat.groovy
@@ -720,7 +720,7 @@ private startSimHvac() {
     }
 }
 
-private runSimHvacCycle() {
+def runSimHvacCycle() {
     def operatingState = getOperatingState()
     def currentTemp = getTemperature()
     def heatSet = getHeatingSetpoint()


### PR DESCRIPTION
The recent Grails/Groovy update requires runIn callbacks to be public or else they won't run.