### PR TITLE
[ICP-9962] Re-include fingerprint for Zooz 4-in-1 sensor

### DIFF
--- a/devicetypes/smartthings/zooz-4-in-1-sensor.src/zooz-4-in-1-sensor.groovy
+++ b/devicetypes/smartthings/zooz-4-in-1-sensor.src/zooz-4-in-1-sensor.groovy
@@ -23,7 +23,7 @@ metadata {
 		capability "Health Check"
 		capability "Tamper Alert"
 
-//		fingerprint mfr: "027A", prod: "2021", model: "2101", deviceJoinName: "Zooz 4-in-1 sensor"
+		fingerprint mfr: "027A", prod: "2021", model: "2101", deviceJoinName: "Zooz 4-in-1 sensor"
 	}
 
 	tiles(scale: 2) {


### PR DESCRIPTION
According to discussion in Jira ticket, manufacturer stated that late illuminance report is expected, so we can go with certification.
@greens @dkirker 