### PR TITLE
ICP-10824 - Added fake 'no motion' event to pairing process for Aurora Smart PIR sensor

### DIFF
--- a/devicetypes/smartthings/motion-detector.src/motion-detector.groovy
+++ b/devicetypes/smartthings/motion-detector.src/motion-detector.groovy
@@ -46,7 +46,7 @@ def installed() {
 	if(isAuroraMotionSensor51AU()) {
 		// Aurora Smart PIR Sensor doesn't report when there is no motion during pairing process
 		// reports are sent only if there is motion detected, so fake event is needed here
-		sendEvent(name: "motion", value: "inactive", descriptionText: "${device.displayName} - initially no motion" )
+		sendEvent(name: "motion", value: "inactive", displayed: false)
 	}
 }
 

--- a/devicetypes/smartthings/motion-detector.src/motion-detector.groovy
+++ b/devicetypes/smartthings/motion-detector.src/motion-detector.groovy
@@ -14,7 +14,6 @@
 metadata {
 	definition (name: "Motion Detector", namespace: "smartthings", author: "SmartThings") {
 		capability "Actuator"
-		capability "Configuration"
 		capability "Health Check"
 		capability "Motion Sensor"
 		capability "Sensor"
@@ -44,6 +43,11 @@ metadata {
 
 def installed() {
 	initialize()
+	if(isAuroraMotionSensor51AU()) {
+		// Aurora Smart PIR Sensor doesn't report when there is no motion during pairing process
+		// reports are sent only if there is motion detected, so fake event is needed here
+		sendEvent(name: "motion", value: "inactive", descriptionText: "${device.displayName} - initially no motion" )
+	}
 }
 
 def updated() {
@@ -85,11 +89,9 @@ def parse(String description) {
 }
 
 def isTracked() {
-	return device.getDataValue("model") == "MotionSensor51AU"
+	return isAuroraMotionSensor51AU()
 }
 
-def configure() {
-	log.debug "configure"
-	return	zigbee.configureReporting(zigbee.IAS_ZONE_CLUSTER, zigbee.ATTRIBUTE_IAS_ZONE_STATUS, 0x19, 0, 180, null) +
-			zigbee.readAttribute(zigbee.IAS_ZONE_CLUSTER, zigbee.ATTRIBUTE_IAS_ZONE_STATUS)
+def isAuroraMotionSensor51AU() {
+	return device.getDataValue("model") == "MotionSensor51AU"
 }


### PR DESCRIPTION
Added fake 'no motion' event to pairing process for Aurora Smart PIR sensor. 
Removed 'Configuration' capability, because polling this device in pairing process didn't help.

@tpmanley @greens @MAblewiczS @ZWozniakS @MGoralczykS @PKacprowiczS 
Please take a look.