### PR TITLE
[ICP-11101] Child devices of hub connected devices not being added to room on join

### DIFF
--- a/devicetypes/erocm123/inovelli-2-channel-smart-plug.src/inovelli-2-channel-smart-plug.groovy
+++ b/devicetypes/erocm123/inovelli-2-channel-smart-plug.src/inovelli-2-channel-smart-plug.groovy
@@ -254,8 +254,14 @@ private channelNumber(String dni) {
 private void createChildDevices() {
 	state.oldLabel = device.label
 	for (i in 1..2) {
-		addChildDevice("Switch Child Device", "${device.deviceNetworkId}-ep${i}", null, [completedSetup: true, label: "${device.displayName} (CH${i})",
-																						 isComponent: true, componentName: "ep$i", componentLabel: "Channel $i"
+		addChildDevice("Switch Child Device",
+				"${device.deviceNetworkId}-ep${i}",
+				device.hubId,
+				[completedSetup: true,
+				 label: "${device.displayName} (CH${i})",
+				 isComponent: true,
+				 componentName: "ep$i",
+				 componentLabel: "Channel $i"
 		])
 	}
 }

--- a/devicetypes/fibargroup/fibaro-double-switch-2-zw5.src/fibaro-double-switch-2-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-double-switch-2-zw5.src/fibaro-double-switch-2-zw5.groovy
@@ -265,8 +265,10 @@ private createChildDevices() {
 		addChildDevice(
 			"Fibaro Double Switch 2 - USB",
 			"${device.deviceNetworkId}-2",
-			null,
-			[completedSetup: true, label: "${device.displayName} (CH2)", isComponent: false]
+			device.hubId,
+			[completedSetup: true,
+			 label: "${device.displayName} (CH2)",
+			 isComponent: false]
 		)
 	} catch (Exception e) {
 		logging("${device.displayName} - error attempting to create child device: "+e, "debug")

--- a/devicetypes/fibargroup/fibaro-wall-plug-us-zw5.src/fibaro-wall-plug-us-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-wall-plug-us-zw5.src/fibaro-wall-plug-us-zw5.groovy
@@ -241,8 +241,10 @@ private createChildDevices() {
 	addChildDevice(
 			"Fibaro Wall Plug USB",
 			"${device.deviceNetworkId}-2",
-			null,
-			[completedSetup: true, label: "${device.displayName} (CH2)", isComponent: false]
+			device.hubId,
+			[completedSetup: true,
+			 label: "${device.displayName} (CH2)",
+			 isComponent: false]
 	)
 }
 

--- a/devicetypes/smartthings/aeon-key-fob.src/aeon-key-fob.groovy
+++ b/devicetypes/smartthings/aeon-key-fob.src/aeon-key-fob.groovy
@@ -218,9 +218,14 @@ private void createChildDevices() {
 	Integer buttons = (device.currentState("numberOfButtons").value).toBigInteger()
 
 	for (i in 1..buttons) {
-		def child = addChildDevice("Child Button", "${device.deviceNetworkId}/${i}", null,
-				[completedSetup: true, label: "${device.displayName} button ${i}",
-				 isComponent: true, componentName: "button$i", componentLabel: "Button $i"])
+		def child = addChildDevice("Child Button",
+				"${device.deviceNetworkId}/${i}",
+				device.hubId,
+				[completedSetup: true,
+				 label: "${device.displayName} button ${i}",
+				 isComponent: true,
+				 componentName: "button$i",
+				 componentLabel: "Button $i"])
 
 		child.sendEvent(name: "supportedButtonValues", value: JsonOutput.toJson(["pushed", "held"]), displayed: false)
 		child.sendEvent(name: "button", value: "pushed", data: [buttonNumber: 1], displayed: false)

--- a/devicetypes/smartthings/eaton-5-scene-keypad.src/eaton-5-scene-keypad.groovy
+++ b/devicetypes/smartthings/eaton-5-scene-keypad.src/eaton-5-scene-keypad.groovy
@@ -320,13 +320,15 @@ private updateLocalSwitchState(childId, state) {
 private addChildSwitches() {
 	for (i in 2..5) {
 		String childDni = "${device.deviceNetworkId}/$i"
-		def child = addChildDevice("Child Switch", childDni, null, [
-			completedSetup: true,
-			label         : "$device.displayName Switch $i",
-			isComponent   : true,
-			componentName : "switch$i",
-			componentLabel: "Switch $i"
-		])
+		def child = addChildDevice("Child Switch",
+				childDni,
+				device.hubId,
+				[completedSetup: true,
+				 label         : "$device.displayName Switch $i",
+				 isComponent   : true,
+				 componentName : "switch$i",
+				 componentLabel: "Switch $i"
+				])
 		child.sendEvent(name: "switch", value: "off")
 	}
 }

--- a/devicetypes/smartthings/zooz-power-strip.src/zooz-power-strip.groovy
+++ b/devicetypes/smartthings/zooz-power-strip.src/zooz-power-strip.groovy
@@ -198,9 +198,14 @@ private void onOffCmd(value, endpoint = null) {
 private void createChildDevices() {
 	state.oldLabel = device.label
 	for (i in 1..5) {
-		addChildDevice("Zooz Power Strip Outlet", "${device.deviceNetworkId}-ep${i}", null,
-				[completedSetup: true, label: "${device.displayName} (CH${i})",
-				 isComponent: true, componentName: "ch$i", componentLabel: "Channel $i"])
+		addChildDevice("Zooz Power Strip Outlet",
+				"${device.deviceNetworkId}-ep${i}",
+				device.hubId,
+				[completedSetup: true,
+				 label: "${device.displayName} (CH${i})",
+				 isComponent: true,
+				 componentName: "ch$i",
+				 componentLabel: "Channel $i"])
 	}
 }
 


### PR DESCRIPTION
Some hub connected DTHs were not setting the hubId when creating child
devices. This was resulting in the child devices not being shown in the
join screen in the app which had the side effect that they were not being
added to the room the user selected when enabling join.

https://smartthings.atlassian.net/browse/ICP-11101