### PR TITLE
[ONEIOT-108] Simulated Device Preferences: Fix format of translations file

### DIFF
--- a/devicetypes/smartthings/testing/simulated-device-preferences.src/i18n/messages.properties
+++ b/devicetypes/smartthings/testing/simulated-device-preferences.src/i18n/messages.properties
@@ -16,9 +16,9 @@
 '''Section 1 Title'''.fr=Section 1 Title (French)
 '''Section 1 Description'''.fr=Section 1 Description (French)
 '''Option 1 Value'''.fr=Option 1 Value (French)
-'''default password'''.fr = (French) default password
+'''default password'''.fr=default password (French)
 
 '''Section 1 Title'''.es=Section 1 Title (Spanish)
 '''Section 1 Description'''.es=Section 1 Description (Spanish)
 '''Option 1 Value'''.es=Option 1 Value (Spanish)
-'''default password'''.es = (Spanish) default password
+'''default password'''.es=default password (Spanish)


### PR DESCRIPTION
The format of this file wasn't valid and was getting an error during deployment or when self published. I verified that I can self publish the updated file.