### PR TITLE
ONEAPP-7319 Send an initial button event to appease OCF

### DIFF
--- a/devicetypes/smartthings/zigbee-button.src/zigbee-button.groovy
+++ b/devicetypes/smartthings/zigbee-button.src/zigbee-button.groovy
@@ -245,6 +245,11 @@ private Map getButtonResult(buttonState, buttonNumber = 1) {
 
 def installed() {
     initialize()
+
+    // Initialize default states
+    device.currentValue("numberOfButtons")?.times {
+        sendEvent(name: "button", value: "pushed", data: [buttonNumber: it+1], displayed: false)
+    }
 }
 
 def updated() {
@@ -255,25 +260,25 @@ def initialize() {
     // Arrival sensors only goes OFFLINE when Hub is off
     sendEvent(name: "DeviceWatch-Enroll", value: JsonOutput.toJson([protocol: "zigbee", scheme:"untracked"]), displayed: false)
     if ((device.getDataValue("manufacturer") == "OSRAM") && (device.getDataValue("model") == "LIGHTIFY Dimming Switch")) {
-        sendEvent(name: "numberOfButtons", value: 2)
+        sendEvent(name: "numberOfButtons", value: 2, displayed: false)
     }
     else if (device.getDataValue("manufacturer") == "CentraLite") {
         if (device.getDataValue("model") == "3130") {
-            sendEvent(name: "numberOfButtons", value: 2)
+            sendEvent(name: "numberOfButtons", value: 2, displayed: false)
         }
         else if ((device.getDataValue("model") == "3455-L") || (device.getDataValue("model") == "3460-L")) {
-            sendEvent(name: "numberOfButtons", value: 1)
+            sendEvent(name: "numberOfButtons", value: 1, displayed: false)
         }
         else if (device.getDataValue("model") == "3450-L") {
-            sendEvent(name: "numberOfButtons", value: 4)
+            sendEvent(name: "numberOfButtons", value: 4, displayed: false)
         }
         else {
-            sendEvent(name: "numberOfButtons", value: 4)    //default case. can be changed later.
+            sendEvent(name: "numberOfButtons", value: 4, displayed: false)    //default case. can be changed later.
         }
     }
     else {
         //default. can be changed
-        sendEvent(name: "numberOfButtons", value: 4)
+        sendEvent(name: "numberOfButtons", value: 4, displayed: false)
     }
 
 }


### PR DESCRIPTION
Button capability is momentary, so initial event is "pushed"