### PR TITLE
ICP-7715 SmartAlert Siren: Exception when calling ping method

### DIFF
--- a/devicetypes/smartthings/smartalert-siren.src/smartalert-siren.groovy
+++ b/devicetypes/smartthings/smartalert-siren.src/smartalert-siren.groovy
@@ -166,5 +166,5 @@ def zwaveEvent(physicalgraph.zwave.Command cmd) {
  * PING is used by Device-Watch in attempt to reach the Device
  * */
 def ping() {
-	secure(zwave.basicV1.basicGet())
+	zwave.basicV1.basicGet().format()
 }


### PR DESCRIPTION
The `ping` method was using the `secure` method even though it wasn't defined in this DTH and the Fortrezz Siren doesn't use secure encapsulation. This means all calls to `ping` were crashing so Device Watch couldn't ping the device which likely resulted in these devices being incorrectly marked
offline.

https://smartthings.atlassian.net/browse/ICP-7715