### PR TITLE
ICP-6895 Add Vid that point to new metadata with power source support

### DIFF
--- a/devicetypes/smartthings/zigbee-thermostat.src/zigbee-thermostat.groovy
+++ b/devicetypes/smartthings/zigbee-thermostat.src/zigbee-thermostat.groovy
@@ -19,7 +19,7 @@
 import physicalgraph.zigbee.zcl.DataType
 
 metadata {
-	definition (name: "Zigbee Thermostat", namespace: "smartthings", author: "SmartThings", mnmn: "SmartThings", vid: "SmartThings-smartthings-Z-Wave_Battery_Thermostat") {
+	definition (name: "Zigbee Thermostat", namespace: "smartthings", author: "SmartThings", mnmn: "SmartThings", vid: "generic-thermostat-1") {
 		capability "Actuator"
 		capability "Temperature Measurement"
 		capability "Thermostat"


### PR DESCRIPTION
Add Vid that point to new metadata with power source support
@greens @tpmanley   Please review this. Metadata from that vid is deployed on STG.