### PR TITLE
Add fingerprint for RGBgenie ZW-1001 Z-Wave Dimmer controller

### DIFF
--- a/devicetypes/smartthings/zwave-dimmer-switch-generic.src/zwave-dimmer-switch-generic.groovy
+++ b/devicetypes/smartthings/zwave-dimmer-switch-generic.src/zwave-dimmer-switch-generic.groovy
@@ -40,6 +40,7 @@ metadata {
 		fingerprint mfr: "001A", prod: "4449", model: "0003", deviceJoinName: "Eaton RF Dimming Plug-In Module"
 		fingerprint mfr: "014F", prod: "5744", model: "3530", deviceJoinName: "GoControl In-Wall Dimmer"
 		fingerprint mfr: "0307", prod: "4447", model: "3034", deviceJoinName: "Satco In-Wall Dimmer"
+		fingerprint mfr: "0330", prod: "0201", model: "D002", deviceJoinName: "RGBgenie ZW-1001 Z-Wave Dimmer"
 	}
 
 	simulator {


### PR DESCRIPTION
@greens  - Adding a fingerprint for a RGBgenie ZW-1001 Z-Wave Dimmer controller.   http://www.rgbgenie.com/ . 
By default the device was recognized as a "Secure Dimmer" but it didn't work under that device type.  Here is the info from the devices tab after inclusion:  
Raw Description 	zw:Ls type:1101 mfr:0330 prod:0201 model:D002 ver:1.03 zwv:4.61 lib:03 cc:5E,55,6C,98,9F role:05 ff:8600 ui:8600

Let me know if you need anything else from me.  Also it seems this device type doesn't work in the new app?