### PR TITLE
ICP-6034 Move remaining sirens using smoke alarm device type to siren…

### DIFF
--- a/devicetypes/smartthings/aeon-siren.src/aeon-siren.groovy
+++ b/devicetypes/smartthings/aeon-siren.src/aeon-siren.groovy
@@ -16,7 +16,7 @@
  *	Date: 2014-07-15
  */
 metadata {
- definition (name: "Aeon Siren", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "x.com.st.d.sensor.smoke", runLocally: true, minHubCoreVersion: '000.017.0012', executeCommandsLocally: false) {
+ definition (name: "Aeon Siren", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "x.com.st.d.siren", runLocally: true, minHubCoreVersion: '000.017.0012', executeCommandsLocally: false) {
 	capability "Actuator"
 	capability "Alarm"
 	capability "Switch"

--- a/devicetypes/smartthings/smartalert-siren.src/smartalert-siren.groovy
+++ b/devicetypes/smartthings/smartalert-siren.src/smartalert-siren.groovy
@@ -16,7 +16,7 @@
  *  Date: 2013-03-05
  */
 metadata {
-	definition (name: "SmartAlert Siren", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "x.com.st.d.sensor.smoke", runLocally: true, minHubCoreVersion: '000.017.0012', executeCommandsLocally: false) {
+	definition (name: "SmartAlert Siren", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "x.com.st.d.siren", runLocally: true, minHubCoreVersion: '000.017.0012', executeCommandsLocally: false) {
 		capability "Actuator"
 		capability "Switch"
 		capability "Sensor"

--- a/devicetypes/smartthings/zigbee-sound-sensor.src/zigbee-sound-sensor.groovy
+++ b/devicetypes/smartthings/zigbee-sound-sensor.src/zigbee-sound-sensor.groovy
@@ -18,7 +18,7 @@ import physicalgraph.zigbee.clusters.iaszone.ZoneStatus
 import physicalgraph.zigbee.zcl.DataType
 
 metadata {
-	definition(name: "ZigBee Sound Sensor", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "x.com.st.d.sensor.smoke") {
+	definition(name: "ZigBee Sound Sensor", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "x.com.st.d.siren") {
 		capability "Battery"
 		capability "Configuration"
 		capability "Health Check"

--- a/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
+++ b/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
@@ -16,7 +16,7 @@
  *  Date: 2014-07-15
  */
 metadata {
-	definition(name: "Z-Wave Siren", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "x.com.st.d.sensor.smoke", runLocally: true, minHubCoreVersion: '000.017.0012', executeCommandsLocally: false) {
+	definition(name: "Z-Wave Siren", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "x.com.st.d.siren", runLocally: true, minHubCoreVersion: '000.017.0012', executeCommandsLocally: false) {
 		capability "Actuator"
 		capability "Alarm"
 		capability "Battery"

--- a/devicetypes/smartthings/zwave-sound-sensor.src/zwave-sound-sensor.groovy
+++ b/devicetypes/smartthings/zwave-sound-sensor.src/zwave-sound-sensor.groovy
@@ -12,7 +12,7 @@
  *
  */
 metadata {
-	definition (name: "Z-Wave Sound Sensor", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "x.com.st.d.sensor.smoke") {
+	definition (name: "Z-Wave Sound Sensor", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "x.com.st.d.siren") {
 		capability "Sound Sensor"
 		capability "Sensor"
 		capability "Battery"


### PR DESCRIPTION
… device type

We've been assured that this will be fixed on the OneApp side so that the smoke devicetype no longer maps to a siren icon.