### PR TITLE
WWST-4216 - DTH upgrade: Alfred Smart Home Touchscreen Deadbolt / DB2

### DIFF
--- a/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
+++ b/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
@@ -26,6 +26,7 @@ metadata {
 		fingerprint mfr: "010E", prod: "0009", model: "0001", deviceJoinName: "Danalock V3 Smart Lock"
 		fingerprint mfr: "0090", prod: "0003", model: "0446", deviceJoinName: "Kwikset Convert Deadbolt Door Lock" //99140
 		fingerprint mfr: "033F", prod: "0001", model: "0001", deviceJoinName: "August Smart Lock Pro"
+		fingerprint mfr: "021D", prod: "0003", model: "0001", deviceJoinName: "Alfred Smart Home Touchscreen Deadbolt" // DB2
 	}
 
 	simulator {


### PR DESCRIPTION
Raw description:
zw:Fs type:4003 mfr:021D prod:0003 model:0001 ver:3.01 zwv:5.03 lib:03 cc:5E,6C,55,8A,98,9F sec:86,72,5A,73,80,62,63,8B,85,8E,71,89,59,7A role:07 ff:8300 ui:8300

@greens @MAblewiczS @ZWozniakS @MGoralczykS @PKacprowiczS


According to discussion in "WWST-4216" (device doesn't report which code was updated) - device will be handled in zwave-lock-without-codes.groovy

Finger print only, please take a look.
