### PR TITLE
ICP-7503 CN Translation for Samsung Smart Doorlock

### DIFF
--- a/devicetypes/samsungsds/samsung-smart-doorlock.src/i18n/message.properties
+++ b/devicetypes/samsungsds/samsung-smart-doorlock.src/i18n/message.properties
@@ -13,4 +13,4 @@
 #  under the License.
 
 # Chinese
-'''SAMSUNG SDS'''.zh-cn=SDS联网型智能锁
+'''Samsung Smart Doorlock'''.zh-cn=SDS联网型智能锁


### PR DESCRIPTION
Previous PR was for the manufacturer name, not the join name.