### PR TITLE
ICP-8430 Update Stelpro outdoor temperature weather API logic

### DIFF
--- a/devicetypes/stelpro/stelpro-ki-thermostat.src/stelpro-ki-thermostat.groovy
+++ b/devicetypes/stelpro/stelpro-ki-thermostat.src/stelpro-ki-thermostat.groovy
@@ -49,8 +49,14 @@ metadata {
 	simulator { }
 
 	preferences {
-		input("heatdetails", "enum", title: "Do you want a detailed operating state notification?", options: ["No", "Yes"], defaultValue: "No", required: true, displayDuringSetup: true)
-		input("zipcode", "text", title: "ZipCode (Outdoor Temperature)", description: "[Do not use space](Blank = No Forecast)")
+		section {
+			input("heatdetails", "enum", title: "Do you want a detailed operating state notification?", options: ["No", "Yes"], defaultValue: "No", required: true, displayDuringSetup: true)
+		}
+		section {
+			input title: "Outdoor Temperature", description: "To get the current outdoor temperature to display on your thermostat enter a zipcode below.", displayDuringSetup: false, type: "paragraph", element: "paragraph"
+			input title: "", description: "Only U.S. based zipcodes are supported by the weather provider. However, if you are outside of the U.S. then enter your zipcode below and make sure that your SmartThings location has a Geolocation configured.", displayDuringSetup: false, type: "paragraph", element: "paragraph"
+			input("zipcode", "text", title: "ZipCode (Outdoor Temperature)", description: "[Do not use space](Blank = No Forecast)")
+		}
 	}
 
 	tiles(scale : 2) {
@@ -161,6 +167,7 @@ def updated() {
 
 	unschedule(scheduledUpdateWeather)
 	if (settings.zipcode) {
+		state.invalidZip = false // Reset and validate the zip-code later
 		runEvery1Hour(scheduledUpdateWeather)
 		scheduledUpdateWeather()
 	}
@@ -208,21 +215,50 @@ def updateWeather() {
 	// If there is a zipcode defined, weather forecast will be sent. Otherwise, no weather forecast.
 	if (settings.zipcode) {
 		log.debug "ZipCode: ${settings.zipcode}"
-		weather = getTwcConditions(settings.zipcode)
-
-		// Check if the variable is populated, otherwise return.
-		if (!weather) {
-			log.debug("Something went wrong, no data found.")
-			return false
+		try {
+			// If we do not have a zip-code setting we've determined as invalid, try to use the zip-code defined.
+			if (!state.invalidZip) {
+				weather = getTwcConditions(settings.zipcode)
+			}
+		} catch (e) {
+			log.debug "getTwcConditions exception: $e"
+			// There was a problem obtaining the weather with this zip-code, so fall back to the hub's location and note this for future runs.
+			state.invalidZip = true
 		}
 
-		def locationScale = getTemperatureScale()
-		def tempToSend = weather.temperature
-		log.debug("Outdoor Temperature: ${tempToSend} ${locationScale}")
-		// Right now this can disrupt device health if the device is
-		// currently offline -- it would be erroneously marked online.
-		//sendEvent(name: 'outsideTemp', value: tempToSend)
-		setOutdoorTemperature(tempToSend)
+		if (!weather) {
+			try {
+				// It is possible that a non-U.S. zip-code was used, so try with the location's lat/lon.
+				if (location?.latitude && location?.longitude) {
+					// Restrict to two decimal places for the API
+					java.text.DecimalFormat formatter = new java.text.DecimalFormat()
+					formatter.setMaximumFractionDigits(2)
+					formatter.setMinimumFractionDigits(0)
+
+					def lat = formatter.format(location.latitude)
+					def lon = formatter.format(location.longitude)
+
+					def latlon = "${lat},${lon}"
+					weather = getTwcConditions(latlon)
+				}
+			} catch (e2) {
+				log.debug "getTwcConditions exception: $e2"
+				weather = null
+			}
+		}
+
+		// Either the location lat,lon was invalid or one was not defined for the location, on top of an error with the given zip-code
+		if (!weather) {
+			log.debug("Something went wrong, no data found.")
+		} else {
+			def locationScale = getTemperatureScale()
+			def tempToSend = weather.temperature
+			log.debug("Outdoor Temperature: ${tempToSend} ${locationScale}")
+			// Right now this can disrupt device health if the device is
+			// currently offline -- it would be erroneously marked online.
+			//sendEvent( name: 'outsideTemp', value: tempToSend )
+			setOutdoorTemperature(tempToSend)
+		}
 	}
 }
 
@@ -387,6 +423,7 @@ def refresh() {
 def configure() {
 	unschedule(scheduledUpdateWeather)
 	if (settings.zipcode) {
+		state.invalidZip = false // Reset and validate the zip-code later
 		runEvery1Hour(scheduledUpdateWeather)
 	}
 	poll()

--- a/devicetypes/stelpro/stelpro-ki-thermostat.src/stelpro-ki-thermostat.groovy
+++ b/devicetypes/stelpro/stelpro-ki-thermostat.src/stelpro-ki-thermostat.groovy
@@ -53,8 +53,7 @@ metadata {
 			input("heatdetails", "enum", title: "Do you want a detailed operating state notification?", options: ["No", "Yes"], defaultValue: "No", required: true, displayDuringSetup: true)
 		}
 		section {
-			input title: "Outdoor Temperature", description: "To get the current outdoor temperature to display on your thermostat enter a zipcode below.", displayDuringSetup: false, type: "paragraph", element: "paragraph"
-			input title: "", description: "Only U.S. based zipcodes are supported by the weather provider. However, if you are outside of the U.S. then enter your zipcode below and make sure that your SmartThings location has a Geolocation configured.", displayDuringSetup: false, type: "paragraph", element: "paragraph"
+			input title: "Outdoor Temperature", description: "To get the current outdoor temperature to display on your thermostat enter your zip code or postal code below and make sure that your SmartThings location has a Geolocation configured (typically used for geofencing).", displayDuringSetup: false, type: "paragraph", element: "paragraph"
 			input("zipcode", "text", title: "ZipCode (Outdoor Temperature)", description: "[Do not use space](Blank = No Forecast)")
 		}
 	}
@@ -231,15 +230,7 @@ def updateWeather() {
 				// It is possible that a non-U.S. zip-code was used, so try with the location's lat/lon.
 				if (location?.latitude && location?.longitude) {
 					// Restrict to two decimal places for the API
-					java.text.DecimalFormat formatter = new java.text.DecimalFormat()
-					formatter.setMaximumFractionDigits(2)
-					formatter.setMinimumFractionDigits(0)
-
-					def lat = formatter.format(location.latitude)
-					def lon = formatter.format(location.longitude)
-
-					def latlon = "${lat},${lon}"
-					weather = getTwcConditions(latlon)
+					weather = getTwcConditions(sprintf("%.2f,%.2f", location.latitude, location.longitude))
 				}
 			} catch (e2) {
 				log.debug "getTwcConditions exception: $e2"

--- a/devicetypes/stelpro/stelpro-ki-zigbee-thermostat.src/stelpro-ki-zigbee-thermostat.groovy
+++ b/devicetypes/stelpro/stelpro-ki-zigbee-thermostat.src/stelpro-ki-zigbee-thermostat.groovy
@@ -56,8 +56,7 @@ metadata {
 			input("heatdetails", "enum", title: "Do you want a detailed operating state notification?", options: ["No", "Yes"], defaultValue: "No", required: false, displayDuringSetup: true)
 		}
 		section {
-			input title: "Outdoor Temperature", description: "To get the current outdoor temperature to display on your thermostat enter a zipcode below.", displayDuringSetup: false, type: "paragraph", element: "paragraph"
-			input title: "", description: "Only U.S. based zipcodes are supported by the weather provider. However, if you are outside of the U.S. then enter your zipcode below and make sure that your SmartThings location has a Geolocation configured.", displayDuringSetup: false, type: "paragraph", element: "paragraph"
+			input title: "Outdoor Temperature", description: "To get the current outdoor temperature to display on your thermostat enter your zip code or postal code below and make sure that your SmartThings location has a Geolocation configured (typically used for geofencing).", displayDuringSetup: false, type: "paragraph", element: "paragraph"
 			input("zipcode", "text", title: "ZipCode (Outdoor Temperature)", description: "[Do not use space](Blank = No Forecast)")
 		}
 	}
@@ -455,15 +454,7 @@ def updateWeather() {
 				// It is possible that a non-U.S. zip-code was used, so try with the location's lat/lon.
 				if (location?.latitude && location?.longitude) {
 					// Restrict to two decimal places for the API
-					java.text.DecimalFormat formatter = new java.text.DecimalFormat()
-					formatter.setMaximumFractionDigits(2)
-					formatter.setMinimumFractionDigits(0)
-
-					def lat = formatter.format(location.latitude)
-					def lon = formatter.format(location.longitude)
-
-					def latlon = "${lat},${lon}"
-					weather = getTwcConditions(latlon)
+					weather = getTwcConditions(sprintf("%.2f,%.2f", location.latitude, location.longitude))
 				}
 			} catch (e2) {
 				log.debug "getTwcConditions exception: $e2"

--- a/devicetypes/stelpro/stelpro-ki-zigbee-thermostat.src/stelpro-ki-zigbee-thermostat.groovy
+++ b/devicetypes/stelpro/stelpro-ki-zigbee-thermostat.src/stelpro-ki-zigbee-thermostat.groovy
@@ -51,9 +51,15 @@ metadata {
 	simulator { }
 
 	preferences {
-		input("lock", "enum", title: "Do you want to lock your thermostat's physical keypad?", options: ["No", "Yes"], defaultValue: "No", required: false, displayDuringSetup: false)
-		input("heatdetails", "enum", title: "Do you want a detailed operating state notification?", options: ["No", "Yes"], defaultValue: "No", required: false, displayDuringSetup: true)
-		input("zipcode", "text", title: "ZipCode (Outdoor Temperature)", description: "[Do not use space](Blank = No Forecast)")
+		section {
+			input("lock", "enum", title: "Do you want to lock your thermostat's physical keypad?", options: ["No", "Yes"], defaultValue: "No", required: false, displayDuringSetup: false)
+			input("heatdetails", "enum", title: "Do you want a detailed operating state notification?", options: ["No", "Yes"], defaultValue: "No", required: false, displayDuringSetup: true)
+		}
+		section {
+			input title: "Outdoor Temperature", description: "To get the current outdoor temperature to display on your thermostat enter a zipcode below.", displayDuringSetup: false, type: "paragraph", element: "paragraph"
+			input title: "", description: "Only U.S. based zipcodes are supported by the weather provider. However, if you are outside of the U.S. then enter your zipcode below and make sure that your SmartThings location has a Geolocation configured.", displayDuringSetup: false, type: "paragraph", element: "paragraph"
+			input("zipcode", "text", title: "ZipCode (Outdoor Temperature)", description: "[Do not use space](Blank = No Forecast)")
+		}
 	}
 
 	tiles(scale : 2) {
@@ -191,6 +197,7 @@ def updated() {
 
 	unschedule(scheduledUpdateWeather)
 	if (settings.zipcode) {
+		state.invalidZip = false // Reset and validate the zip-code later
 		requests += updateWeather()
 		runEvery1Hour(scheduledUpdateWeather)
 	}
@@ -432,21 +439,50 @@ def updateWeather() {
 	// If there is a zipcode defined, weather forecast will be sent. Otherwise, no weather forecast.
 	if (settings.zipcode) {
 		log.debug "ZipCode: ${settings.zipcode}"
-		weather = getTwcConditions(settings.zipcode)
-
-		// Check if the variable is populated, otherwise return.
-		if (!weather) {
-			log.debug("Something went wrong, no data found.")
-			return false
+		try {
+			// If we do not have a zip-code setting we've determined as invalid, try to use the zip-code defined.
+			if (!state.invalidZip) {
+				weather = getTwcConditions(settings.zipcode)
+			}
+		} catch (e) {
+			log.debug "getTwcConditions exception: $e"
+			// There was a problem obtaining the weather with this zip-code, so fall back to the hub's location and note this for future runs.
+			state.invalidZip = true
 		}
 
-		def locationScale = getTemperatureScale()
-		def tempToSend = weather.temperature
-		log.debug("Outdoor Temperature: ${tempToSend} ${locationScale}")
-		// Right now this can disrupt device health if the device is
-		// currently offline -- it would be erroneously marked online.
-		//sendEvent( name: 'outsideTemp', value: tempToSend )
-		setOutdoorTemperature(tempToSend)
+		if (!weather) {
+			try {
+				// It is possible that a non-U.S. zip-code was used, so try with the location's lat/lon.
+				if (location?.latitude && location?.longitude) {
+					// Restrict to two decimal places for the API
+					java.text.DecimalFormat formatter = new java.text.DecimalFormat()
+					formatter.setMaximumFractionDigits(2)
+					formatter.setMinimumFractionDigits(0)
+
+					def lat = formatter.format(location.latitude)
+					def lon = formatter.format(location.longitude)
+
+					def latlon = "${lat},${lon}"
+					weather = getTwcConditions(latlon)
+				}
+			} catch (e2) {
+				log.debug "getTwcConditions exception: $e2"
+				weather = null
+			}
+		}
+
+		// Either the location lat,lon was invalid or one was not defined for the location, on top of an error with the given zip-code
+		if (!weather) {
+			log.debug("Something went wrong, no data found.")
+		} else {
+			def locationScale = getTemperatureScale()
+			def tempToSend = weather.temperature
+			log.debug("Outdoor Temperature: ${tempToSend} ${locationScale}")
+			// Right now this can disrupt device health if the device is
+			// currently offline -- it would be erroneously marked online.
+			//sendEvent( name: 'outsideTemp', value: tempToSend )
+			setOutdoorTemperature(tempToSend)
+		}
 	}
 }
 
@@ -614,6 +650,7 @@ def configure() {
 
 	unschedule(scheduledUpdateWeather)
 	if (settings.zipcode) {
+		state.invalidZip = false // Reset and validate the zip-code later
 		requests += updateWeather()
 		runEvery1Hour(scheduledUpdateWeather)
 	}

--- a/devicetypes/stelpro/stelpro-maestro-thermostat.src/stelpro-maestro-thermostat.groovy
+++ b/devicetypes/stelpro/stelpro-maestro-thermostat.src/stelpro-maestro-thermostat.groovy
@@ -52,9 +52,15 @@ metadata {
 	simulator { }
 
 	preferences {
-		input("lock", "enum", title: "Do you want to lock your thermostat's physical keypad?", options: ["No", "Yes"], defaultValue: "No", required: false, displayDuringSetup: false)
-		input("heatdetails", "enum", title: "Do you want a detailed operating state notification?", options: ["No", "Yes"], defaultValue: "No", required: false, displayDuringSetup: true)
-		input("zipcode", "text", title: "ZipCode (Outdoor Temperature)", description: "[Do not use space](Blank = No Forecast)")
+		section {
+			input("lock", "enum", title: "Do you want to lock your thermostat's physical keypad?", options: ["No", "Yes"], defaultValue: "No", required: false, displayDuringSetup: false)
+			input("heatdetails", "enum", title: "Do you want a detailed operating state notification?", options: ["No", "Yes"], defaultValue: "No", required: false, displayDuringSetup: true)
+		}
+		section {
+			input title: "Outdoor Temperature", description: "To get the current outdoor temperature to display on your thermostat enter a zipcode below.", displayDuringSetup: false, type: "paragraph", element: "paragraph"
+			input title: "", description: "Only U.S. based zipcodes are supported by the weather provider. However, if you are outside of the U.S. then enter your zipcode below and make sure that your SmartThings location has a Geolocation configured.", displayDuringSetup: false, type: "paragraph", element: "paragraph"
+			input("zipcode", "text", title: "ZipCode (Outdoor Temperature)", description: "[Do not use space](Blank = No Forecast)")
+		}
 		/*
 		input("away_setpoint", "enum", title: "Away setpoint", options: ["5", "5.5", "6", "6.5", "7", "7.5", "8", "8.5", "9", "9.5", "10", "10.5", "11", "11.5", "12", "12.5", "13", "13.5", "14", "14.5", "15", "5.5", "15.5", "16", "16.5", "17", "17.5", "18", "18.5", "19", "19.5", "20", "20.5", "21", "21.5", "22", "22.5", "23", "24", "24.5", "25", "25.5", "26", "26.5", "27", "27.5", "28", "28.5", "29", "29.5", "30"], defaultValue: "21", required: true)
 		input("away_setpoint", "enum", title: "Away Setpoint", options: ["5", "5.5", "6", "6.5", "7", "7.5", "8", "8.5", "9", "9.5", "10", "10.5", "11", "11.5", "12", "12.5", "13", "13.5", "14", "14.5", "15", "5.5", "15.5", "16", "16.5", "17", "17.5", "18", "18.5", "19", "19.5", "20", "20.5", "21", "21.5", "22", "22.5", "23", "24", "24.5", "25", "25.5", "26", "26.5", "27", "27.5", "28", "28.5", "29", "29.5", "30"], defaultValue: "17", required: true)
@@ -203,6 +209,7 @@ def updated() {
 
 	unschedule(scheduledUpdateWeather)
 	if (settings.zipcode) {
+		state.invalidZip = false // Reset and validate the zip-code later
 		requests += updateWeather()
 		runEvery1Hour(scheduledUpdateWeather)
 	}
@@ -349,21 +356,50 @@ def updateWeather() {
 	// If there is a zipcode defined, weather forecast will be sent. Otherwise, no weather forecast.
 	if (settings.zipcode) {
 		log.debug "ZipCode: ${settings.zipcode}"
-		weather = getTwcConditions(settings.zipcode)
-
-		// Check if the variable is populated, otherwise return.
-		if (!weather) {
-			log.debug("Something went wrong, no data found.")
-			return false
+		try {
+			// If we do not have a zip-code setting we've determined as invalid, try to use the zip-code defined.
+			if (!state.invalidZip) {
+				weather = getTwcConditions(settings.zipcode)
+			}
+		} catch (e) {
+			log.debug "getTwcConditions exception: $e"
+			// There was a problem obtaining the weather with this zip-code, so fall back to the hub's location and note this for future runs.
+			state.invalidZip = true
 		}
 
-		def locationScale = getTemperatureScale()
-		def tempToSend = weather.temperature
-		log.debug("Outdoor Temperature: ${tempToSend} ${locationScale}")
-		// Right now this can disrupt device health if the device is
-		// currently offline -- it would be erroneously marked online.
-		//sendEvent( name: 'outsideTemp', value: tempToSend )
-		setOutdoorTemperature(tempToSend)
+		if (!weather) {
+			try {
+				// It is possible that a non-U.S. zip-code was used, so try with the location's lat/lon.
+				if (location?.latitude && location?.longitude) {
+					// Restrict to two decimal places for the API
+					java.text.DecimalFormat formatter = new java.text.DecimalFormat()
+					formatter.setMaximumFractionDigits(2)
+					formatter.setMinimumFractionDigits(0)
+
+					def lat = formatter.format(location.latitude)
+					def lon = formatter.format(location.longitude)
+
+					def latlon = "${lat},${lon}"
+					weather = getTwcConditions(latlon)
+				}
+			} catch (e2) {
+				log.debug "getTwcConditions exception: $e2"
+				weather = null
+			}
+		}
+
+		// Either the location lat,lon was invalid or one was not defined for the location, on top of an error with the given zip-code
+		if (!weather) {
+			log.debug("Something went wrong, no data found.")
+		} else {
+			def locationScale = getTemperatureScale()
+			def tempToSend = weather.temperature
+			log.debug("Outdoor Temperature: ${tempToSend} ${locationScale}")
+			// Right now this can disrupt device health if the device is
+			// currently offline -- it would be erroneously marked online.
+			//sendEvent( name: 'outsideTemp', value: tempToSend )
+			setOutdoorTemperature(tempToSend)
+		}
 	}
 }
 
@@ -389,11 +425,11 @@ def poll() {
 
 	requests += updateWeather()
 	requests += zigbee.readAttribute(THERMOSTAT_CLUSTER, ATTRIBUTE_LOCAL_TEMP)
+	requests += zigbee.readAttribute(zigbee.RELATIVE_HUMIDITY_CLUSTER, ATTRIBUTE_HUMIDITY_INFO)
 	requests += zigbee.readAttribute(THERMOSTAT_CLUSTER, ATTRIBUTE_PI_HEATING_STATE)
 	requests += zigbee.readAttribute(THERMOSTAT_CLUSTER, ATTRIBUTE_HEAT_SETPOINT)
 	requests += zigbee.readAttribute(THERMOSTAT_UI_CONFIG_CLUSTER, ATTRIBUTE_TEMP_DISP_MODE)
 	requests += zigbee.readAttribute(THERMOSTAT_UI_CONFIG_CLUSTER, ATTRIBUTE_KEYPAD_LOCKOUT)
-	requests += zigbee.readAttribute(zigbee.RELATIVE_HUMIDITY_CLUSTER, 0x0000)
 
 	requests
 }
@@ -497,10 +533,10 @@ def heat() {
 
 def configure() {
 	def requests = []
-	log.debug "binding to Thermostat cluster"
 
 	unschedule(scheduledUpdateWeather)
 	if (settings.zipcode) {
+		state.invalidZip = false // Reset and validate the zip-code later
 		requests += updateWeather()
 		runEvery1Hour(scheduledUpdateWeather)
 	}
@@ -508,6 +544,7 @@ def configure() {
 	// This thermostat only supports heat
 	sendEvent("name":"thermostatMode", "value":"heat")
 
+	log.debug "binding to Thermostat cluster"
 	requests += zigbee.addBinding(THERMOSTAT_CLUSTER)
 	// Configure Thermostat Cluster
 	requests += zigbee.configureReporting(THERMOSTAT_CLUSTER, ATTRIBUTE_LOCAL_TEMP, DataType.INT16, 10, 60, 50)
@@ -521,6 +558,7 @@ def configure() {
 	requests += zigbee.configureReporting(zigbee.RELATIVE_HUMIDITY_CLUSTER, ATTRIBUTE_HUMIDITY_INFO, DataType.UINT16, 10, 300, 1)
 
 	// Read the configured variables
+	requests += zigbee.readAttribute(zigbee.RELATIVE_HUMIDITY_CLUSTER, ATTRIBUTE_HUMIDITY_INFO)
 	requests += zigbee.readAttribute(THERMOSTAT_CLUSTER, ATTRIBUTE_LOCAL_TEMP)
 	requests += zigbee.readAttribute(THERMOSTAT_CLUSTER, ATTRIBUTE_HEAT_SETPOINT)
 	requests += zigbee.readAttribute(THERMOSTAT_CLUSTER, ATTRIBUTE_PI_HEATING_STATE)

--- a/devicetypes/stelpro/stelpro-maestro-thermostat.src/stelpro-maestro-thermostat.groovy
+++ b/devicetypes/stelpro/stelpro-maestro-thermostat.src/stelpro-maestro-thermostat.groovy
@@ -57,8 +57,7 @@ metadata {
 			input("heatdetails", "enum", title: "Do you want a detailed operating state notification?", options: ["No", "Yes"], defaultValue: "No", required: false, displayDuringSetup: true)
 		}
 		section {
-			input title: "Outdoor Temperature", description: "To get the current outdoor temperature to display on your thermostat enter a zipcode below.", displayDuringSetup: false, type: "paragraph", element: "paragraph"
-			input title: "", description: "Only U.S. based zipcodes are supported by the weather provider. However, if you are outside of the U.S. then enter your zipcode below and make sure that your SmartThings location has a Geolocation configured.", displayDuringSetup: false, type: "paragraph", element: "paragraph"
+			input title: "Outdoor Temperature", description: "To get the current outdoor temperature to display on your thermostat enter your zip code or postal code below and make sure that your SmartThings location has a Geolocation configured (typically used for geofencing).", displayDuringSetup: false, type: "paragraph", element: "paragraph"
 			input("zipcode", "text", title: "ZipCode (Outdoor Temperature)", description: "[Do not use space](Blank = No Forecast)")
 		}
 		/*
@@ -372,15 +371,7 @@ def updateWeather() {
 				// It is possible that a non-U.S. zip-code was used, so try with the location's lat/lon.
 				if (location?.latitude && location?.longitude) {
 					// Restrict to two decimal places for the API
-					java.text.DecimalFormat formatter = new java.text.DecimalFormat()
-					formatter.setMaximumFractionDigits(2)
-					formatter.setMinimumFractionDigits(0)
-
-					def lat = formatter.format(location.latitude)
-					def lon = formatter.format(location.longitude)
-
-					def latlon = "${lat},${lon}"
-					weather = getTwcConditions(latlon)
+					weather = getTwcConditions(sprintf("%.2f,%.2f", location.latitude, location.longitude))
 				}
 			} catch (e2) {
 				log.debug "getTwcConditions exception: $e2"


### PR DESCRIPTION
The new API does not allow for non-U.S. zip codes; however, it allows for any geolocation. To make sure that this works globally, and to require no extra steps for existing installations (except for the possible ones that do not have a geolocation defined for their SmartThings location), we'll keep track of a failed API call on the defined zipcode with a flag so that we don't continue to make requests in the future that we know will fail.