### PR TITLE
[ICP-8433] Zigbee Plugin Motion Sensor: Remove blank manufacturer from fingerprint

### DIFF
--- a/devicetypes/smartthings/zigbee-plugin-motion-sensor.src/zigbee-plugin-motion-sensor.groovy
+++ b/devicetypes/smartthings/zigbee-plugin-motion-sensor.src/zigbee-plugin-motion-sensor.groovy
@@ -23,7 +23,7 @@ metadata {
         capability "Health Check"
         capability "Sensor"
        
-        fingerprint profileId: "0104", deviceId: "0107", inClusters: "0000, 0003, 0004, 0406", outClusters:"0006, 0019", manufacturer:"", model:"E280-KR0A0Z0-HA", deviceJoinName: "Smart Occupancy Sensor (AC Type)"
+        fingerprint profileId: "0104", deviceId: "0107", inClusters: "0000, 0003, 0004, 0406", outClusters: "0006, 0019", model: "E280-KR0A0Z0-HA", deviceJoinName: "Smart Occupancy Sensor (AC Type)"
     }
     tiles(scale: 2) {
         multiAttributeTile(name: "motion", type: "generic", width: 6, height: 4) {


### PR DESCRIPTION
We believe the blank manufacturer value in the fingerprint was being handled incorrectly by the fingerprinting system and while we are going to make the fingerprinting system handle this in the future the quickest fix is to remove the blank manufacturer from the fingerprint altogether.

https://smartthings.atlassian.net/browse/ICP-8433