### PR TITLE
ICP-9647 OneApp expecting level events after setLevels, even if value…

### DIFF
--- a/devicetypes/smartthings/zigbee-accessory-dimmer.src/zigbee-accessory-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-accessory-dimmer.src/zigbee-accessory-dimmer.groovy
@@ -81,7 +81,7 @@ def parse(String description) {
 					if (value == 0) {
 						sendEvent(name: "switch", value: "off")
 					} else {
-						sendEven t(name: "level", value: value)
+						sendEvent(name: "level", value: value)
 					}
 				}
 			} else if (descMap.commandInt == 0x01) {

--- a/devicetypes/smartthings/zigbee-accessory-dimmer.src/zigbee-accessory-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-accessory-dimmer.src/zigbee-accessory-dimmer.groovy
@@ -120,7 +120,11 @@ def setLevel(value, rate = null) {
 	} else {
 		sendEvent(name: "switch", value: "on")
 	}
-	sendEvent(name: "level", value: value)
+	runIn(1, delayedSend, [data: createEvent(name: "level", value: value), overwrite: true])
+}
+
+def delayedSend(data) {
+	sendEvent(data)
 }
 
 def installed() {

--- a/devicetypes/smartthings/zigbee-accessory-dimmer.src/zigbee-accessory-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-accessory-dimmer.src/zigbee-accessory-dimmer.groovy
@@ -81,7 +81,7 @@ def parse(String description) {
 					if (value == 0) {
 						sendEvent(name: "switch", value: "off")
 					} else {
-						sendEvent(name: "level", value: value)
+						sendEven t(name: "level", value: value)
 					}
 				}
 			} else if (descMap.commandInt == 0x01) {
@@ -115,10 +115,12 @@ def on() {
 def setLevel(value, rate = null) {
 	if (value == 0) {
 		sendEvent(name: "switch", value: "off")
+		// OneApp expects a level event when the dimmer value is changed
+		value = device.currentValue("level")
 	} else {
 		sendEvent(name: "switch", value: "on")
-		sendEvent(name: "level", value: value)
 	}
+	sendEvent(name: "level", value: value)
 }
 
 def installed() {

--- a/devicetypes/smartthings/zigbee-battery-accessory-dimmer.src/zigbee-battery-accessory-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-battery-accessory-dimmer.src/zigbee-battery-accessory-dimmer.groovy
@@ -312,10 +312,12 @@ def on() {
 def setLevel(value, rate = null) {
 	if (value == 0) {
 		sendEvent(name: "switch", value: "off")
+		// OneApp expects a level event when the dimmer value is changed
+		value = device.currentValue("level")
 	} else {
 		sendEvent(name: "switch", value: "on")
-		sendEvent(name: "level", value: value)
 	}
+	sendEvent(name: "level", value: value)
 }
 
 def ping() {

--- a/devicetypes/smartthings/zigbee-battery-accessory-dimmer.src/zigbee-battery-accessory-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-battery-accessory-dimmer.src/zigbee-battery-accessory-dimmer.groovy
@@ -317,7 +317,11 @@ def setLevel(value, rate = null) {
 	} else {
 		sendEvent(name: "switch", value: "on")
 	}
-	sendEvent(name: "level", value: value)
+	runIn(1, delayedSend, [data: createEvent(name: "level", value: value), overwrite: true])
+}
+
+def delayedSend(data) {
+	sendEvent(data)
 }
 
 def ping() {


### PR DESCRIPTION
… does not change

OneApp will timeout waiting for a level event that won't occur. This is fine for physical devices since we poll them after sets anyway, but for these emulated devices we'll need to fake it to match.