### PR TITLE
[WWST-2089] Change severe weather to use lat/long instead of zipCode for alerts

### DIFF
--- a/smartapps/smartthings/severe-weather-alert.src/severe-weather-alert.groovy
+++ b/smartapps/smartthings/severe-weather-alert.src/severe-weather-alert.groovy
@@ -78,10 +78,7 @@ def scheduleJob() {
 def checkForSevereWeather() {
     def alerts
     if(locationIsDefined()) {
-        if(!(zipcodeIsValid())) {
-            log.warn "Severe Weather Alert: Invalid zipcode entered, defaulting to location's zipcode"
-        }
-        alerts = getTwcAlerts(zipCode)
+        alerts = getTwcAlerts() // Will fallback to using location lat/long since we're not passing zipCode
     } else {
         log.warn "Severe Weather Alert: Location is not defined"
     }


### PR DESCRIPTION
The TWC alerts API doesn't support zip codes, so this PR just removes the zip from being passed into the  `getTwcAlerts` method call since the `CloudIntegrationService.getTwcFeature` logic under the hood will fallback to using the lat/long from the location if zipCode is null. Also, removed the `zipcodeIsValid` check since that logic is busted which means we're always going to log that warn and no need to check the zip if we're not going to use it for the alerts call anyways.

/cc @bflorian @juano2310 