### PR TITLE
WWST-955: Add manufacturer to Orvibo Motion Detector fingerprint

### DIFF
--- a/devicetypes/smartthings/zigbee-motion-detector.src/zigbee-motion-detector.groovy
+++ b/devicetypes/smartthings/zigbee-motion-detector.src/zigbee-motion-detector.groovy
@@ -25,7 +25,7 @@ metadata {
 		capability "Refresh"
 		capability "Health Check"
 		capability "Sensor"
-		fingerprint profileId: "0104", deviceId: "0402", inClusters: "0000,0003,0500,0001", model:"895a2d80097f4ae2b2d40500d5e03dcc", deviceJoinName: "Orvibo Motion Sensor"
+		fingerprint profileId: "0104", deviceId: "0402", inClusters: "0000,0003,0500,0001", manufacturer:"ORVIBO", model:"895a2d80097f4ae2b2d40500d5e03dcc", deviceJoinName: "Orvibo Motion Sensor"
 	}
 	simulator {
 		status "active": "zone status 0x0001 -- extended status 0x00"


### PR DESCRIPTION
The device was joining as a Thing without the manufacturer in the fingerprint.

https://smartthings.atlassian.net/browse/WWST-955