### PR TITLE
[CHAD-2943] Z-Wave Lock: Fix unreleased regression with call to requestCode

### DIFF
--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -1341,7 +1341,7 @@ def setCode(codeID, code, codeName = null) {
 
 	def cmds = validateAttributes()
 	cmds << secure(zwave.userCodeV1.userCodeSet(userIdentifier:codeID, userIdStatus:1, user:code))
-	cmds << requestCode(userIdentifier:codeID)
+	cmds << requestCode(codeID)
 	if(cmds.size() > 1) {
 		cmds = delayBetween(cmds, 4200)
 	}


### PR DESCRIPTION
The regression was introduced here:
https://github.com/SmartThingsCommunity/SmartThingsPublic/pull/4010

The problem was called out here:
https://github.com/SmartThingsCommunity/SmartThingsPublic/pull/4010#issuecomment-471463993