### PR TITLE
WWST-1615 Adding fingerprint for Ozom Smart Carbon Monoxide Sensor

### DIFF
--- a/devicetypes/smartthings/zigbee-smoke-sensor.src/zigbee-smoke-sensor.groovy
+++ b/devicetypes/smartthings/zigbee-smoke-sensor.src/zigbee-smoke-sensor.groovy
@@ -29,6 +29,7 @@ metadata {
 		capability "Health Check"
 
 		fingerprint profileId: "0104", deviceId: "0402", inClusters: "0000,0001,0003,0500,0502,0009", outClusters: "0019", manufacturer: "Heiman", model: "b5db59bfd81e4f1f95dc57fdbba17931", deviceJoinName: "Orvibo Smoke Sensor"
+		fingerprint profileId: "0104", deviceId: "0402", inClusters: "0000,0003,0500", outClusters: "0000", manufacturer: "ClimaxTechnology", model: "CO_00.00.00.22TC", deviceJoinName: "Ozom Smart Carbon Monoxide Sensor"
 	}
 
 	tiles {


### PR DESCRIPTION
Dears,
@mckeed @tpmanley @MAblewiczS @greens 

Could you please approve this change ?
Note: This device does not has battery status monitoring once cluster 0x0001 is not present in device spec.

Best regards,