### PR TITLE
Configurable acceleration sensitivity

### DIFF
--- a/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+++ b/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2016 SmartThings
+ *  Copyright 2016 SmartThings, Contribution by RBoy Apps
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
  *  use this file except in compliance with the License. You may obtain a copy


### PR DESCRIPTION
Add support for configuring acceleration sensitivity for 2nd gen and 3rd gen chipsets. Default sensitivity can be too high for most uses as it leads to false triggering from nearby vibrations and insufficient for specialized use cases where careful handling of sensor doesn't trigger it.

@tpmanley to follow up on our discussion. Tested with the v2 sensor, please test on the v3 sensor.