### PR TITLE
[ICP-8219] Zigbee Plugin Motion Sensor: Removing failing call to refresh from installed

### DIFF
--- a/devicetypes/smartthings/zigbee-plugin-motion-sensor.src/zigbee-plugin-motion-sensor.groovy
+++ b/devicetypes/smartthings/zigbee-plugin-motion-sensor.src/zigbee-plugin-motion-sensor.groovy
@@ -41,9 +41,8 @@ metadata {
     }
 }
 
-def installed(){
+def installed() {
     log.debug "installed"
-    response(refresh())
 }
 
 def parse(String description) {


### PR DESCRIPTION
At the time "installed" is called the device isn't sufficiently initialized
so it's not possible to send the device Zigbee commands. If Zigbee commands
are attempted like they were before this change they will cause an exception
which will prevent the device from being initialized correctly.

https://smartthings.atlassian.net/browse/ICP-8219