### PR TITLE
[CHAD-1813] Arrival Sensor HA: Make the DTH run locally

### DIFF
--- a/devicetypes/smartthings/arrival-sensor-ha.src/arrival-sensor-ha.groovy
+++ b/devicetypes/smartthings/arrival-sensor-ha.src/arrival-sensor-ha.groovy
@@ -14,7 +14,8 @@ import groovy.json.JsonOutput
  *
  */
 metadata {
-    definition (name: "Arrival Sensor HA", namespace: "smartthings", author: "SmartThings") {
+    definition (name: "Arrival Sensor HA", namespace: "smartthings", author: "SmartThings",
+            runLocally: true, minHubCoreVersion: '000.025.00025', executeCommandsLocally: true) {
         capability "Tone"
         capability "Actuator"
         capability "Presence Sensor"
@@ -58,6 +59,7 @@ metadata {
 }
 
 def updated() {
+    stopTimer()
     startTimer()
 }
 
@@ -159,16 +161,19 @@ private handlePresenceEvent(present) {
 
 private startTimer() {
     log.debug "Scheduling periodic timer"
-    runEvery1Minute("checkPresenceCallback")
+    // Unlike stopTimer, only schedule this when running in the cloud since the hub will take care presence detection
+    // when it is running locally
+    runEvery1Minute("checkPresenceCallback", [forceForLocallyExecuting: false])
 }
 
 private stopTimer() {
     log.debug "Stopping periodic timer"
-    unschedule()
+    // Always unschedule to handle the case where the DTH was running in the cloud and is now running locally
+    unschedule("checkPresenceCallback", [forceForLocallyExecuting: true])
 }
 
 def checkPresenceCallback() {
-    def timeSinceLastCheckin = (now() - state.lastCheckin) / 1000
+    def timeSinceLastCheckin = (now() - state.lastCheckin ?: 0) / 1000
     def theCheckInterval = (checkInterval ? checkInterval as int : 2) * 60
     log.debug "Sensor checked in ${timeSinceLastCheckin} seconds ago"
     if (timeSinceLastCheckin >= theCheckInterval) {


### PR DESCRIPTION
The DTH is now marked to run locally on 0.18.20+. When it moves from cloud
execution to local execution `updated` will be called which will stop the
scheduled presence check running if it is currently running.

Also fixed an issue where `state.lastCheckin` is not set (presumably
because the device never sent us a message). Currently it raises an exception
but with the change it should just create a 'not present' event and then
stop the scheduled check.

https://smartthings.atlassian.net/browse/CHAD-1813