### PR TITLE
Fix return value to avoid an exception

### DIFF
--- a/devicetypes/smartthings/smartweather-station-tile.src/smartweather-station-tile.groovy
+++ b/devicetypes/smartthings/smartweather-station-tile.src/smartweather-station-tile.groovy
@@ -292,6 +292,8 @@ def poll() {
     else {
         log.warn "No response from TWC API"
     }
+    
+    return null
 }
 
 def parseAlertTime(s) {


### PR DESCRIPTION
Return `null` from `poll()` and `refresh()` otherwise when a SA calls the `refresh` method it results in an error:
`error groovy.lang.MissingMethodException: No signature of method: physicalgraph.device.HubMultiAction.add() is applicable for argument types: (groovy.json.internal.LazyMap)`

@juano2310  @bflorian 