### PR TITLE
DVCSMP-3179 Zigbee Switch: Ikea control outlet fingerprint

### DIFF
--- a/devicetypes/smartthings/zigbee-switch.src/zigbee-switch.groovy
+++ b/devicetypes/smartthings/zigbee-switch.src/zigbee-switch.groovy
@@ -31,6 +31,7 @@ metadata {
 		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0019", manufacturer: "Third Reality, Inc", model: "3RSS008Z", deviceJoinName: "RealitySwitch Plus"
 		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0019", manufacturer: "Third Reality, Inc", model: "3RSS007Z", deviceJoinName: "RealitySwitch"
 		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0B05", outClusters: "0003, 0006, 0019", manufacturer: "Centralite Systems", model: "4200-C", deviceJoinName: "Centralite Smart Outlet"
+		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, FC7C", outClusters: "0005, 0019, 0020", manufacturer:"IKEA of Sweden", model: "TRADFRI control outlet", deviceJoinName: "IKEA TRÅDFRI control outlet"
 	}
 
 	// simulator metadata


### PR DESCRIPTION
Fingerprint info:
- application: 14
- manufacturer: IKEA of Sweden
- model: TRADFRI control outlet
- simple: 01 0104 010A 00 07 0000 0003 0004 0005 0006 0008 FC7C 03 0005 0019 0020

https://smartthings.atlassian.net/browse/DVCSMP-3179