### PR TITLE
WWST-2325 - DTH upgrade - Aurora Smart PIR Sensor

### DIFF
--- a/devicetypes/smartthings/motion-detector.src/motion-detector.groovy
+++ b/devicetypes/smartthings/motion-detector.src/motion-detector.groovy
@@ -17,8 +17,8 @@ metadata {
 		capability "Sensor"
 
 		fingerprint profileId: "0104", deviceId: "0402", inClusters: "0000,0001,0003,0009,0500"
-		//raw description 23 0104 0402 00 06 0000 0001 0003 000F 0020 0500 02 000A 0019
-		fingerprint endpoint: "23", profileId: "0104", inClusters: "0000,0001,0003,000F,0020,0500", outClusters: "000A,0019", deviceJoinName: "Aurora Smart PIR Sensor"
+		//raw description 22 0104 0107 00 03 0000 0003 0406 00
+		fingerprint mfr: "Aurora", model: "MotionSensor51AU", deviceJoinName: "Aurora Smart PIR Sensor"
 	}
 
 	// simulator metadata

--- a/devicetypes/smartthings/motion-detector.src/motion-detector.groovy
+++ b/devicetypes/smartthings/motion-detector.src/motion-detector.groovy
@@ -17,8 +17,8 @@ metadata {
 		capability "Sensor"
 
 		fingerprint profileId: "0104", deviceId: "0402", inClusters: "0000,0001,0003,0009,0500"
-		//raw data: 01 C0C9 0001 01 03 0003 0005 0006 00
-		fingerprint profileId: "C0C9", deviceId: "0001", inClusters: "0003,0005,0006",  deviceJoinName: "Aurora Smart PIR Sensor"
+		//raw description 23 0104 0402 00 06 0000 0001 0003 000F 0020 0500 02 000A 0019
+		fingerprint endpoint: "23", profileId: "0104", inClusters: "0000,0001,0003,000F,0020,0500", outClusters: "000A,0019", deviceJoinName: "Aurora Smart PIR Sensor"
 	}
 
 	// simulator metadata

--- a/devicetypes/smartthings/motion-detector.src/motion-detector.groovy
+++ b/devicetypes/smartthings/motion-detector.src/motion-detector.groovy
@@ -18,7 +18,7 @@ metadata {
 
 		fingerprint profileId: "0104", deviceId: "0402", inClusters: "0000,0001,0003,0009,0500"
 		//raw description 22 0104 0107 00 03 0000 0003 0406 00
-		fingerprint mfr: "Aurora", model: "MotionSensor51AU", deviceJoinName: "Aurora Smart PIR Sensor"
+		fingerprint manufacturer: "Aurora", model: "MotionSensor51AU", deviceJoinName: "Aurora Smart PIR Sensor"
 	}
 
 	// simulator metadata

--- a/devicetypes/smartthings/motion-detector.src/motion-detector.groovy
+++ b/devicetypes/smartthings/motion-detector.src/motion-detector.groovy
@@ -17,6 +17,8 @@ metadata {
 		capability "Sensor"
 
 		fingerprint profileId: "0104", deviceId: "0402", inClusters: "0000,0001,0003,0009,0500"
+		//raw data: 01 C0C9 0001 01 03 0003 0005 0006 00
+		fingerprint profileId: "C0C9", deviceId: "0001", inClusters: "0003,0005,0006",  deviceJoinName: "Aurora Smart PIR Sensor"
 	}
 
 	// simulator metadata


### PR DESCRIPTION
@greens @tpmanley @MAblewiczS @ZWozniakS @MGoralczykS @PKacprowiczS 

Raw data of this one is quite short: 01 C0C9 0001 01 03 0003 0005 0006 00
No manufacturer and no model in device’s details in graphapi.
I’ve managed to pair this device using this fingerprint:
fingerprint profileId: "C0C9", deviceId: "0001", inClusters: "0003,0005,0006" , deviceJoinName: "Aurora Smart PIR Sensor"

Please take a look.

