### PR TITLE
WWST-1624 Add enrollResponse() to configure()

### DIFF
--- a/devicetypes/smartthings/zigbee-dimmer-with-motion-sensor.src/zigbee-dimmer-with-motion-sensor.groovy
+++ b/devicetypes/smartthings/zigbee-dimmer-with-motion-sensor.src/zigbee-dimmer-with-motion-sensor.groovy
@@ -157,5 +157,5 @@ def configure() {
 	setupHealthCheck()
 
 	// OnOff minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
-	zigbee.onOffConfig(0, 300) + zigbee.levelConfig() + refresh()
+	zigbee.onOffConfig(0, 300) + zigbee.levelConfig() + zigbee.enrollResponse() + refresh()
 }


### PR DESCRIPTION
While it isn't necessary to handle the "enroll request" message in parse(), we do need to send an enrollResponse() to the bulb in order to receive the motion events.