### PR TITLE
Wwst-989 Add Ikea TRADFRI bulb E14 W op/ch 400lm fingerprint

### DIFF
--- a/devicetypes/smartthings/zll-dimmer-bulb.src/zll-dimmer-bulb.groovy
+++ b/devicetypes/smartthings/zll-dimmer-bulb.src/zll-dimmer-bulb.groovy
@@ -44,6 +44,8 @@ metadata {
 		fingerprint profileId: "C05E", inClusters: "0000, 0003, 0004, 0005, 0006, 0008", outClusters: "0019", manufacturer: "innr", model: "RB 175 W", deviceJoinName: "innr Smart Bulb (Warm Dimming)"
 		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 0702, 0B05", outClusters: "0019", manufacturer: "sengled", model: "E14-U43", deviceJoinName: "Sengled E14-U43"
 		fingerprint profileId: "C05E", inClusters: "0000, 0003, 0004, 0005, 0006, 0008", outClusters: "0019", manufacturer: "innr", model: "RB 145", deviceJoinName: "innr Smart Candle"
+		//IKEA TRADFRI bulb E14 W op/ch 400lm: 01 C05E 0100 02 08 0000 0003 0004 0005 0006 0008 0B05 1000 04 0005 0019 0020 1000
+		fingerprint profileId: "C05E", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 0300, 0B05, 1000", outClusters: "0005, 0019, 0020, 1000", manufacturer: "IKEA of Sweden", model: "TRADFRI bulb E14 W op/ch 400lm", deviceJoinName: "IKEA TRADFRI LED Bulb"
 
 	}
 

--- a/devicetypes/smartthings/zll-dimmer-bulb.src/zll-dimmer-bulb.groovy
+++ b/devicetypes/smartthings/zll-dimmer-bulb.src/zll-dimmer-bulb.groovy
@@ -45,7 +45,7 @@ metadata {
 		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 0702, 0B05", outClusters: "0019", manufacturer: "sengled", model: "E14-U43", deviceJoinName: "Sengled E14-U43"
 		fingerprint profileId: "C05E", inClusters: "0000, 0003, 0004, 0005, 0006, 0008", outClusters: "0019", manufacturer: "innr", model: "RB 145", deviceJoinName: "innr Smart Candle"
 		//IKEA TRADFRI bulb E14 W op/ch 400lm: 01 C05E 0100 02 08 0000 0003 0004 0005 0006 0008 0B05 1000 04 0005 0019 0020 1000
-		fingerprint profileId: "C05E", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 0300, 0B05, 1000", outClusters: "0005, 0019, 0020, 1000", manufacturer: "IKEA of Sweden", model: "TRADFRI bulb E14 W op/ch 400lm", deviceJoinName: "IKEA TRADFRI LED Bulb"
+		fingerprint profileId: "C05E", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 0B05, 1000", outClusters: "0005, 0019, 0020, 1000", manufacturer: "IKEA of Sweden", model: "TRADFRI bulb E14 W op/ch 400lm", deviceJoinName: "IKEA TRADFRI LED Bulb"
 
 	}
 


### PR DESCRIPTION
Wwst-989 Add Ikea TRADFRI bulb E14 W op/ch 400lm fingerprint