### PR TITLE
WWST-1624 Add enrollResponse() back to refresh()

### DIFF
--- a/devicetypes/smartthings/zigbee-dimmer-with-motion-sensor.src/zigbee-dimmer-with-motion-sensor.groovy
+++ b/devicetypes/smartthings/zigbee-dimmer-with-motion-sensor.src/zigbee-dimmer-with-motion-sensor.groovy
@@ -139,7 +139,7 @@ def ping() {
 }
 
 def refresh() {
-	zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.readAttribute(zigbee.IAS_ZONE_CLUSTER, zigbee.ATTRIBUTE_IAS_ZONE_STATUS)
+	zigbee.onOffRefresh() + zigbee.levelRefresh() + zigbee.readAttribute(zigbee.IAS_ZONE_CLUSTER, zigbee.ATTRIBUTE_IAS_ZONE_STATUS) + zigbee.enrollResponse()
 }
 
 def setupHealthCheck() {


### PR DESCRIPTION
While it isn't necessary to handle the "enroll request" message in parse(), we do need to send an enrollResponse() to the bulb in order to receive the motion events.