### PR TITLE
CHAD-2943: Add AlarmReport V2 to Parse + User Code Get after Set

### DIFF
--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -248,7 +248,7 @@ def parse(String description) {
 			)
 		}
 	} else {
-		def cmd = zwave.parse(description, [ 0x98: 1, 0x72: 2, 0x85: 2, 0x86: 1 ])
+		def cmd = zwave.parse(description, [ 0x98: 1, 0x62: 1, 0x63: 1, 0x71: 2, 0x72: 2, 0x80: 1, 0x85: 2, 0x86: 1 ])
 		if (cmd) {
 			result = zwaveEvent(cmd)
 		}
@@ -1341,6 +1341,7 @@ def setCode(codeID, code, codeName = null) {
 
 	def cmds = validateAttributes()
 	cmds << secure(zwave.userCodeV1.userCodeSet(userIdentifier:codeID, userIdStatus:1, user:code))
+	cmds << requestCode(userIdentifier:codeID)
 	if(cmds.size() > 1) {
 		cmds = delayBetween(cmds, 4200)
 	}


### PR DESCRIPTION
We need to specify Version 2 when parsing Alarm Report Z-Wave messages since by default the message would be identified as a Notification Report message and there is not a handler for the newer command class messages. The version 2 was being specified when unwrapping secure encrypted messages, and so therefore those command classes and their associated versions were copied to the parse() method. This change is needed since in 0.25.X release we are going to remove the encryption header at the hub level before forwarding the message to the cloud. As a result, we must also specify the version at the parse level.

As is, Z-Wave lock DTH is assuming that after setting a user code, the device will respond itself, and that is true for some locks, but it is better to issue a User Code Get after each set to ensure we have a feedback for the locks that do not respond automatically to User Code Sets.