### PR TITLE
ICP-7540 Add color control binding for zigbee rgb bulbs

### DIFF
--- a/devicetypes/smartthings/zigbee-rgb-bulb.src/zigbee-rgb-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-rgb-bulb.src/zigbee-rgb-bulb.groovy
@@ -128,6 +128,7 @@ def refresh() {
 	zigbee.levelRefresh() +
 	zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE) +
 	zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION) +
+	zigbee.addBinding(COLOR_CONTROL_CLUSTER) +
 	zigbee.onOffConfig(0, 300) +
 	zigbee.levelConfig()
 }

--- a/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
@@ -166,6 +166,7 @@ def refresh() {
 			zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_COLOR_TEMPERATURE) +
 			zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE) +
 			zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION) +
+			zigbee.addBinding(COLOR_CONTROL_CLUSTER) +
 			zigbee.onOffConfig(0, 300) +
 			zigbee.levelConfig()
 }

--- a/devicetypes/smartthings/zll-rgb-bulb.src/zll-rgb-bulb.groovy
+++ b/devicetypes/smartthings/zll-rgb-bulb.src/zll-rgb-bulb.groovy
@@ -138,6 +138,7 @@ def configureAttributes() {
 def refreshAttributes() {
 	zigbee.onOffRefresh() +
 	zigbee.levelRefresh() +
+	zigbee.addBinding(COLOR_CONTROL_CLUSTER) +
 	zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE) +
 	zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION)
 }

--- a/devicetypes/smartthings/zll-rgbw-bulb.src/zll-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zll-rgbw-bulb.src/zll-rgbw-bulb.groovy
@@ -181,6 +181,7 @@ def refreshAttributes() {
     zigbee.onOffRefresh() +
     zigbee.levelRefresh() +
     zigbee.colorTemperatureRefresh() +
+    zigbee.addBinding(COLOR_CONTROL_CLUSTER) +
     zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE) +
     zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION)
 }


### PR DESCRIPTION
Some bulbs have the ability to manually change their colors. This should prompt the device to notify us of those events.