### PR TITLE
ONEAPP-8927 Ecolink Zigbee Water/Freeze Sensor: Set initial state for temperatureAlarm

### DIFF
--- a/devicetypes/smartthings/ecolink-zigbee-water-freeze-sensor.src/ecolink-zigbee-water-freeze-sensor.groovy
+++ b/devicetypes/smartthings/ecolink-zigbee-water-freeze-sensor.src/ecolink-zigbee-water-freeze-sensor.groovy
@@ -75,6 +75,7 @@ private getDEVICE_CHECK_IN_INTERVAL_VAL_INT() { 30 * 60 }
 
 def installed() {
 	sendEvent(name: "water", value: "dry", displayed: false)
+	sendEvent(name: "temperatureAlarm", value: "cleared", displayed: false)
 	refresh()
 }
 


### PR DESCRIPTION
By default the Temperature Alarm will be set to 'cleared'.

https://smartthings.atlassian.net/browse/ONEAPP-8927