### PR TITLE
ICP-8828 Shorten CO Sensor CheckInterval

### DIFF
--- a/devicetypes/smartthings/zigbee-co-sensor.src/zigbee-co-sensor.groovy
+++ b/devicetypes/smartthings/zigbee-co-sensor.src/zigbee-co-sensor.groovy
@@ -145,10 +145,10 @@ def ping() {
 
 def configure() {
 	log.debug "configure"
-	sendEvent(name: "checkInterval", value:6 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
 	Integer minReportTime = 0
 	Integer maxReportTime = 180
 	Integer reportableChange = null
+	sendEvent(name: "checkInterval", value: maxReportTime * 2 + 10 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
 	return refresh() + zigbee.enrollResponse() + zigbee.configureReporting(zigbee.POWER_CONFIGURATION_CLUSTER, 0x0021, DataType.UINT8, 30, 21600, 0x10) +
 				zigbee.configureReporting(zigbee.IAS_ZONE_CLUSTER, zigbee.ATTRIBUTE_IAS_ZONE_STATUS, DataType.BITMAP16, minReportTime, maxReportTime, reportableChange)
 }


### PR DESCRIPTION
We configure the device to report every 3 minutes, so the checkInterval should reflect that.