### PR TITLE
ICP-8076 Manually generate chime events, restart alarm if it was active

### DIFF
--- a/devicetypes/smartthings/philio-multiple-sound-siren.src/philio-multiple-sound-siren.groovy
+++ b/devicetypes/smartthings/philio-multiple-sound-siren.src/philio-multiple-sound-siren.groovy
@@ -62,6 +62,7 @@ metadata {
 	}
 
 	preferences {
+		// Philio Siren treats chime as momentary and does NOT provide a status update to us, so DON'T allow this as an alarm sound preference.
 		input "sound", "enum", title: "What sound should play for an alarm event?", description: "Default is 'Emergency'", options: ["Smoke", "Emergency", "Police", "Fire", "Ambulance"]
 		input "duration", "enum", title: "How long should the sound play?", description: "Default is 'Forever'", options: ["Forever", "30 seconds", "1 minute", "2 minutes", "3 minutes", "5 minutes", "10 minutes", "20 minutes", "30 minutes", "45 minutes", "1 hour"]
 	}
@@ -76,6 +77,8 @@ def getSoundMap() {[
 			notificationType: 0x01,
 			event: 0x01
 		],
+	// Philio Siren treats chime as momentary and does NOT provide a status update to us,
+	// so DON'T allow this as an alarm sound preference.
 	Chime: [
 			notificationType: 0x06,
 			event: 0x16
@@ -137,7 +140,10 @@ def installed() {
 	state.duration = defaultDuration
 
 	// Get default values
-	response([secure(zwave.basicV1.basicGet()), secure(zwave.configurationV1.configurationSet(parameterNumber: 31, size: 1, configurationValue: [durationMap[state.duration]]))])
+	response([
+			secure(zwave.basicV1.basicGet()),
+			secure(zwave.configurationV1.configurationSet(parameterNumber: 31, size: 1, configurationValue: [durationMap[state.duration]]))
+		])
 }
 
 def updated() {
@@ -175,6 +181,7 @@ private getCommandClassVersions() {
 def parse(String description) {
 	log.debug "parse($description)"
 	def result = null
+
 	if (description.startsWith("Err")) {
 		if (zwInfo?.zw?.contains("s")) {
 			result = createEvent(descriptionText:description, displayed:false)
@@ -267,17 +274,30 @@ def generateCommand(command) {
 	secure(zwave.notificationV3.notificationReport(notificationType: sound.notificationType, event: sound.event))
 }
 
+def chimeOff() {
+	log.debug "chimeOff()"
+	sendEvent(name: "chime", value: "off")
+
+	// If chime() was called during an alarm event, we need to verify that and reset the alarm,
+	// as the alarm does not properly appear to do that.
+	def currentAlarm = device.currentValue("alarm")
+	if (currentAlarm && currentAlarm != "off") {
+		log.debug "resetting alarm..."
+
+		sendHubCommand(on())
+	}
+}
+
 def chime() {
+	def results = []
 	log.debug "chime!"
 
 	// Chime is kind of special as the alarm treats it as momentary
-	// and thus sends no updates to us, so we'll send this and request an update
+	// and thus sends no updates to us, so we'll send this event and then send an off event soon after.
 	sendEvent(name: "chime", value: "chime")
+	runIn(1, "chimeOff", [overwrite: true])
 
-	[
-		generateCommand("Chime"),
-		secure(zwave.basicV1.basicGet())
-	]
+	generateCommand("Chime")
 }
 
 def on() {


### PR DESCRIPTION
Send `chime:off` ourselves, instead of trying to ask the device its current state. There's a chance that packet might be missed, or the device doesn't process it. We know that, in the current firmware, the chime command to the device is only momentary.

Also, if the siren was going off (either with `alarm.on()` or by a tamper event) when a `chime.chime()` event is received make sure to restart the alarm as the device won't do so itself.