### PR TITLE
Allow user to select icon for generic child switch

### DIFF
--- a/devicetypes/smartthings/child-switch.src/child-switch.groovy
+++ b/devicetypes/smartthings/child-switch.src/child-switch.groovy
@@ -19,7 +19,7 @@ metadata {
 	}
 
 	tiles(scale: 2) {
-		multiAttributeTile(name: "switch", width: 6, height: 4, canChangeIcon: false) {
+		multiAttributeTile(name: "switch", width: 6, height: 4, canChangeIcon: true) {
 			tileAttribute("device.switch", key: "PRIMARY_CONTROL") {
 				attributeState "on", label: '${name}', action: "switch.off", icon: "st.switches.light.on", backgroundColor: "#00a0dc"
 				attributeState "off", label: '${name}', action: "switch.on", icon: "st.switches.light.off", backgroundColor: "#ffffff"


### PR DESCRIPTION
The default icon is a light bulb but the child DTH is a generic switch. It can (is) used by many DTH's using multi component devices for switch endpoints. This allows the user to select their own icon there by allow it to be more meaningful when used a child switch or outlet.

@greens this CR is based on user feedback