### PR TITLE
Create zwave-rgbw-bulb.groovy

### DIFF
--- a/devicetypes/smartthings/zwave-rgbw-bulb.src/zwave-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zwave-rgbw-bulb.src/zwave-rgbw-bulb.groovy
@@ -25,13 +25,13 @@ metadata {
 		capability "Refresh"
 		capability "Actuator"
 		capability "Sensor"
-    capability "Health Check"
-    capability "Light"
+    		capability "Health Check"
+    		capability "Light"
 
 		command "reset"
 
 		fingerprint inClusters: "0x33"
-    fingerprint inClusters: "0x26,0x33"
+    		fingerprint inClusters: "0x26,0x33"
 		fingerprint inClusters: "0x26,0x33,0x98"
 		fingerprint deviceId: "0x11", inClusters: "0x98,0x33"
 		fingerprint deviceId: "0x1102", inClusters: "0x98"		
@@ -69,7 +69,7 @@ metadata {
 	}
 
 	main(["switch"])
-	details(["switch", "colorTempSliderControl", "reset", "refresh"])
+	details(["switch", "levelSliderControl", "rgbSelector", "colorTempSliderControl", "reset", "refresh"])
 }
 
 def updated() {
@@ -189,7 +189,7 @@ def setColor(value) {
 		def c = value.hex.findAll(/[0-9a-fA-F]{2}/).collect { Integer.parseInt(it, 16) }
 		result << zwave.switchColorV3.switchColorSet(red:c[0], green:c[1], blue:c[2], warmWhite:0, coldWhite:0)
 	} else {
-    def rgb = huesatToRGB(value.hue, value.saturation)
+    		def rgb = huesatToRGB(value.hue, value.saturation)
 		result << zwave.switchColorV3.switchColorSet(red: rgb[0], green: rgb[1], blue: rgb[2], warmWhite:0, coldWhite:0)
 	}
 
@@ -201,16 +201,27 @@ def setColor(value) {
 	commands(result)
 }
 
-def setColorTemperature(percent) {
-	if(percent > 99) percent = 99
-	int warmValue = percent * 255 / 99
-	command(zwave.switchColorV3.switchColorSet(red:0, green:0, blue:0, warmWhite:warmValue, coldWhite:(255 - warmValue)))
+private getCOLOR_TEMP_MAX() { 6500 }
+private getCOLOR_TEMP_MIN() { 2700 }
+private getCOLOR_TEMP_DIFF() { COLOR_TEMP_MAX - COLOR_TEMP_MIN }
+
+def setColorTemperature(temp) {
+	if(temp > COLOR_TEMP_MAX)
+		temp = COLOR_TEMP_MAX
+	else if(temp < COLOR_TEMP_MIN)
+		temp = COLOR_TEMP_MIN
+	log.debug "setColorTemperature($temp)"
+	def warmValue = ((COLOR_TEMP_MAX - temp) / COLOR_TEMP_DIFF * 255) as Integer
+	def coldValue = 255 - warmValue
+	def cmds = [zwave.switchColorV3.switchColorSet(red: 0, green: 0, blue: 0, warmWhite: warmValue, coldWhite: coldValue)]
+	cmds += queryAllColors()
+	commands(cmds)
 }
 
 def reset() {
 	log.debug "reset()"
 	sendEvent(name: "color", value: "#ffffff")
-	setColorTemperature(99)
+	setColorTemperature(COLOR_TEMP_MAX)
 }
 
 private command(physicalgraph.zwave.Command cmd) {

--- a/devicetypes/smartthings/zwave-rgbw-bulb.src/zwave-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zwave-rgbw-bulb.src/zwave-rgbw-bulb.groovy
@@ -1,0 +1,241 @@
+/**
+ *  Copyright 2018 SmartThings
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ *  for the specific language governing permissions and limitations under the License.
+ *
+ *  Z-wave RGBW Bulb
+ *
+ *  Author: SmartThings / vseven (Allan)
+ *  Date: 2018-10-30
+ */
+
+metadata {
+	definition (name: "ZWave RGBW Bulb", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.light", mnmn: "SmartThings", vid: "generic-rgbw-color-bulb") {
+		capability "Switch Level"
+		capability "Color Control"
+		capability "Color Temperature"
+		capability "Switch"
+		capability "Refresh"
+		capability "Actuator"
+		capability "Sensor"
+    capability "Health Check"
+    capability "Light"
+
+		command "reset"
+
+		fingerprint inClusters: "0x33"
+    fingerprint inClusters: "0x26,0x33"
+		fingerprint inClusters: "0x26,0x33,0x98"
+		fingerprint deviceId: "0x11", inClusters: "0x98,0x33"
+		fingerprint deviceId: "0x1102", inClusters: "0x98"		
+		fingerprint mfr: "0086", prod: "0103", model: "0079", deviceJoinName: "Aeotec LED Strip" //US
+		fingerprint mfr: "0086", prod: "0003", model: "0079", deviceJoinName: "Aeotec LED Strip" //EU
+	}
+
+	simulator {
+	}
+
+	tiles(scale: 2) {
+		multiAttributeTile(name:"switch", type: "lighting", width: 6, height: 4, canChangeIcon: true) {
+			tileAttribute("device.switch", key: "PRIMARY_CONTROL") {
+				attributeState("on", label:'${name}', action:"switch.off", icon:"st.lights.philips.hue-single", backgroundColor:"#00a0dc", nextState:"turningOff")
+				attributeState("off", label:'${name}', action:"switch.on", icon:"st.lights.philips.hue-single", backgroundColor:"#ffffff", nextState:"turningOn")
+				attributeState("turningOn", label:'${name}', action:"switch.off", icon:"st.lights.philips.hue-single", backgroundColor:"#00a0dc", nextState:"turningOff")
+				attributeState("turningOff", label:'${name}', action:"switch.on", icon:"st.lights.philips.hue-single", backgroundColor:"#ffffff", nextState:"turningOn")
+			}
+			tileAttribute ("device.level", key: "SLIDER_CONTROL") {
+				attributeState "level", action:"switch level.setLevel"
+			}
+			tileAttribute ("device.color", key: "COLOR_CONTROL") {
+				attributeState "color", action:"setColor"
+			}
+		}
+  	}
+  	controlTile("colorTempSliderControl", "device.colorTemperature", "slider", width: 2, height: 2, inactiveLabel: false, range:"(2700..6500)") {
+   	   state "colorTemperature", action:"color temperature.setColorTemperature"
+ 	 }
+	standardTile("reset", "device.reset", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
+		state "default", label:"Reset Color", action:"reset", icon:"st.lights.philips.hue-single"
+  	}
+	standardTile("refresh", "device.refresh", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
+		state "default", label:"Refresh", action:"refresh.refresh", icon:"st.secondary.refresh"
+	}
+
+	main(["switch"])
+	details(["switch", "colorTempSliderControl", "reset", "refresh"])
+}
+
+def updated() {
+     addDeviceWatch
+     response(refresh())
+}
+
+def installed() {
+     addDeviceWatch
+}
+
+def addDeviceWatch() {
+     // Device-Watch simply pings if no device events received for 122 min (checkInterval)
+     sendEvent(name: "checkInterval", value: 2 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
+}
+
+def parse(description) {
+	def result = null
+	if (description.startsWith("Err 106")) {
+		state.sec = 0
+	} else if (description != "updated") {
+		def cmd = zwave.parse(description, [0x20: 1, 0x26: 3, 0x70: 1, 0x33:3])
+		if (cmd) {
+			result = zwaveEvent(cmd)
+			log.debug("'$description' parsed to $result")
+		} else {
+			log.debug("Couldn't zwave.parse '$description'")
+		}
+	}
+	result
+}
+
+def zwaveEvent(physicalgraph.zwave.commands.basicv1.BasicReport cmd) {
+	dimmerEvents(cmd)
+}
+
+def zwaveEvent(physicalgraph.zwave.commands.basicv1.BasicSet cmd) {
+	dimmerEvents(cmd)
+}
+
+def zwaveEvent(physicalgraph.zwave.commands.switchmultilevelv3.SwitchMultilevelReport cmd) {
+	dimmerEvents(cmd)
+}
+
+private dimmerEvents(physicalgraph.zwave.Command cmd) {
+	def value = (cmd.value ? "on" : "off")
+	def result = [createEvent(name: "switch", value: value, descriptionText: "$device.displayName was turned $value")]
+	if (cmd.value) {
+		result << createEvent(name: "level", value: cmd.value == 99 ? 100 : cmd.value , unit: "%")
+	}
+	return result
+}
+
+def zwaveEvent(physicalgraph.zwave.commands.hailv1.Hail cmd) {
+	response(command(zwave.switchMultilevelV1.switchMultilevelGet()))
+}
+
+def zwaveEvent(physicalgraph.zwave.commands.securityv1.SecurityMessageEncapsulation cmd) {
+	def encapsulatedCommand = cmd.encapsulatedCommand([0x20: 1, 0x84: 1])
+	if (encapsulatedCommand) {
+		state.sec = 1
+		def result = zwaveEvent(encapsulatedCommand)
+		result = result.collect {
+			if (it instanceof physicalgraph.device.HubAction && !it.toString().startsWith("9881")) {
+				response(cmd.CMD + "00" + it.toString())
+			} else {
+				it
+			}
+		}
+		result
+	}
+}
+
+
+def zwaveEvent(physicalgraph.zwave.Command cmd) {
+	def linkText = device.label ?: device.name
+	[linkText: linkText, descriptionText: "$linkText: $cmd", displayed: false]
+}
+
+def on() {
+	command(zwave.basicV1.basicSet(value: 0xFF))
+}
+
+def off() {
+	command(zwave.basicV1.basicSet(value: 0x00))
+}
+
+def setLevel(level) {
+	setLevel(level, 1)
+}
+
+def setLevel(level, duration) {
+	if(level > 99) level = 99
+	command(zwave.switchMultilevelV3.switchMultilevelSet(value: level, dimmingDuration: duration))
+}
+
+def refresh() {
+	commands([
+		zwave.switchMultilevelV1.switchMultilevelGet(),
+	], 1000)
+}
+
+def setSaturation(percent) {
+	log.debug "setSaturation($percent)"
+	setColor(saturation: percent)
+}
+
+def setHue(value) {
+	log.debug "setHue($value)"
+	setColor(hue: value)
+}
+
+def setColor(value) {
+	def result = []
+	log.debug "setColor: ${value}"
+	if (value.hex) {
+		def c = value.hex.findAll(/[0-9a-fA-F]{2}/).collect { Integer.parseInt(it, 16) }
+		result << zwave.switchColorV3.switchColorSet(red:c[0], green:c[1], blue:c[2], warmWhite:0, coldWhite:0)
+	} else {
+    def rgb = huesatToRGB(value.hue, value.saturation)
+		result << zwave.switchColorV3.switchColorSet(red: rgb[0], green: rgb[1], blue: rgb[2], warmWhite:0, coldWhite:0)
+	}
+
+	if(value.hue) sendEvent(name: "hue", value: value.hue)
+	if(value.hex) sendEvent(name: "color", value: value.hex)
+	if(value.switch) sendEvent(name: "switch", value: value.switch)
+	if(value.saturation) sendEvent(name: "saturation", value: value.saturation)
+
+	commands(result)
+}
+
+def setColorTemperature(percent) {
+	if(percent > 99) percent = 99
+	int warmValue = percent * 255 / 99
+	command(zwave.switchColorV3.switchColorSet(red:0, green:0, blue:0, warmWhite:warmValue, coldWhite:(255 - warmValue)))
+}
+
+def reset() {
+	log.debug "reset()"
+	sendEvent(name: "color", value: "#ffffff")
+	setColorTemperature(99)
+}
+
+private command(physicalgraph.zwave.Command cmd) {
+	if (state.sec != 0) {
+		zwave.securityV1.securityMessageEncapsulation().encapsulate(cmd).format()
+	} else {
+		cmd.format()
+	}
+}
+
+private commands(commands, delay=200) {
+	delayBetween(commands.collect{ command(it) }, delay)
+}
+
+def rgbToHSV(red, green, blue) {
+	def hex = colorUtil.rgbToHex(red as int, green as int, blue as int)
+	def hsv = colorUtil.hexToHsv(hex)
+	return [hue: hsv[0], saturation: hsv[1], value: hsv[2]]
+}
+
+def huesatToRGB(hue, sat) {
+	def color = colorUtil.hsvToHex(Math.round(hue) as int, Math.round(sat) as int)
+	return colorUtil.hexToRgb(color)
+}
+
+def ping() {
+	refresh()
+}


### PR DESCRIPTION
Creation of a new "zwave-rgbw-bulb" to be the eventual replacement of the "rgbw-light" DTH which is not being maintained with recent changes and is for the most part a duplicate of "aeon-led-bulb".  Naming is also more consistent with other DTH's (zll-rgbw-bulb, zigbee-rgbw-bulb, etc).   Re: https://github.com/SmartThingsCommunity/SmartThingsPublic/pull/3599#issuecomment-432804367 @greens  

Source code is based on the aeon as it was most up to date.  Modifications made:
- Updated copyright
- Merged all fingerprints from both "aeon-led-bulb" and "rgbw-light" into this DTH
- Added metadata for ocfDeviceType, mnmn, and vid with proper identifiers
- Switched standard tile over to a multiAttributeTile to more closely match "zll-rgbw-bulb"
- Removed tiles no longer needed after conversion to mutliAttributeTile
- Added capabilities "Light" & "Health Check"
- Added a "addDeviceWatch" routine to add our checkInterval for device health
- Fixed a issue that would prevent "Red" and "Grey" from being set through hue/sat per fix here https://github.com/SmartThingsCommunity/SmartThingsPublic/pull/3633#issuecomment-434410557

Needs full testing but since code is 98% from existing working DTH it should be minimal.  Also would be nice once approved to have this added to locally run devices like other "generic" Z-Wave and ZigBee DTH's.  Eventually I would think the aeon-rgbw-bulb and rgbw-light can both be replaced by this (and possibly other z-wave rgbw devices) and hopefully can be the base for a zwave-rgb-bulb by just removing the color temperature capability and slider.

(This replaced a closed pull request that was outdated with recent above changes)