### PR TITLE
ICP-9675: device type should change to energy meter

### DIFF
--- a/devicetypes/smartthings/ezex-smart-electric-switch.src/ezex-smart-electric-switch.groovy
+++ b/devicetypes/smartthings/ezex-smart-electric-switch.src/ezex-smart-electric-switch.groovy
@@ -12,7 +12,7 @@
  *
  */
 metadata {
-    definition (name: "eZEX smart electric switch", namespace: "smartthings", author: "SmartThings", mnmn: "SmartThings", vid: "generic-switch-power-energy") {
+    definition (name: "eZEX smart electric switch", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "x.com.st.d.energymeter", mnmn: "SmartThings", vid: "generic-switch-power-energy") {
         capability "Energy Meter"
         capability "Power Meter"
         capability "Actuator"


### PR DESCRIPTION
@tpmanley  the ezex electric switch's icon be request changing to energy meter, so modify the device type. 