### PR TITLE
ICP-8170 Set divisor for Aurora energy readings

### DIFF
--- a/devicetypes/smartthings/zigbee-switch-power.src/zigbee-switch-power.groovy
+++ b/devicetypes/smartthings/zigbee-switch-power.src/zigbee-switch-power.groovy
@@ -59,7 +59,8 @@ def parse(String description) {
 	if (event) {
 		if (event.name == "power") {
 			def powerValue
-			powerValue = (event.value as Integer)/10			//TODO: The divisor value needs to be set as part of configuration
+			def div = state.divisor ?: 10
+			powerValue = (event.value as Integer)/div
 			sendEvent(name: "power", value: powerValue)
 		}
 		else {
@@ -93,6 +94,9 @@ def refresh() {
 
 def configure() {
 	log.debug "in configure()"
+	if (device.getDataValue("manufacturer") == "Aurora") {
+		state.divisor = 1
+	}
 	return configureHealthCheck()
 }
 

--- a/devicetypes/smartthings/zigbee-switch-power.src/zigbee-switch-power.groovy
+++ b/devicetypes/smartthings/zigbee-switch-power.src/zigbee-switch-power.groovy
@@ -59,7 +59,8 @@ def parse(String description) {
 	if (event) {
 		if (event.name == "power") {
 			def powerValue
-			def div = state.divisor ?: 10
+			def div = device.getDataValue("divisor")
+			div = div ? (div as int) : 10
 			powerValue = (event.value as Integer)/div
 			sendEvent(name: "power", value: powerValue)
 		}
@@ -95,7 +96,7 @@ def refresh() {
 def configure() {
 	log.debug "in configure()"
 	if (device.getDataValue("manufacturer") == "Aurora") {
-		state.divisor = 1
+		device.updateDataValue("divisor", "1")
 	}
 	return configureHealthCheck()
 }

--- a/devicetypes/smartthings/zigbee-switch-power.src/zigbee-switch-power.groovy
+++ b/devicetypes/smartthings/zigbee-switch-power.src/zigbee-switch-power.groovy
@@ -95,7 +95,7 @@ def refresh() {
 
 def configure() {
 	log.debug "in configure()"
-	if (device.getDataValue("manufacturer") == "Aurora") {
+	if (device.getDataValue("manufacturer") == "Develco Products A/S") {
 		device.updateDataValue("divisor", "1")
 	}
 	return configureHealthCheck()


### PR DESCRIPTION
Should leverage code changes made in hubcore 26 to allow the multiplier/divisor fields to be set in the DTH but still used in local execution.