### PR TITLE
DVCSMP-4499 Z-Wave Lock: set manufacturer device data for LEE

### DIFF
--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -161,6 +161,7 @@ def uninstalled() {
 def updated() {
 	// Device-Watch pings if no device events received for 1 hour (checkInterval)
 	sendEvent(name: "checkInterval", value: 1 * 60 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
+	initializeManufacturerData()
 
 	def hubAction = null
 	try {
@@ -1738,6 +1739,15 @@ private isSamsungLock() {
 		return true
 	}
 	return false
+}
+
+/**
+ * Sets the manufacuter device data value so it can be used by LEE
+ *
+ */
+private initializeManufacturerData() {
+	// These utility functions init the data value if it hasn't been already
+	isSchlageLock() || isYaleLock() || isKwiksetLock() || isSamsungLock()
 }
 
 /**


### PR DESCRIPTION
Local execution for Z-Wave lock alarm report code 18 is currently relying on the manufacturer name being in device data, but it hasn't been getting set any more if everything is handled locally.