### PR TITLE
ICP-9525 Move Philio Smart Plug fingerprint

### DIFF
--- a/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
+++ b/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
@@ -34,7 +34,6 @@ metadata {
 		fingerprint profileId: "0010", inClusters: "0000 0003 0004 0005 0006 0008 0702 0B05", outClusters: "0019", manufacturer: "innr", model: "SP 120", deviceJoinName: "Innr Smart Plug"
 		fingerprint profileId: "0104", inClusters: "0000,0002,0003,0004,0005,0006,0009,0B04,0702", outClusters: "0019,000A,0003,0406", manufacturer: "Aurora", model: "SmartPlug51AU", deviceJoinName: "Aurora SmartPlug"
 		fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0702,0B04,0B05,FC03", outClusters: "0019", manufacturer: "CentraLite", model: "3210-L", deviceJoinName: "Iris Smart Plug"
-		fingerprint manufacturer: " ", model: "PAN18-v1.0.7", deviceJoinName: "Philio Smart Plug"
 	}
 
 	// simulator metadata

--- a/devicetypes/smartthings/zigbee-switch-power.src/zigbee-switch-power.groovy
+++ b/devicetypes/smartthings/zigbee-switch-power.src/zigbee-switch-power.groovy
@@ -29,6 +29,7 @@ metadata {
 		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0702, 0B05", outClusters: "000A, 0019", manufacturer: "Jasco Products", model: "45856", deviceJoinName: "GE ZigBee In-Wall Switch"
 		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0702", outClusters: "0000", manufacturer: "ClimaxTechnology", model: "PSM_00.00.00.35TC", deviceJoinName: "Ozom Smart Plug"
 		fingerprint profileId: "0104", inClusters: "0000, 0702, 0003, 0009, 0B04, 0006, 0004, 0005, 0002", outClusters: "0000, 0019, 000A, 0003, 0406", manufacturer: "Develco Products A/S", model: "Smart16ARelay51AU", deviceJoinName: "Aurora Smart Inline Relay"
+		fingerprint manufacturer: " ", model: "PAN18-v1.0.7", deviceJoinName: "Philio Smart Plug", ocfDeviceType: "oic.d.smartplug" //profileId: "0104", inClusters: "0000, 0003, 0006, 0702", outClusters: "0003, 0019",
 	}
 
 	tiles(scale: 2) {


### PR DESCRIPTION
This is why including clusters in the fingerprint is important, I guess. Device was added to a DTH that uses the electrical measurement cluster, but it uses simple metering. Power readings were not being parsed.