### PR TITLE
CHAD-3509 Enable mcdSync for z-wave device multichannel

### DIFF
--- a/devicetypes/smartthings/zwave-device-multichannel.src/zwave-device-multichannel.groovy
+++ b/devicetypes/smartthings/zwave-device-multichannel.src/zwave-device-multichannel.groovy
@@ -12,7 +12,7 @@
  *
  */
 metadata {
-	definition (name: "Z-Wave Device Multichannel", namespace: "smartthings", author: "SmartThings") {
+	definition (name: "Z-Wave Device Multichannel", namespace: "smartthings", author: "SmartThings", mcdSync: true) {
 		capability "Actuator"
 		capability "Switch"
 		capability "Switch Level"


### PR DESCRIPTION
Hopefully fallback metadata is enough to work for this.