### PR TITLE
[ICP-7026] Fix to fingerprint for GoControl Z-wave Thermostat. 

### DIFF
--- a/devicetypes/smartthings/zwave-battery-thermostat.src/zwave-battery-thermostat.groovy
+++ b/devicetypes/smartthings/zwave-battery-thermostat.src/zwave-battery-thermostat.groovy
@@ -37,7 +37,7 @@ metadata {
 
 		fingerprint inClusters: "0x43,0x40,0x44,0x31,0x80"
 		fingerprint mfr: "014F", prod: "5442", model: "5431", deviceJoinName: "Linear Z-Wave Thermostat"
-		fingerprint mfr: "014F", prod: "5442", model: "5436", deviceJoinName: "Go Control Z-Wave Thermostat"
+		fingerprint mfr: "014F", prod: "5442", model: "5436", deviceJoinName: "GoControl Z-Wave Thermostat"
 	}
 
 	tiles {


### PR DESCRIPTION
@MAblewiczS @DCzarneckaS @KKlimczukS 
Could you review this? 