### PR TITLE
ICP-6040 Ecolink Siren: Update status when device is plugged in

### DIFF
--- a/devicetypes/smartthings/ecolink-wireless-siren.src/ecolink-wireless-siren.groovy
+++ b/devicetypes/smartthings/ecolink-wireless-siren.src/ecolink-wireless-siren.groovy
@@ -73,8 +73,13 @@ def parse(String description) {
 	}
 }
 
-def zwaveEvent(physicalgraph.zwave.commands.basicv1.BasicReport cmd) {	
+def zwaveEvent(physicalgraph.zwave.commands.basicv1.BasicReport cmd) {
+	//When device is plugged in, it sends BasicReport with value "0" to parent endpoint.
+	//It means that parent and child devices are available, but status of child devices must be updated.
 	createEvents(cmd.value)
+	if(cmd.value == 0) {
+		sendHubCommand(addDelay(refreshChildren()))
+	}
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.switchbinaryv1.SwitchBinaryReport cmd) {
@@ -136,12 +141,22 @@ def ping() {
 }
 
 def refresh() {
-	def cmds = []	
+	def cmds = []
+	cmds << refreshChildren()
+	cmds << basicGetCmd(1)
+	return addDelay(cmds)
+}
+
+def refreshChildren() {
+	def cmds = []
 	endPoints.each {
 		cmds << basicGetCmd(it)
 	}
-	cmds << basicGetCmd(1)
-	return delayBetween(cmds, 200)
+	return cmds
+}
+
+def addDelay(cmds) {
+	delayBetween(cmds, 200)
 }
 
 def setSirenChildrenOff() {


### PR DESCRIPTION
When the device is plugged in it sends a BasicReport with a value of 0 to the parent endpoint. On receipt of that message it will now refresh the status of all the child endpoints.

https://smartthings.atlassian.net/browse/ICP-6040