### PR TITLE
[CHAD-3868] Fix window shade commands not being visible on device view

### DIFF
--- a/devicetypes/axis/axis-gear-st.src/axis-gear-st.groovy
+++ b/devicetypes/axis/axis-gear-st.src/axis-gear-st.groovy
@@ -308,7 +308,7 @@ def configure() {
 	sendEvent(name: "windowShade", value: "unknown")
 	log.debug "Configuring Reporting and Bindings."
 	sendEvent(name: "checkInterval", value: (2 * 60 * 60 + 10 * 60), displayed: true, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
-	sendEvent(name: "supportedWindowShadeCommands", value: JsonOutput.toJson(["open", "close", "pause"]))
+	sendEvent(name: "supportedWindowShadeCommands", value: JsonOutput.toJson(["open", "close", "pause"]), displayed: false)
 
 	def attrs_refresh = zigbee.readAttribute(CLUSTER_BASIC, BASIC_ATTR_SWBUILDID) +
 						zigbee.readAttribute(CLUSTER_WINDOWCOVERING, WINDOWCOVERING_ATTR_LIFTPERCENTAGE) +

--- a/devicetypes/smartthings/springs-window-fashions-shade.src/springs-window-fashions-shade.groovy
+++ b/devicetypes/smartthings/springs-window-fashions-shade.src/springs-window-fashions-shade.groovy
@@ -11,6 +11,9 @@
  *  for the specific language governing permissions and limitations under the License.
  *
  */
+import groovy.json.JsonOutput
+
+
 metadata {
     definition (name: "Springs Window Fashions Shade", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.blind") {
         capability "Window Shade"
@@ -111,6 +114,7 @@ def getCheckInterval() {
 
 def installed() {
     sendEvent(name: "checkInterval", value: checkInterval, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
+    sendEvent(name: "supportedWindowShadeCommands", value: JsonOutput.toJson(["open", "close", "pause"]), displayed: false)
     response(refresh())
 }
 
@@ -240,6 +244,11 @@ def setLevel(value, duration = null) {
 
 def presetPosition() {
     zwave.switchMultilevelV1.switchMultilevelSet(value: 0xFF).format()
+}
+
+def pause() {
+    log.debug "pause()"
+    stop()
 }
 
 def stop() {

--- a/devicetypes/smartthings/zigbee-window-shade.src/zigbee-window-shade.groovy
+++ b/devicetypes/smartthings/zigbee-window-shade.src/zigbee-window-shade.groovy
@@ -11,6 +11,8 @@
  *	on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  *	for the specific language governing permissions and limitations under the License.
  */
+
+import groovy.json.JsonOutput
 import physicalgraph.zigbee.zcl.DataType
 
 metadata {
@@ -199,6 +201,10 @@ def refresh() {
 		cmds = zigbee.readAttribute(zigbee.LEVEL_CONTROL_CLUSTER, ATTRIBUTE_CURRENT_LEVEL)
 	}
 	return cmds
+}
+
+def installed() {
+	sendEvent(name: "supportedWindowShadeCommands", value: JsonOutput.toJson(["open", "close", "pause"]), displayed: false)
 }
 
 def configure() {

--- a/devicetypes/smartthings/zwave-window-shade.src/zwave-window-shade.groovy
+++ b/devicetypes/smartthings/zwave-window-shade.src/zwave-window-shade.groovy
@@ -11,6 +11,9 @@
  *  for the specific language governing permissions and limitations under the License.
  *
  */
+import groovy.json.JsonOutput
+
+
 metadata {
     definition (name: "Z-Wave Window Shade", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.blind") {
         capability "Window Shade"
@@ -106,6 +109,7 @@ def getCheckInterval() {
 
 def installed() {
     sendEvent(name: "checkInterval", value: checkInterval, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
+    sendEvent(name: "supportedWindowShadeCommands", value: JsonOutput.toJson(["open", "close", "pause"]), displayed: false)
     response(refresh())
 }
 
@@ -220,6 +224,11 @@ def setLevel(value, duration = null) {
 
 def presetPosition() {
     setLevel(preset ?: state.preset ?: 50)
+}
+
+def pause() {
+    log.debug "pause()"
+    stop()
 }
 
 def stop() {


### PR DESCRIPTION
The latest device plugin expects that devices implementing the Window
Shade capability have created the supportedWindowShadeCommands event to
indicate which commands they support. If that event hasnt' been generated
then the plugin doesn't render the device properly.