### PR TITLE
WWST-2086 Cherry-pick Null pointer exception (#4137) to production

### DIFF
--- a/devicetypes/smartthings/smartweather-station-tile.src/smartweather-station-tile.groovy
+++ b/devicetypes/smartthings/smartweather-station-tile.src/smartweather-station-tile.groovy
@@ -215,7 +215,7 @@ def poll() {
             log.debug zipCode.substring(4)
             pollUsingPwsId(zipCode.substring(4).toUpperCase())
         } else {
-            pollUsingZipCode(zipCode.toUpperCase())
+            pollUsingZipCode(zipCode?.toUpperCase())
         }
     }
 }


### PR DESCRIPTION
If the user doesn’t enter a zipcode it causes a null pointer exception