### PR TITLE
ICP-7202

### DIFF
--- a/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
+++ b/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
@@ -16,7 +16,7 @@
  *  Date: 2014-07-15
  */
 metadata {
-	definition(name: "KK Z-Wave Siren 2", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "x.com.st.d.siren", runLocally: true, minHubCoreVersion: '000.017.0012', executeCommandsLocally: false) {
+	definition(name: "Z-Wave Siren", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "x.com.st.d.siren", runLocally: true, minHubCoreVersion: '000.017.0012', executeCommandsLocally: false) {
 		capability "Actuator"
 		capability "Alarm"
 		capability "Battery"


### PR DESCRIPTION
@greens @MAblewiczS @MGoralczykS @DCzarneckaS @MMateusiakS @PKacprowiczS 
Please, could You take a look ?
 
DTH relied too much on NotificationReport (the state on/off was set to according to it). Meanwhile workaround for cleaning tamper was added and it caused switching siren OFF after few seconds. In case of Yale Siren tamper only activates the siren and doesn't change it's internal state (SwitchBinaryGet reported 0 when the siren was ON), that's why we shouldn't rely on it.
