### PR TITLE
[ICP-9587] Changed deviceJoinName and deleted doubled fingerprint

### DIFF
--- a/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-white-color-temperature-bulb.src/zigbee-white-color-temperature-bulb.groovy
@@ -80,8 +80,7 @@ metadata {
 		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 0300", outClusters: "0019", manufacturer: "ETI", model: "Zigbee CCT Downlight", deviceJoinName: "Commercial Electric Can Tunable White"
 
 		// Muller Licht Tint
-		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 0300, 1000", outClusters: "0019", manufacturer: "MLI", model: "ZBT-ColorTemperature", deviceJoinName: "Müller Licht Tint GU10 Spot White"
-		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 0300, 1000", outClusters: "0019", manufacturer: "MLI", model: "ZBT-ColorTemperature", deviceJoinName: "Müller Licht Tint Candle White"
+		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 0300, 1000", outClusters: "0019", manufacturer: "MLI", model: "ZBT-ColorTemperature", deviceJoinName: "Müller Licht Tint White Bulb"
 	}
 
 	// UI tile definitions


### PR DESCRIPTION
@greens @MMateusiakS There is a problem with two Muller's Licht bulbs: Tint GU10 Spot White, Tint Candle White which shares the same DTH and the same fingerprint as well. The same fingerprints are making them indistinguishable and that is why both bulbs are pairing with the first fingerprint we've made (with the deviceJoinName for GU10 Spot White). Muller Licht did not give different model names in fingerprints for these bulbs so our solution, for now, is to leave only one fingerprint for both bulbs and give them one universal name "Muller Licht Tint White Bulb". What do you think about this? Maybe we should contact with Muller Licht and ask if they don't want to update model names in those fingerprints?