### PR TITLE
ICP-9040 Check to see if operating state from thermostat is correct when we set mode to off

### DIFF
--- a/devicetypes/stelpro/stelpro-ki-zigbee-thermostat.src/stelpro-ki-zigbee-thermostat.groovy
+++ b/devicetypes/stelpro/stelpro-ki-zigbee-thermostat.src/stelpro-ki-zigbee-thermostat.groovy
@@ -418,7 +418,7 @@ def validateOperatingStateBugfix(map) {
 	if (state.rawSetpoint != null && state.rawTemp != null) {
 		def oldVal = map.value
 
-		if (state.rawSetpoint <= state.rawTemp) {
+		if (state.rawSetpoint <= state.rawTemp || device.currentValue("thermostatMode") == "off") {
 			map.value = "idle"
 		} else {
 			map.value = "heating"
@@ -429,6 +429,7 @@ def validateOperatingStateBugfix(map) {
 			map.data = [correctedValue: true]
 		}
 	}
+
 	map
 }
 


### PR DESCRIPTION
This change checks to see if the current mode is off and forces the operatingState to be idle if it told us it was heating. Sometimes the thermostat indicates that it is heating using the somewhat arbitrary heat demand value even if the mode is off or the temperature is not currently valid for heating.