### PR TITLE
ICP-6254 Remove hidden field from range extender

### DIFF
--- a/devicetypes/smartthings/zwave-range-extender.src/zwave-range-extender.groovy
+++ b/devicetypes/smartthings/zwave-range-extender.src/zwave-range-extender.groovy
@@ -12,7 +12,7 @@
  *
  */
 metadata {
-	definition (name: "Z-Wave Range Extender", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.networking", hidden: true) {
+	definition (name: "Z-Wave Range Extender", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.networking") {
 		capability "Health Check"
 
 		fingerprint mfr: "0086", prod: "0104", model: "0075", deviceJoinName: "Aeotec Range Extender 6" //US


### PR DESCRIPTION
So that empty device is displayed in device list.