### PR TITLE
WWST-4222 Early fw versions of fibaro dimmer 2 do not support param 38

### DIFF
--- a/devicetypes/fibargroup/fibaro-dimmer-2-zw5.src/fibaro-dimmer-2-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-dimmer-2-zw5.src/fibaro-dimmer-2-zw5.groovy
@@ -150,7 +150,7 @@ def installed(){
 }
 
 def configure(){
-	  sendEvent(name: "switch", value: "off", displayed: "true") //set the initial state to off.
+	sendEvent(name: "switch", value: "off", displayed: "true") //set the initial state to off.
 }
 
 def updated() {
@@ -165,7 +165,10 @@ def syncStart() {
 	parameterMap().each {
 		if(settings."$it.key" != null) {
 			if (state."$it.key" == null) { state."$it.key" = [value: null, state: "synced"] }
-			if (state."$it.key".value != settings."$it.key" as Integer || state."$it.key".state in ["notSynced","inProgress"]) {
+			// this parameter (38) is not supported on some earlier firmware versions, so we'll mark it as already synced
+			if ("$it.key" == "levelCorrection" && (!zwaveInfo.ver || (zwaveInfo.ver as float) <= REDUCED_CONFIGURATION_VERSION)) {
+				state."$it.key".state = "synced"
+			} else if (state."$it.key".value != settings."$it.key" as Integer || state."$it.key".state in ["notSynced","inProgress"]) {
 				state."$it.key".value = settings."$it.key" as Integer
 				state."$it.key".state = "notSynced"
 				syncNeeded = true
@@ -446,6 +449,8 @@ private Map cmdVersions() {
 	[0x5E: 1, 0x86: 1, 0x72: 2, 0x59: 1, 0x73: 1, 0x22: 1, 0x31: 5, 0x32: 3, 0x71: 3, 0x56: 1, 0x98: 1, 0x7A: 2, 0x20: 1, 0x5A: 1, 0x85: 2, 0x26: 3, 0x8E: 2, 0x60: 3, 0x70: 2, 0x75: 2, 0x27: 1]
 }
 
+private getREDUCED_CONFIGURATION_VERSION() {3.04}
+
 private parameterMap() {[
 		[key: "autoStepTime", num: 6, size: 2, type: "enum", options: [
 				1: "10 ms",
@@ -491,5 +496,5 @@ private parameterMap() {[
 				2: "control mode selected automatically (based on auto-calibration)"
 		], def: "2", min: 0, max: 2 , title: "Load control mode", descr: "This parameter allows to set the desired load control mode. The device automatically adjusts correct control mode, but the installer may force its change using this parameter."],
 		[key: "levelCorrection", num: 38, size: 2, type: "number", def: 255, min: 0, max: 255 , title: "Brightness level correction for flickering loads",
-		 descr: "Correction reduces spontaneous flickering of some capacitive load (e.g. dimmable LEDs) at certain brightness levels in 2-wire installation. In countries using ripple-control, correction may cause changes in brightness. In this case it is necessary to disable correction or adjust time of correction for flickering loads. (1-254 – duration of correction in seconds. For further information please see the manual)"]
+		 descr: "[Only supported on device versions > $REDUCED_CONFIGURATION_VERSION] Correction reduces spontaneous flickering of some capacitive load (e.g. dimmable LEDs) at certain brightness levels in 2-wire installation. In countries using ripple-control, correction may cause changes in brightness. In this case it is necessary to disable correction or adjust time of correction for flickering loads. (1-254 – duration of correction in seconds. For further information please see the manual)"]
 ]}


### PR DESCRIPTION
Reports from users indicate v3.03 does not have support for this param, causing sync to never complete. Fibaro confirmed this was true for version 3.04 and below.