### PR TITLE
Fix Pabal parameter

### DIFF
--- a/smartapps/imbrianj/door-knocker.src/door-knocker.groovy
+++ b/smartapps/imbrianj/door-knocker.src/door-knocker.groovy
@@ -93,7 +93,7 @@ private send(kSensor) {
   String code = 'SmartApps_DoorKnocker_V_0001'
   List params = [
     [
-      'name': 'knockSensor.label',
+      'n': '${knockSensor.name}',
       'value': kSensor
     ]
   ]


### PR DESCRIPTION
Pabal requires a key of `n` and a value of `${knockSensor.name}` (brackets must be included) to successfully fill the device name.