### PR TITLE
[WWST-2350, WWST-2353] Aeotec Wallmote: Fix issue syncing components to OCF

### DIFF
--- a/devicetypes/smartthings/aeotec-wallmote.src/aeotec-wallmote.groovy
+++ b/devicetypes/smartthings/aeotec-wallmote.src/aeotec-wallmote.groovy
@@ -49,6 +49,7 @@ def getNumberOfButtons() {
 }
 
 def installed() {
+    createChildDevices()
     sendEvent(name: "numberOfButtons", value: numberOfButtons)
     sendEvent(name: "supportedButtonValues", value: ["pushed", "held"])
     sendEvent(name: "button", value: "pushed", data: [buttonNumber: 1])
@@ -68,7 +69,6 @@ def updated() {
 
 def configure() {
     sendEvent(name: "DeviceWatch-Enroll", value: [protocol: "zwave", scheme:"untracked"].encodeAsJson(), displayed: false)
-    createChildDevices()
     response([
             secure(zwave.batteryV1.batteryGet()),
             "delay 2000",


### PR DESCRIPTION
By creating the components in `installed` we avoid a platform bug with the syncing of components that are created after the device is created (aka in `updated`). Before this change was made I wasn't seeing all the components on the device view in the new SmartThings app and after this change I did.

https://smartthings.atlassian.net/browse/WWST-2353
https://smartthings.atlassian.net/browse/WWST-2350