### PR TITLE
ICP-7041 Remove false isStateChange from Zigbee Accessory Dimmer initial events

### DIFF
--- a/devicetypes/smartthings/zigbee-accessory-dimmer.src/zigbee-accessory-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-accessory-dimmer.src/zigbee-accessory-dimmer.groovy
@@ -120,9 +120,9 @@ def setLevel(value) {
 }
 
 def installed() {
-	sendEvent(name: "switch", value: "on", isStateChange: false, displayed: false)
-	sendEvent(name: "level", value: 100, isStateChange: false, displayed: false)
-	sendEvent(name: "button", value: "pushed", data: [buttonNumber: 1], isStateChange: false, displayed: false)
+	sendEvent(name: "switch", value: "on", displayed: false)
+	sendEvent(name: "level", value: 100, displayed: false)
+	sendEvent(name: "button", value: "pushed", data: [buttonNumber: 1], displayed: false)
 	sendEvent(name: "numberOfButtons", value: 1, displayed: false)
 }
 


### PR DESCRIPTION
Events were being discarded because of the "isStateChange: false" attribute.