### PR TITLE
ICP-6205 Fix RGB<->HSV conversion for Z-Wave color bulbs

### DIFF
--- a/devicetypes/smartthings/aeon-led-bulb-6.src/aeon-led-bulb-6.groovy
+++ b/devicetypes/smartthings/aeon-led-bulb-6.src/aeon-led-bulb-6.groovy
@@ -16,6 +16,8 @@
  *  Date: 2018-8-31
  */
 
+import physicalgraph.developer.ColorUtilities
+
 metadata {
 	definition (name: "Aeon LED Bulb 6 Multi-Color", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.light", mnmn: "SmartThings", vid: "generic-rgbw-color-bulb") {
 		capability "Switch Level"
@@ -49,7 +51,7 @@ metadata {
 			}
 
 			tileAttribute ("device.color", key: "COLOR_CONTROL") {
-				attributeState "color", action:"setColor"
+				attributeState "color", action:"color control.setColor"
 			}
 		}
 	}
@@ -270,7 +272,7 @@ def setColorTemperature(temp) {
 }
 
 private queryAllColors() {
-	def colors = RGB_NAMES + WHITE_NAMES
+	def colors = WHITE_NAMES + RGB_NAMES
 	colors.collect { zwave.switchColorV3.switchColorGet(colorComponent: it) }
 }
 
@@ -297,39 +299,12 @@ private commands(commands, delay=200) {
 }
 
 def rgbToHSV(red, green, blue) {
-	float r = red / 255f
-	float g = green / 255f
-	float b = blue / 255f
-	float max = [r, g, b].max()
-	float delta = max - [r, g, b].min()
-	def hue = 13
-	def saturation = 0
-	if (max && delta) {
-		saturation = 100 * delta / max
-		if (r == max) {
-			hue = ((g - b) / delta) * 100 / 6
-		} else if (g == max) {
-			hue = (2 + (b - r) / delta) * 100 / 6
-		} else {
-			hue = (4 + (r - g) / delta) * 100 / 6
-		}
-	}
-	[hue: hue, saturation: saturation, value: max * 100]
+	def hex = ColorUtilities.rgbToHex(red as int, green as int, blue as int)
+	def hsv = ColorUtilities.hexToHsv(hex)
+	return [hue: hsv[0], saturation: hsv[1], value: hsv[2]]
 }
 
 def huesatToRGB(hue, sat) {
-	while(hue >= 100) hue -= 100
-	int h = (int)(hue / 100 * 6)
-	float f = hue / 100 * 6 - h
-	int p = Math.round(255 * (1 - (sat / 100)))
-	int q = Math.round(255 * (1 - (sat / 100) * f))
-	int t = Math.round(255 * (1 - (sat / 100) * (1 - f)))
-	switch (h) {
-		case 0: return [255, t, p]
-		case 1: return [q, 255, p]
-		case 2: return [p, 255, t]
-		case 3: return [p, q, 255]
-		case 4: return [t, p, 255]
-		case 5: return [255, p, q]
-	}
+	def color = ColorUtilities.hsvToHex(Math.round(hue) as int, Math.round(sat) as int)
+	return ColorUtilities.hexToRgb(color)
 }

--- a/devicetypes/smartthings/aeon-led-bulb.src/aeon-led-bulb.groovy
+++ b/devicetypes/smartthings/aeon-led-bulb.src/aeon-led-bulb.groovy
@@ -16,6 +16,8 @@
  *  Date: 2015-7-12
  */
 
+import physicalgraph.developer.ColorUtilities
+
 metadata {
 	definition (name: "Aeon LED Bulb", namespace: "smartthings", author: "SmartThings") {
 		capability "Switch Level"
@@ -52,7 +54,7 @@ metadata {
 		state "level", action:"switch level.setLevel"
 	}
 	controlTile("rgbSelector", "device.color", "color", height: 3, width: 3, inactiveLabel: false) {
-		state "color", action:"setColor"
+		state "color", action:"color control.setColor"
 	}
 	valueTile("level", "device.level", inactiveLabel: false, decoration: "flat") {
 		state "level", label: 'Level ${currentValue}%'
@@ -216,39 +218,12 @@ private commands(commands, delay=200) {
 }
 
 def rgbToHSV(red, green, blue) {
-	float r = red / 255f
-	float g = green / 255f
-	float b = blue / 255f
-	float max = [r, g, b].max()
-	float delta = max - [r, g, b].min()
-	def hue = 13
-	def saturation = 0
-	if (max && delta) {
-		saturation = 100 * delta / max
-		if (r == max) {
-			hue = ((g - b) / delta) * 100 / 6
-		} else if (g == max) {
-			hue = (2 + (b - r) / delta) * 100 / 6
-		} else {
-			hue = (4 + (r - g) / delta) * 100 / 6
-		}
-	}
-	[hue: hue, saturation: saturation, value: max * 100]
+	def hex = ColorUtilities.rgbToHex(red as int, green as int, blue as int)
+	def hsv = ColorUtilities.hexToHsv(hex)
+	return [hue: hsv[0], saturation: hsv[1], value: hsv[2]]
 }
 
-def huesatToRGB(float hue, float sat) {
-	while(hue >= 100) hue -= 100
-	int h = (int)(hue / 100 * 6)
-	float f = hue / 100 * 6 - h
-	int p = Math.round(255 * (1 - (sat / 100)))
-	int q = Math.round(255 * (1 - (sat / 100) * f))
-	int t = Math.round(255 * (1 - (sat / 100) * (1 - f)))
-	switch (h) {
-		case 0: return [255, t, p]
-		case 1: return [q, 255, p]
-		case 2: return [p, 255, t]
-		case 3: return [p, q, 255]
-		case 4: return [t, p, 255]
-		case 5: return [255, p, q]
-	}
+def huesatToRGB(hue, sat) {
+	def color = ColorUtilities.hsvToHex(Math.round(hue) as int, Math.round(sat) as int)
+	return ColorUtilities.hexToRgb(color)
 }


### PR DESCRIPTION
This has been broken. Seemingly due to assuming that computer modulo and mathematical modulo are the same wrt negative numbers. They're not. Also we get to use some nice utility functions that someone wrote but never used.