### PR TITLE
ICP-9902 Change normal battery raproting for C2O lock from 50 to 55 t…

### DIFF
--- a/devicetypes/smartthings/zigbee-lock-without-codes.src/zigbee-lock-without-codes.groovy
+++ b/devicetypes/smartthings/zigbee-lock-without-codes.src/zigbee-lock-without-codes.groovy
@@ -216,7 +216,7 @@ private def parseAttributeResponse(String description) {
 
 private def parseIasMessage(String description) {
 	ZoneStatus zs = zigbee.parseZoneStatus(description)
-	def responseMap = [ name: "battery", value: zs.isBatterySet() ? 5 : 50]
+	def responseMap = [ name: "battery", value: zs.isBatterySet() ? 5 : 55]
 	return responseMap
 }
 
@@ -269,7 +269,7 @@ private def parseCommandResponse(String description) {
 		//isBatterySet() == false -> battery is ok -> send value 50
 		//isBatterySet() == true -> battery is low -> send value 5
 		//metadata can receive 2 values: 5 or 50 for C2O lock
-		responseMap = [ name: "battery", value: zs.isBatterySet() ? 5 : 50]
+		responseMap = [ name: "battery", value: zs.isBatterySet() ? 5 : 55]
 	}
 
 	result << createEvent(responseMap)


### PR DESCRIPTION
ICP-9902 Change normal battery raproting for C2O lock from 50 to 55 to use diffrent icon in SmartThing mobile app.

@greens @tpmanley @dkirker 
Could you review this small change?