### PR TITLE
[DVCSMP-1803] Fixing command cluster access during install

### DIFF
--- a/devicetypes/smartthings/springs-window-fashions-remote.src/springs-window-fashions-remote.groovy
+++ b/devicetypes/smartthings/springs-window-fashions-remote.src/springs-window-fashions-remote.groovy
@@ -44,7 +44,7 @@ metadata {
 }
 
 def installed() {
-    if (zwaveInfo.zw && zwaveInfo.zw.cc?.contains("84")) {
+    if (zwaveInfo.cc?.contains("84")) {
         response(zwave.wakeUpV1.wakeUpNoMoreInformation())
     }
 }


### PR DESCRIPTION
This looks like it contributed to DataMgmt Driver onInstall alerts being triggered in NA02.

```
timestamp=2019-03-23 17:37:17.914, level=ERROR, log_id=ed88d7dd-43b8-4b5e-ae7b-10c12ef5138c, trace_id=, user=, cat=CompilerService, key=sandbox_error, owner=, id=341b2303-76ef-42f0-8aa8-9dd9e124427d, deviceTypeName=Springs Window Fashions Remote, gitRepoId=null,
groovy.lang.MissingPropertyException: No such property: cc for class: java.lang.String
	at org.kohsuke.groovy.sandbox.impl.Checker$4.call(Checker.java:115)
	at physicalgraph.sandbox.SmartAppSandbox.onGetProperty(SmartAppSandbox.groovy:362)
	at org.kohsuke.groovy.sandbox.impl.Checker$4.call(Checker.java:113)
	at org.kohsuke.groovy.sandbox.impl.Checker.checkedGetProperty(Checker.java:110)
	at script_dth_54450beafca4680be6e27ace11676bcf1f073d717c11d38869043804295c7fa3.installed(script_dth_54450beafca4680be6e27ace11676bcf1f073d717c11d38869043804295c7fa3:47)
```

\cc @greens @ajguyot 