### PR TITLE
Curb definition block for oneapp compatibiity

### DIFF
--- a/smartapps/curb/curb-control.src/curb-control.groovy
+++ b/smartapps/curb/curb-control.src/curb-control.groovy
@@ -12,7 +12,10 @@ definition(
     category: "Convenience",
     iconUrl: "http://energycurb.com/images/logo.png",
     iconX2Url: "http://energycurb.com/images/logo.png",
-    oauth: [displayName: "SmartThings Curb Control", displayLink: "energycurb.com"]
+    singleInstance: true,
+    oauth: true,
+    usesThirdPartyAuthentication: true,
+    pausable: false
 )
 
 preferences {


### PR DESCRIPTION
Adds code to the definition block so that it shows up in the right place for one app