### PR TITLE
[ICP-9111, ICP-10109, ICP-10123, ICP-10121, ICP-10136, ICP-10646] Z-Wave Multi Metering Switch: Fix problem with automations and child devices

### DIFF
--- a/devicetypes/smartthings/zwave-multi-metering-switch.src/zwave-multi-metering-switch.groovy
+++ b/devicetypes/smartthings/zwave-multi-metering-switch.src/zwave-multi-metering-switch.groovy
@@ -101,7 +101,7 @@ def zwaveEvent(physicalgraph.zwave.commands.switchbinaryv1.SwitchBinaryReport cm
 
 private changeSwitch(endpoint, value) {
 	def result = []
-	if(endpoint == 1) {
+	if (endpoint == 1) {
 		result += createEvent(name: "switch", value: value, isStateChange: true, descriptionText: "Switch ${endpoint} is ${value}")
 	} else {
 		String childDni = "${device.deviceNetworkId}:$endpoint"
@@ -114,7 +114,7 @@ private changeSwitch(endpoint, value) {
 def zwaveEvent(physicalgraph.zwave.commands.meterv3.MeterReport cmd, ep) {
 	log.debug "Meter ${cmd}" + (ep ? " from endpoint $ep" : "")
 	def result = []
-	if(ep == 1) {
+	if (ep == 1) {
 		result += createEvent(createMeterEventMap(cmd))
 	} else if(ep) {
 		String childDni = "${device.deviceNetworkId}:$ep"
@@ -286,16 +286,14 @@ private secureEncap(cmd, endpoint = null) {
 }
 
 private addChildSwitches(numberOfSwitches) {
-	for(def endpoint : 2..numberOfSwitches) {
+	for (def endpoint : 2..numberOfSwitches) {
 		try {
 			String childDni = "${device.deviceNetworkId}:$endpoint"
 			def componentLabel = device.displayName[0..-2] + "${endpoint}"
 			addChildDevice("Child Metering Switch", childDni, device.getHub().getId(), [
 					completedSetup: true,
 					label         : componentLabel,
-					isComponent   : false,
-					componentName : "switch$endpoint",
-					componentLabel: "Switch $endpoint"
+					isComponent   : false
 			])
 		} catch(Exception e) {
 			log.debug "Exception: ${e}"
@@ -334,7 +332,7 @@ private lateConfigure() {
 }
 
 private getDeviceModel() {
-	if((zwaveInfo.mfr?.contains("0086") && zwaveInfo.model?.contains("0084")) || (getDataValue("mfr") == "86") && (getDataValue("model") == "84")) {
+	if ((zwaveInfo.mfr?.contains("0086") && zwaveInfo.model?.contains("0084")) || (getDataValue("mfr") == "86") && (getDataValue("model") == "84")) {
 		"Aeotec Nano Switch"
 	} else if(zwaveInfo.mfr?.contains("027A")) {
 		"Zooz Switch"


### PR DESCRIPTION
Even though this isn't a MCD DTH it was setting the componentName and componentLabel on the child devices. The platform expects that a single component device always calls that component "main". Since these child devices had a component named something other than "main", for example "switch2", it was causing errors during operations like creating automations.

https://smartthings.atlassian.net/browse/ICP-10646