### PR TITLE
WWST-1485 Zigbee Multi Switch: Fix child device naming

### DIFF
--- a/devicetypes/smartthings/zigbee-multi-switch.src/zigbee-multi-switch.groovy
+++ b/devicetypes/smartthings/zigbee-multi-switch.src/zigbee-multi-switch.groovy
@@ -96,7 +96,7 @@ def parse(String description) {
 private void createChildDevices() {
 	def i = 2
 	addChildDevice("Child Switch Health", "${device.deviceNetworkId}:0${i}", device.hubId,
-			[completedSetup: true, label: "${device.displayName.split("1")[-1]}${i}", isComponent : false])
+			[completedSetup: true, label: "${device.displayName[0..-2]}${i}", isComponent : false])
 }
 
 private getChildEndpoint(String dni) {


### PR DESCRIPTION
The Chinese translation for the join name is "智能墙面开关 三星智家(T21W2Z) 1"
which wasn't working because of the "1" in the join name. I changed it to
just replace the last character with the switch number. This obviously
won't work if the switch number is not at the end or if there are more
than 9 switches.

https://smartthings.atlassian.net/browse/WWST-1485

FYI @FenMei007S I tweaked your change a little bit and pulled it out into its own PR