### PR TITLE
[CHAD-3119] Unify Command Class Version Mapping when Parsing Z-Wave Messages

### DIFF
--- a/devicetypes/smartthings/aeon-siren.src/aeon-siren.groovy
+++ b/devicetypes/smartthings/aeon-siren.src/aeon-siren.groovy
@@ -100,6 +100,18 @@ def updated() {
 	response(commands)
 }
 
+/**
+ * Mapping of command classes and associated versions used for this DTH
+ */
+private getCommandClassVersions() {
+	[
+		0x20: 1,  // Basic
+		0x70: 1,  // Configuration
+		0x85: 2,  // Association
+		0x98: 1,  // Security 0
+	]
+}
+
 def parse(String description) {
 	log.debug "parse($description)"
 	def result = null
@@ -116,7 +128,7 @@ def parse(String description) {
 			)
 		}
 	} else {
-		def cmd = zwave.parse(description, [0x98: 1, 0x20: 1, 0x70: 1])
+		def cmd = zwave.parse(description, commandClassVersions)
 		if (cmd) {
 			result = zwaveEvent(cmd)
 		}
@@ -126,7 +138,7 @@ def parse(String description) {
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.securityv1.SecurityMessageEncapsulation cmd) {
-	def encapsulatedCommand = cmd.encapsulatedCommand([0x20: 1, 0x85: 2, 0x70: 1])
+	def encapsulatedCommand = cmd.encapsulatedCommand(commandClassVersions)
 	// log.debug "encapsulated: $encapsulatedCommand"
 	if (encapsulatedCommand) {
 		zwaveEvent(encapsulatedCommand)

--- a/devicetypes/smartthings/danalock.src/danalock.groovy
+++ b/devicetypes/smartthings/danalock.src/danalock.groovy
@@ -61,6 +61,21 @@ metadata {
 
 import physicalgraph.zwave.commands.doorlockv1.*
 
+/**
+ * Mapping of command classes and associated versions used for this DTH
+ */
+private getCommandClassVersions() {
+	[
+		0x62: 1,  // Door Lock
+		0x71: 2,  // Alarm
+		0x72: 2,  // Manufacturer Specific
+		0x80: 1,  // Battery
+		0x8A: 1,  // Time
+		0x85: 2,  // Association
+		0x98: 1   // Security 0
+	]
+}
+
 def parse(String description) {
 	def result = null
 	if (description.startsWith("Err")) {
@@ -76,7 +91,7 @@ def parse(String description) {
 			)
 		}
 	} else {
-		def cmd = zwave.parse(description, [ 0x98: 1, 0x72: 2, 0x85: 2, 0x8A: 1 ])
+		def cmd = zwave.parse(description, commandClassVersions)
 		if (cmd) {
 			result = zwaveEvent(cmd)
 		}
@@ -86,7 +101,7 @@ def parse(String description) {
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.securityv1.SecurityMessageEncapsulation cmd) {
-	def encapsulatedCommand = cmd.encapsulatedCommand([0x62: 1, 0x71: 2, 0x80: 1, 0x8A: 1, 0x85: 2, 0x98: 1])
+	def encapsulatedCommand = cmd.encapsulatedCommand(commandClassVersions)
 	// log.debug "encapsulated: $encapsulatedCommand"
 	if (encapsulatedCommand) {
 		zwaveEvent(encapsulatedCommand)

--- a/devicetypes/smartthings/fibaro-dimmer.src/fibaro-dimmer.groovy
+++ b/devicetypes/smartthings/fibaro-dimmer.src/fibaro-dimmer.groovy
@@ -73,6 +73,17 @@ metadata {
 	}
 }
 
+/**
+ * Mapping of command classes and associated versions used for this DTH
+ */
+private getCommandClassVersions() {
+	[
+		0x26: 1,  // Switch Multilevel
+		0x70: 2,  // Configuration
+		0x72: 2   // Manufacturer Specific
+	]
+}
+
 def parse(String description) {
 	def item1 = [
 		canBeCurrentState: false,
@@ -83,7 +94,7 @@ def parse(String description) {
 		value:  description
 	]
 	def result
-	def cmd = zwave.parse(description, [0x26: 1, 0x70: 2, 072: 2])
+	def cmd = zwave.parse(description, commandClassVersions)
     //log.debug "cmd: ${cmd}"
     
     if (cmd) {
@@ -141,6 +152,10 @@ def createEvent(physicalgraph.zwave.commands.switchmultilevelv1.SwitchMultilevel
 		result[i].type = "digital"
 	}
 	result
+}
+
+def zwaveEvent(physicalgraph.zwave.commands.manufacturerspecificv2.ManufacturerSpecificReport cmd) {
+	log.trace "[DTH] Executing 'zwaveEvent(physicalgraph.zwave.commands.manufacturerspecificv2.ManufacturerSpecificReport)' with cmd = $cmd"
 }
 
 def doCreateEvent(physicalgraph.zwave.Command cmd, Map item1) {

--- a/devicetypes/smartthings/fibaro-door-window-sensor.src/fibaro-door-window-sensor.groovy
+++ b/devicetypes/smartthings/fibaro-door-window-sensor.src/fibaro-door-window-sensor.groovy
@@ -105,11 +105,28 @@
 	}
 }
 
+/**
+ * Mapping of command classes and associated versions used for this DTH
+ */
+private getCommandClassVersions() {
+	[
+		0x30: 1,  // Sensor Binary
+		0x31: 2,  // Sensor MultiLevel
+		0x56: 1,  // Crc16Encap
+		0x60: 3,  // Multi-Channel
+		0x70: 2,  // Configuration
+		0x72: 2,  // Manufacturer Specific
+		0x80: 1,  // Battery
+		0x84: 1,  // WakeUp
+		0x9C: 1   // Sensor Alarm
+	]
+}
+
 // Parse incoming device messages to generate events 
 def parse(String description)
 {
 	def result = []
-	def cmd = zwave.parse(description, [0x30: 1, 0x84: 1, 0x9C: 1, 0x70: 2, 0x80: 1, 0x72: 2, 0x56: 1, 0x60: 3])
+	def cmd = zwave.parse(description, commandClassVersions)
 	if (cmd) {
 		result += zwaveEvent(cmd)
 	}
@@ -119,7 +136,7 @@ def parse(String description)
 
 def zwaveEvent(physicalgraph.zwave.commands.crc16encapv1.Crc16Encap cmd)
 {
-	def versions = [0x30: 1, 0x84: 1, 0x9C: 1, 0x70: 2, 0x80: 1, 0x72: 2, 0x60: 3]
+	def versions = commandClassVersions
 	// def encapsulatedCommand = cmd.encapsulatedCommand(versions)
 	def version = versions[cmd.commandClass as Integer]
 	def ccObj = version ? zwave.commandClass(cmd.commandClass, version) : zwave.commandClass(cmd.commandClass)

--- a/devicetypes/smartthings/philio-multiple-sound-siren.src/philio-multiple-sound-siren.groovy
+++ b/devicetypes/smartthings/philio-multiple-sound-siren.src/philio-multiple-sound-siren.groovy
@@ -159,6 +159,19 @@ def updated() {
 	response(commands)
 }
 
+/**
+ * Mapping of command classes and associated versions used for this DTH
+ */
+private getCommandClassVersions() {
+	[
+		0x20: 1,  // Basic
+		0x70: 1,  // Configuration
+		0x85: 2,  // Association
+		0x98: 1,  // Security 0
+	]
+}
+
+
 def parse(String description) {
 	log.debug "parse($description)"
 	def result = null
@@ -175,7 +188,7 @@ def parse(String description) {
 			)
 		}
 	} else {
-		def cmd = zwave.parse(description, [0x98: 1, 0x20: 1, 0x70: 1])
+		def cmd = zwave.parse(description, commandClassVersions)
 		if (cmd) {
 			result = zwaveEvent(cmd)
 		}
@@ -185,7 +198,7 @@ def parse(String description) {
 }
 
 def zwaveEvent(securityv1.SecurityMessageEncapsulation cmd) {
-	def encapsulatedCommand = cmd.encapsulatedCommand([0x20: 1, 0x85: 2, 0x70: 1])
+	def encapsulatedCommand = cmd.encapsulatedCommand(commandClassVersions)
 	// log.debug "encapsulated: $encapsulatedCommand"
 	if (encapsulatedCommand) {
 		zwaveEvent(encapsulatedCommand)

--- a/devicetypes/smartthings/zwave-device-multichannel.src/zwave-device-multichannel.groovy
+++ b/devicetypes/smartthings/zwave-device-multichannel.src/zwave-device-multichannel.groovy
@@ -163,12 +163,28 @@ private queryCommandForCC(cc) {
 	}
 }
 
+def getCommandClassVersions() {
+	[
+		0x20: 1,  // Basic
+		0x25: 1,  // Switch Binary
+		0x30: 1,  // Sensor Binary
+		0x31: 2,  // Sensor MultiLevel
+		0x32: 3,  // Meter
+		0x56: 1,  // Crc16Encap
+		0x60: 3,  // Multi-Channel
+		0x70: 2,  // Configuration
+		0x84: 1,  // WakeUp
+		0x98: 1,  // Security 0
+		0x9C: 1   // Sensor Alarm
+	]
+}
+
 def parse(String description) {
 	def result = null
 	if (description.startsWith("Err")) {
 	    result = createEvent(descriptionText:description, isStateChange:true)
 	} else if (description != "updated") {
-		def cmd = zwave.parse(description, [0x20: 1, 0x84: 1, 0x98: 1, 0x56: 1, 0x60: 3])
+		def cmd = zwave.parse(description, commandClassVersions)
 		if (cmd) {
 			result = zwaveEvent(cmd)
 		}
@@ -274,7 +290,7 @@ def zwaveEvent(physicalgraph.zwave.commands.multichannelv3.MultiChannelCmdEncap 
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.securityv1.SecurityMessageEncapsulation cmd) {
-	def encapsulatedCommand = cmd.encapsulatedCommand([0x20: 1, 0x84: 1])
+	def encapsulatedCommand = cmd.encapsulatedCommand(commandClassVersions)
 	if (encapsulatedCommand) {
 		state.sec = 1
 		def result = zwaveEvent(encapsulatedCommand)
@@ -290,7 +306,7 @@ def zwaveEvent(physicalgraph.zwave.commands.securityv1.SecurityMessageEncapsulat
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.crc16encapv1.Crc16Encap cmd) {
-	def versions = [0x31: 2, 0x30: 1, 0x84: 1, 0x9C: 1, 0x70: 2]
+	def versions = commandClassVersions
 	// def encapsulatedCommand = cmd.encapsulatedCommand(versions)
 	def version = versions[cmd.commandClass as Integer]
 	def ccObj = version ? zwave.commandClass(cmd.commandClass, version) : zwave.commandClass(cmd.commandClass)

--- a/devicetypes/smartthings/zwave-device.src/zwave-device.groovy
+++ b/devicetypes/smartthings/zwave-device.src/zwave-device.groovy
@@ -54,12 +54,29 @@ metadata {
 	}
 }
 
+/**
+ * Mapping of command classes and associated versions used for this DTH
+ */
+private getCommandClassVersions() {
+	[
+		0x20: 1,  // Basic
+		0x30: 1,  // Sensor Binary
+		0x31: 2,  // Sensor MultiLevel
+		0x56: 1,  // Crc16Encap
+		0x60: 3,  // Multi-Channel
+		0x70: 2,  // Configuration
+		0x84: 1,  // WakeUp
+		0x98: 1,  // Security 0
+		0x9C: 1   // Sensor Alarm
+	]
+}
+
 def parse(String description) {
 	def result = []
 	if (description.startsWith("Err")) {
 	    result = createEvent(descriptionText:description, isStateChange:true)
 	} else {
-		def cmd = zwave.parse(description, [0x20: 1, 0x84: 1, 0x98: 1, 0x56: 1, 0x60: 3])
+		def cmd = zwave.parse(description, commandClassVersions)
 		if (cmd) {
 			result += zwaveEvent(cmd)
 		}
@@ -89,7 +106,7 @@ def zwaveEvent(physicalgraph.zwave.commands.basicv1.BasicReport cmd) {
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.securityv1.SecurityMessageEncapsulation cmd) {
-	def encapsulatedCommand = cmd.encapsulatedCommand([0x20: 1, 0x84: 1])
+	def encapsulatedCommand = cmd.encapsulatedCommand(commandClassVersions)
 	if (encapsulatedCommand) {
 		state.sec = 1
 		def result = zwaveEvent(encapsulatedCommand)
@@ -105,7 +122,7 @@ def zwaveEvent(physicalgraph.zwave.commands.securityv1.SecurityMessageEncapsulat
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.crc16encapv1.Crc16Encap cmd) {
-	def versions = [0x31: 2, 0x30: 1, 0x84: 1, 0x9C: 1, 0x70: 2]
+	def versions = commandClassVersions
 	// def encapsulatedCommand = cmd.encapsulatedCommand(versions)
 	def version = versions[cmd.commandClass as Integer]
 	def ccObj = version ? zwave.commandClass(cmd.commandClass, version) : zwave.commandClass(cmd.commandClass)

--- a/devicetypes/smartthings/zwave-garage-door-opener.src/zwave-garage-door-opener.groovy
+++ b/devicetypes/smartthings/zwave-garage-door-opener.src/zwave-garage-door-opener.groovy
@@ -76,6 +76,20 @@ def updated(){
 	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
 }
 
+/**
+ * Mapping of command classes and associated versions used for this DTH
+ */
+private getCommandClassVersions() {
+	[
+		0x63: 1,  // User Code
+		0x71: 3,  // Notification
+		0x72: 2,  // Manufacturer Specific
+		0x80: 1,  // Battery
+		0x85: 2,  // Association
+		0x98: 1   // Security 0
+	]
+}
+
 def parse(String description) {
 	def result = null
 	if (description.startsWith("Err")) {
@@ -91,7 +105,7 @@ def parse(String description) {
 			)
 		}
 	} else {
-		def cmd = zwave.parse(description, [ 0x98: 1, 0x72: 2 ])
+		def cmd = zwave.parse(description, commandClassVersions)
 		if (cmd) {
 			result = zwaveEvent(cmd)
 		}
@@ -101,7 +115,7 @@ def parse(String description) {
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.securityv1.SecurityMessageEncapsulation cmd) {
-	def encapsulatedCommand = cmd.encapsulatedCommand([0x71: 3, 0x80: 1, 0x85: 2, 0x63: 1, 0x98: 1])
+	def encapsulatedCommand = cmd.encapsulatedCommand(commandClassVersions)
 	log.debug "encapsulated: $encapsulatedCommand"
 	if (encapsulatedCommand) {
 		zwaveEvent(encapsulatedCommand)

--- a/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
+++ b/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
@@ -63,6 +63,22 @@ metadata {
 import physicalgraph.zwave.commands.doorlockv1.*
 
 /**
+ * Mapping of command classes and associated versions used for this DTH
+ */
+private getCommandClassVersions() {
+	[
+		0x62: 1,  // Door Lock
+		0x63: 1,  // User Code
+		0x71: 2,  // Alarm
+		0x72: 2,  // Manufacturer Specific
+		0x80: 1,  // Battery
+		0x85: 2,  // Association
+		0x86: 1,  // Version
+		0x98: 1   // Security 0
+	]
+}
+
+/**
  * Called on app installed
  */
 def installed() {
@@ -186,7 +202,7 @@ def parse(String description) {
 			)
 		}
 	} else {
-		def cmd = zwave.parse(description, [0x98: 1, 0x72: 2, 0x85: 2, 0x86: 1])
+		def cmd = zwave.parse(description, commandClassVersions)
 		if (cmd) {
 			result = zwaveEvent(cmd)
 		}
@@ -205,7 +221,7 @@ def parse(String description) {
  */
 def zwaveEvent(physicalgraph.zwave.commands.securityv1.SecurityMessageEncapsulation cmd) {
 	log.trace "[DTH] Executing 'zwaveEvent(physicalgraph.zwave.commands.securityv1.SecurityMessageEncapsulation)' with cmd = $cmd"
-	def encapsulatedCommand = cmd.encapsulatedCommand([0x62: 1, 0x71: 2, 0x80: 1, 0x85: 2, 0x63: 1, 0x98: 1, 0x86: 1])
+	def encapsulatedCommand = cmd.encapsulatedCommand(commandClassVersions)
 	if (encapsulatedCommand) {
 		zwaveEvent(encapsulatedCommand)
 	}


### PR DESCRIPTION
When parsing a Z-Wave message received from devices, a given DTH would need to map that message to a specific version of a command class as different versions of the command class may have different fields and require special parsing. The initial design of the Z-Wave messages could possibly include the encapsulation the message was received with. However, starting in 0.25.X Hub Firmware Release, the hub started removing the encapsulation the message was received with in preparation to handle S2 devices. The encapsulation removal allows most DTHs to support S2 seamlessly without having to worry about encapsulation.

However, with removal of encapsulation of the received messages, we also need to ensure that all the mapping used for encapsulated messages are also used in `zwave.parse()` method as well, and as such, the changes in this PR is to ensure SmartThings DTHs have the same source of command class version mapping regardless of encapsulation.

For more information, please visit: https://community.smartthings.com/t/z-wave-dths-changes-to-encapsulation-handling-starting-in-0-25-x-hub-firmware-release/159433