### PR TITLE
[CHAD-2943] Z-Wave Lock: Fix unreleased regression causing duplicate events

### DIFF
--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -1341,7 +1341,6 @@ def setCode(codeID, code, codeName = null) {
 
 	def cmds = validateAttributes()
 	cmds << secure(zwave.userCodeV1.userCodeSet(userIdentifier:codeID, userIdStatus:1, user:code))
-	cmds << requestCode(codeID)
 	if(cmds.size() > 1) {
 		cmds = delayBetween(cmds, 4200)
 	}


### PR DESCRIPTION
The recent addition of the requesting of the code inside of setCode was causing duplicate events in some situations.

https://smartthings.atlassian.net/browse/CHAD-2943

cc @vaish-rahul 