### PR TITLE
[WWST-2009] Corrected Fibaro Dimmer 2 fingerprint for Chile

### DIFF
--- a/devicetypes/fibargroup/fibaro-dimmer-2-zw5.src/fibaro-dimmer-2-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-dimmer-2-zw5.src/fibaro-dimmer-2-zw5.groovy
@@ -18,6 +18,7 @@ metadata {
 
 		fingerprint mfr: "010F", prod: "0102", model: "2000"
 		fingerprint mfr: "010F", prod: "0102", model: "1000"
+		fingerprint mfr: "010F", prod: "0102", model: "3000"
 	}
 
 	tiles (scale: 2) {


### PR DESCRIPTION
@tpmanley @greens Please check DTH to correct Fibaro Dimmer 2 fingerprint for Chile.
Raw Description of device: 
zw:Ls type:1101 mfr:010F prod:0102 model:3000 ver:3.05 zwv:4.05 lib:03 cc:5E,86,72,59,73,22,31,32,71,56,98,7A sec:20,5A,85,26,8E,60,70,75,27 secOut:2B role:05 ff:8600 ui:8600 ep:['1101 5E,20,86,26,85,59,8E,32,31,71', '1101 5E,20,86,26,85,59,8E']