### PR TITLE
ICP-8046 Z-Wave Siren mistakenly always send 10 config commands

### DIFF
--- a/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
+++ b/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
@@ -123,7 +123,7 @@ def initialize() {
 
 	// if there's anything we need to send, send it now, and check again in 12s
 	if (cmds.size > 0) {
-		sendHubCommands(cmds)
+		sendHubCommand(cmds)
 		runIn(12, "initialize", [overwrite: true, forceForLocallyExecuting: true])
 	}
 }
@@ -317,6 +317,7 @@ def zwaveEvent(physicalgraph.zwave.commands.configurationv2.ConfigurationReport 
 	} else {
 		state.configured = true
 	}
+    return [:]
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.basicv1.BasicReport cmd) {

--- a/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
+++ b/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
@@ -317,7 +317,7 @@ def zwaveEvent(physicalgraph.zwave.commands.configurationv2.ConfigurationReport 
 	} else {
 		state.configured = true
 	}
-    return [:]
+	return [:]
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.basicv1.BasicReport cmd) {

--- a/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
+++ b/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
@@ -92,6 +92,7 @@ def installed() {
 
 def updated() {
 	log.debug "updated()"
+	state.configured = false
 	// Device-Watch simply pings if no device events received for 122min(checkInterval)
 	sendEvent(name: "checkInterval", value: 2 * 60 * 60 + 2 * 60, isStateChanged: true, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
 	runIn(12, "initialize", [overwrite: true, forceForLocallyExecuting: true])
@@ -100,16 +101,6 @@ def updated() {
 def initialize() {
 	log.debug "initialize()"
 	def cmds = []
-
-	// Set a limit to the number of times that we run so that we don't run forever and ever
-	if (!state.initializeCount) {
-		state.initializeCount = 1
-	} else if (state.initializeCount <= 10) { // Keep checking for ~2 mins (10 * 12 sec intervals)
-		state.initializeCount = state.initializeCount + 1
-	} else {
-		state.initializeCount = 0
-		return // TODO: This might be a good opportunity to mark the device unhealthy
-	}
 
 	if (!device.currentState("alarm")) {
 		cmds << secure(zwave.basicV1.basicGet())
@@ -125,12 +116,15 @@ def initialize() {
 			sendEvent(name: "battery", value: 100, unit: "%")
 		}
 	}
-	cmds << getConfigurationCommands()
-	if (cmds.size()) {
-		sendHubCommand(cmds)
+	if (!state.configured) {
+        // if this flag is not set, we have not successfully configured
+		cmds << getConfigurationCommands()
+	}
+
+    // if there's anything we need to send, send it now, and check again in 12s
+	if (cmds.size > 0) {
+		sendHubCommands(cmds)
 		runIn(12, "initialize", [overwrite: true, forceForLocallyExecuting: true])
-	} else {
-		state.initializeCount = 0
 	}
 }
 
@@ -144,13 +138,13 @@ def getConfigurationCommands() {
 	def cmds = []
 	if (isZipato()) {
 		// Set alarm volume to 3 (loud)
-		cmds << secure(zwave.configurationV1.configurationSet(parameterNumber: 1, size: 1, configurationValue: [3]))
+		cmds << secure(zwave.configurationV2.configurationSet(parameterNumber: 1, size: 1, configurationValue: [3]))
 		cmds << "delay 500"
 		// Set alarm duration to 60s (default)
-		cmds << secure(zwave.configurationV1.configurationSet(parameterNumber: 2, size: 1, configurationValue: [2]))
+		cmds << secure(zwave.configurationV2.configurationSet(parameterNumber: 2, size: 1, configurationValue: [2]))
 		cmds << "delay 500"
 		// Set alarm sound to no.10
-		cmds << secure(zwave.configurationV1.configurationSet(parameterNumber: 5, size: 1, configurationValue: [10]))
+		cmds << secure(zwave.configurationV2.configurationSet(parameterNumber: 5, size: 1, configurationValue: [10]))
 	} else if (isYale()) {
 		if (!state.alarmLength) state.alarmLength = 10 // default value
 		if (!state.alarmLEDflash) state.alarmLEDflash = true // default value
@@ -171,13 +165,22 @@ def getConfigurationCommands() {
 			state.comfortLED = comfortLED
 			state.tamper = tamper
 
-			cmds << secure(zwave.configurationV1.configurationSet(parameterNumber: 1, size: 1, configurationValue: [alarmLength]))
-			cmds << secure(zwave.configurationV1.configurationSet(parameterNumber: 2, size: 1, configurationValue: [alarmLEDflash ? 1 : 0]))
-			cmds << secure(zwave.configurationV1.configurationSet(parameterNumber: 3, size: 1, configurationValue: [comfortLED]))
-			cmds << secure(zwave.configurationV1.configurationSet(parameterNumber: 4, size: 1, configurationValue: [tamper ? 1 : 0]))
+			cmds << secure(zwave.configurationV2.configurationSet(parameterNumber: 1, size: 1, configurationValue: [alarmLength]))
+			cmds << secure(zwave.configurationV2.configurationSet(parameterNumber: 2, size: 1, configurationValue: [alarmLEDflash ? 1 : 0]))
+			cmds << secure(zwave.configurationV2.configurationSet(parameterNumber: 3, size: 1, configurationValue: [comfortLED]))
+			cmds << secure(zwave.configurationV2.configurationSet(parameterNumber: 4, size: 1, configurationValue: [tamper ? 1 : 0]))
 			cmds << "delay 1000"
 			cmds << secure(zwave.basicV1.basicSet(value: 0x00))
+		} else {
+			state.configured = true
 		}
+	} else {
+		// if there's nothing to configure, we're configured
+		state.configured = true
+	}
+    if (cmds.size > 0) {
+        // send this last to confirm we were heard
+		cmds << secure(zwave.configurationV2.configurationGet(parameterNumber: 1))
 	}
 	cmds
 }
@@ -297,6 +300,22 @@ def zwaveEvent(physicalgraph.zwave.commands.securityv1.SecurityMessageEncapsulat
 	log.debug "encapsulated: $encapsulatedCommand"
 	if (encapsulatedCommand) {
 		zwaveEvent(encapsulatedCommand)
+	}
+}
+
+def zwaveEvent(physicalgraph.zwave.commands.configurationv2.ConfigurationReport cmd) {
+	def checkVal
+	// the last message sent by configure is a configuration get, so if we get a report, we succeeded in transmission
+	// and if the parameter 1 values match what we expect, then the configuration probably succeeded
+	if (isZipato()) {
+		checkVal = 3
+	} else if (isYale()) {
+		checkVal = state.alarmLength
+	}
+	if (checkVal) {
+		state.configured = (checkVal == cmd.scaledConfigurationValue)
+	} else {
+		state.configured = true
 	}
 }
 

--- a/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
+++ b/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
@@ -312,7 +312,7 @@ def zwaveEvent(physicalgraph.zwave.commands.configurationv2.ConfigurationReport 
 	} else if (isYale()) {
 		checkVal = state.alarmLength
 	}
-	if (checkVal) {
+	if (checkVal != null) {
 		state.configured = (checkVal == cmd.scaledConfigurationValue)
 	} else {
 		state.configured = true

--- a/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
+++ b/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
@@ -117,11 +117,11 @@ def initialize() {
 		}
 	}
 	if (!state.configured) {
-        // if this flag is not set, we have not successfully configured
+		// if this flag is not set, we have not successfully configured
 		cmds << getConfigurationCommands()
 	}
 
-    // if there's anything we need to send, send it now, and check again in 12s
+	// if there's anything we need to send, send it now, and check again in 12s
 	if (cmds.size > 0) {
 		sendHubCommands(cmds)
 		runIn(12, "initialize", [overwrite: true, forceForLocallyExecuting: true])
@@ -178,8 +178,8 @@ def getConfigurationCommands() {
 		// if there's nothing to configure, we're configured
 		state.configured = true
 	}
-    if (cmds.size > 0) {
-        // send this last to confirm we were heard
+	if (cmds.size > 0) {
+		// send this last to confirm we were heard
 		cmds << secure(zwave.configurationV2.configurationGet(parameterNumber: 1))
 	}
 	cmds


### PR DESCRIPTION
This rework attempts to move away from a counter to a flag-based system based on receiving a config report with a correct value in it.