### PR TITLE
Removing entrypoint command from circle build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ defaults: &defaults
   working_directory: ~/SmartThingsCommunity/SmartThingsPublic
   docker:
     - image: smartthings-docker-build.jfrog.io/releng/build-common:latest
-      command: /sbin/init
       auth:
         username: $ARTIFACTORY_USERNAME
         password: $ARTIFACTORY_PASSWORD


### PR DESCRIPTION
Removed the entrypoint from circle-ci config per https://support.circleci.com/hc/en-us/articles/360013144894-Resolving-CircleCI-was-unable-to-start-the-container-

While no changes occurred on our end, my guess is some contract was broken on the CircleCI side. This change allowed internal builds to pass.