### PR TITLE
WWST-4050 Eaton 5-Scene Keypad switch to multi-component

### DIFF
--- a/devicetypes/smartthings/eaton-5-scene-keypad.src/eaton-5-scene-keypad.groovy
+++ b/devicetypes/smartthings/eaton-5-scene-keypad.src/eaton-5-scene-keypad.groovy
@@ -12,7 +12,7 @@
  *
  */
 metadata {
-	definition(name: "Eaton 5-Scene Keypad", namespace: "smartthings", author: "SmartThings", mnmn: "SmartThings", vid: "generic-switch") {
+	definition(name: "Eaton 5-Scene Keypad", namespace: "smartthings", author: "SmartThings", mcdSync: true) {
 		capability "Actuator"
 		capability "Health Check"
 		capability "Refresh"


### PR DESCRIPTION
set multi-component flag and device should now point to custom metadata