### PR TITLE
[ICP-8538] Removed checkInterval for Aeotec NanoMote One

### DIFF
--- a/devicetypes/smartthings/zwave-button.src/zwave-button.groovy
+++ b/devicetypes/smartthings/zwave-button.src/zwave-button.groovy
@@ -13,6 +13,7 @@
  *  for the specific language governing permissions and limitations under the License.
  *
  */
+import groovy.json.JsonOutput
 
 metadata {
 	definition (name: "Z-Wave Button", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "x.com.st.d.remotecontroller" ,vid: "generic-button-4") {
@@ -43,7 +44,11 @@ metadata {
 }
 
 def installed() {
-	sendEvent(name: "checkInterval", value: 8 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
+	if(zwaveInfo.mfr?.contains("0371")) {
+		sendEvent(name: "DeviceWatch-Enroll", value: JsonOutput.toJson([protocol: "zwave", scheme:"untracked"]), displayed: false)
+	} else {
+		sendEvent(name: "checkInterval", value: 8 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
+	}
 	sendEvent(name: "numberOfButtons", value: 1)
 	sendEvent(name: "button", value: "pushed", data: [buttonNumber: 1])
 	response([


### PR DESCRIPTION
ICP-8539, ICP-8524, ICP-8523
We cannot track device health, cause wakeUpInterval has value 0 seconds and we're unable to change it, which causes that device doesn't wake up by itself in set interval - wake up events can be only triggered manually by user.
@greens @MMateusiakS @KKlimczukS @MGoralczykS @DCzarneckaS 