### PR TITLE
ICP-8469 Child devices do not display during setup screen

### DIFF
--- a/devicetypes/smartthings/zigbee-multi-switch.src/zigbee-multi-switch.groovy
+++ b/devicetypes/smartthings/zigbee-multi-switch.src/zigbee-multi-switch.groovy
@@ -96,7 +96,7 @@ def parse(String description) {
 private void createChildDevices() {
 	def i = 2
 	addChildDevice("Child Switch Health", "${device.deviceNetworkId}:0${i}", device.hubId,
-			[completedSetup: true, label: "${device.displayName[0..-2]}${i}", isComponent : false])
+			[completedSetup: false, label: "${device.displayName[0..-2]}${i}", isComponent : false])
 }
 
 private getChildEndpoint(String dni) {


### PR DESCRIPTION
Changing "completedSetup" to "false" should give us the correct behavior