### PR TITLE
[DVCSMP-4721]Replace iasZoneConfig with just zone status config

### DIFF
--- a/devicetypes/smartthings/Orvibo-Contact-Sensor.src/Orvibo-Contact-Sensor.groovy
+++ b/devicetypes/smartthings/Orvibo-Contact-Sensor.src/Orvibo-Contact-Sensor.groovy
@@ -131,7 +131,7 @@ def configure() {
 	log.debug "Configuring Reporting, IAS CIE, and Bindings."
 	//The electricity attribute is reported without bind and reporting CFG. The TI plan reports the power once in about 10 minutes; the NXP plan reports the electricity once in 20 minutes
 	if (getDataValue("manufacturer") == "Aurora") {
-		cmds = zigbee.iasZoneConfig(30, 60 * 5) + zigbee.batteryConfig()
+		cmds = zigbee.enrollResponse() + zigbee.configureReporting(zigbee.IAS_ZONE_CLUSTER, zigbee.ATTRIBUTE_IAS_ZONE_STATUS, DataType.BITMAP16, 30, 60 * 5, null) + zigbee.batteryConfig()
 	}
 	cmds += refresh()
 	cmds

--- a/devicetypes/smartthings/nyce-motion-sensor.src/nyce-motion-sensor.groovy
+++ b/devicetypes/smartthings/nyce-motion-sensor.src/nyce-motion-sensor.groovy
@@ -166,10 +166,7 @@ private Map parseIasMessage(String description) {
 def refresh()
 {
 	log.debug "refresh called"
-	[
-		"st rattr 0x${device.deviceNetworkId} 1 1 0x20"
-
-	]
+	return zigbee.readAttribute(zigbee.POWER_CONFIGURATION_CLUSTER, 0x0020) //battery read
 }
 
 def ping() {
@@ -177,55 +174,13 @@ def ping() {
 }
 
 def configure() {
-
-	String zigbeeEui = swapEndianHex(device.hub.zigbeeEui)
 	log.debug "Configuring Reporting, IAS CIE, and Bindings."
-	def configCmds = [
-		"zcl global write 0x500 0x10 0xf0 {${zigbeeEui}}", "delay 200",
-		"send 0x${device.deviceNetworkId} 1 1", "delay 1500",
-
-		"zcl global send-me-a-report 1 0x20 0x20 0x3600 0x3600 {01}", "delay 200",
-		"send 0x${device.deviceNetworkId} 1 1", "delay 1500",
-
-		"zdo bind 0x${device.deviceNetworkId} 1 1 0x001 {${device.zigbeeId}} {}", "delay 1500",
-
-		"raw 0x500 {01 23 00 00 00}", "delay 200",
-		"send 0x${device.deviceNetworkId} 1 1", "delay 1500",
-	]
-	return configCmds + zigbee.enrollResponse() + refresh() + zigbee.iasZoneConfig(30, 300) + zigbee.enrollResponse() // send refresh cmds as part of config
-}
-
-def enrollResponse() {
-	log.debug "Sending enroll response"
-	[
-
-	"raw 0x500 {01 23 00 00 00}", "delay 200",
-	"send 0x${device.deviceNetworkId} 1 1"
-
-	]
+	return zigbee.batteryConfig(3600, 3600, 1) +
+			zigbee.enrollResponse() +
+			refresh() +
+			zigbee.configureReporting(zigbee.IAS_ZONE_CLUSTER, zigbee.ATTRIBUTE_IAS_ZONE_STATUS, DataType.BITMAP16, 30, 60 * 5, null) // send refresh cmds as part of config
 }
 
 def initialize(){
 	sendEvent(name: "checkInterval", value: 2 * 60 * 60 * 4 + 2 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
-}
-private hex(value) {
-	new BigInteger(Math.round(value).toString()).toString(16)
-}
-
-private String swapEndianHex(String hex) {
-	reverseArray(hex.decodeHex()).encodeHex()
-}
-
-private byte[] reverseArray(byte[] array) {
-	int i = 0;
-	int j = array.length - 1;
-	byte tmp;
-	while (j > i) {
-		tmp = array[j];
-		array[j] = array[i];
-		array[i] = tmp;
-		j--;
-		i++;
-	}
-	return array
 }

--- a/devicetypes/smartthings/nyce-open-closed-sensor.src/nyce-open-closed-sensor.groovy
+++ b/devicetypes/smartthings/nyce-open-closed-sensor.src/nyce-open-closed-sensor.groovy
@@ -261,7 +261,8 @@ def configure() {
 		zigbee.batteryConfig(30, 300) + zigbee.enrollResponse()
 	} else {
 		// battery minReportTime 30 seconds, maxReportTime 5 min. Reporting interval if no activity
-		return zigbee.iasZoneConfig() + zigbee.batteryConfig(30, 300) + refresh() // send refresh cmds as part of config
+		return zigbee.enrollResponse() + zigbee.configureReporting(zigbee.IAS_ZONE_CLUSTER, zigbee.ATTRIBUTE_IAS_ZONE_STATUS, DataType.BITMAP16, 0, 60 * 60, null) +
+				zigbee.batteryConfig(30, 300) + refresh() // send refresh cmds as part of config
 	}
 }
 

--- a/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
@@ -182,7 +182,11 @@ def configure() {
 	sendEvent(name: "checkInterval", value: 2 * 60 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
 
 	log.debug "Configuring Reporting, IAS CIE, and Bindings."
-	def cmds = refresh() + zigbee.iasZoneConfig(30, 60 * 5) + zigbee.batteryConfig() + zigbee.temperatureConfig(30, 60 * 30) + zigbee.enrollResponse()
+	def cmds = refresh() +
+			zigbee.configureReporting(zigbee.IAS_ZONE_CLUSTER, zigbee.ATTRIBUTE_IAS_ZONE_STATUS, DataType.BITMAP16, 30, 60 * 5, null) +
+			zigbee.batteryConfig() +
+			zigbee.temperatureConfig(30, 60 * 30) +
+			zigbee.enrollResponse()
 	if(getDataValue("manufacturer") == "Ecolink") {
 		cmds += configureEcolink()
 	}

--- a/devicetypes/smartthings/zigbee-sound-sensor.src/zigbee-sound-sensor.groovy
+++ b/devicetypes/smartthings/zigbee-sound-sensor.src/zigbee-sound-sensor.groovy
@@ -179,7 +179,7 @@ def configure() {
 			zigbee.writeAttribute(POLL_CONTROL_CLUSTER, FAST_POLL_TIMEOUT_ATTR, DataType.UINT16, 0x0028) + zigbee.writeAttribute(POLL_CONTROL_CLUSTER, CHECK_IN_INTERVAL_ATTR, DataType.UINT32, 0x00001950))
 
 	//send enroll commands, configures battery reporting to happen every 30 minutes, create binding for check in attribute so check ins will occur
-	return zigbee.enrollResponse() + zigbee.iasZoneConfig(30, 60 * 30) + zigbee.batteryConfig(60 * 30, 60 * 30 + 1) + zigbee.temperatureConfig(60 * 30, 60 * 30 + 1) + zigbee.configureReporting(POLL_CONTROL_CLUSTER, CHECK_IN_INTERVAL_ATTR, DataType.UINT32, 0, 3600, null) + refresh() + enrollCmds
+	return zigbee.enrollResponse() + zigbee.configureReporting(zigbee.IAS_ZONE_CLUSTER, zigbee.ATTRIBUTE_IAS_ZONE_STATUS, DataType.BITMAP16, 30, 60 * 30, null) + zigbee.batteryConfig(60 * 30, 60 * 30 + 1) + zigbee.temperatureConfig(60 * 30, 60 * 30 + 1) + zigbee.configureReporting(POLL_CONTROL_CLUSTER, CHECK_IN_INTERVAL_ATTR, DataType.UINT32, 0, 3600, null) + refresh() + enrollCmds
 }
 
 private boolean isZoneMessage(description) {

--- a/devicetypes/smartthings/zigbee-valve.src/zigbee-valve.groovy
+++ b/devicetypes/smartthings/zigbee-valve.src/zigbee-valve.groovy
@@ -158,7 +158,8 @@ def refresh() {
     cmds += zigbee.configureReporting(CLUSTER_BASIC, BASIC_ATTR_POWER_SOURCE, DataType.ENUM8, 5, 21600, 1)
     if (device.getDataValue("model") == "E253-KR0B0ZX-HA") {
         cmds += zigbee.readAttribute(zigbee.IAS_ZONE_CLUSTER, zigbee.ATTRIBUTE_IAS_ZONE_STATUS)
-        cmds += zigbee.iasZoneConfig()
+        cmds += zigbee.enrollResponse()
+        cmds += zigbee.configureReporting(zigbee.IAS_ZONE_CLUSTER, zigbee.ATTRIBUTE_IAS_ZONE_STATUS, DataType.BITMAP16, 0, 60 * 60, null)
     } else {
         cmds += zigbee.readAttribute(CLUSTER_POWER, POWER_ATTR_BATTERY_PERCENTAGE_REMAINING)
         cmds += zigbee.configureReporting(CLUSTER_POWER, POWER_ATTR_BATTERY_PERCENTAGE_REMAINING, DataType.UINT8, 600, 21600, 1)


### PR DESCRIPTION
This is because the iasZoneConfig zigbee library call also configures
reporting for the IAS CIE address which we don't need for any of these
devices.