### PR TITLE
WWST-2091 Update to SmartWeather Station UI metadata

### DIFF
--- a/devicetypes/smartthings/smartweather-station-tile.src/smartweather-station-tile.groovy
+++ b/devicetypes/smartthings/smartweather-station-tile.src/smartweather-station-tile.groovy
@@ -17,7 +17,11 @@
  *  Date: 2013-04-30
  */
 metadata {
-    definition (name: "SmartWeather Station Tile", namespace: "smartthings", author: "SmartThings") {
+    definition (name: "SmartWeather Station Tile", namespace: "smartthings", author: "SmartThings",
+            ocfDeviceType: "oic.d.thermostat",
+            mnmn: "SmartThings",
+            vid:"SmartThings-smartthings-SmartSense_Temp/Humidity_Sensor") {
+
         capability "Illuminance Measurement"
         capability "Temperature Measurement"
         capability "Relative Humidity Measurement"


### PR DESCRIPTION
Change to UI metadata and OCF device type so that device displays current temperature properly on the One App dashboard and device list view.