### PR TITLE
ICP-6317 Zigbee Multi Switch: Make sure child device is not a component

### DIFF
--- a/devicetypes/smartthings/zigbee-multi-switch.src/zigbee-multi-switch.groovy
+++ b/devicetypes/smartthings/zigbee-multi-switch.src/zigbee-multi-switch.groovy
@@ -96,8 +96,7 @@ def parse(String description) {
 private void createChildDevices() {
 	def i = 2
 	addChildDevice("Child Switch Health", "${device.deviceNetworkId}:0${i}", device.hubId,
-			[completedSetup: true, label: "${device.displayName.split("1")[-1]}${i}",
-			 isComponent   : false, componentName: "ch$i", componentLabel: "Channel $i"])
+			[completedSetup: true, label: "${device.displayName.split("1")[-1]}${i}", isComponent : false])
 }
 
 private getChildEndpoint(String dni) {


### PR DESCRIPTION
Using componentName when creating child devices causes it to be a component. Multi-component devices aren't fully supported right now so we need it to just be a regular child device.

https://smartthings.atlassian.net/browse/ICP-6317