### PR TITLE
[DVCSMP-4721] SmartSense Open/Close Sensor/NYCE Motion Sensor: Add missing DataType imports

### DIFF
--- a/devicetypes/smartthings/nyce-motion-sensor.src/nyce-motion-sensor.groovy
+++ b/devicetypes/smartthings/nyce-motion-sensor.src/nyce-motion-sensor.groovy
@@ -14,6 +14,7 @@
  *
  */
 import physicalgraph.zigbee.clusters.iaszone.ZoneStatus
+import physicalgraph.zigbee.zcl.DataType
 
 metadata {
 	definition (name: "NYCE Motion Sensor", namespace: "smartthings", author: "SmartThings", mnmn: "SmartThings", vid: "generic-motion-2") {

--- a/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-open-closed-sensor.src/smartsense-open-closed-sensor.groovy
@@ -14,6 +14,7 @@
  *
  */
 import physicalgraph.zigbee.clusters.iaszone.ZoneStatus
+import physicalgraph.zigbee.zcl.DataType
 
 metadata {
 	definition(name: "SmartSense Open/Closed Sensor", namespace: "smartthings", author: "SmartThings", runLocally: true, minHubCoreVersion: '000.017.0012', executeCommandsLocally: false, genericHandler: "Zigbee") {


### PR DESCRIPTION
This recent PR introduced the use of DataType in these DTHs but forgot to
import it:
https://github.com/SmartThingsCommunity/SmartThingsPublic/pull/4141

This bug has not yet gone to staging.

https://smartthings.atlassian.net/browse/DVCSMP-4721