### PR TITLE
ICP-10136 - calling sendHubCommand() once with all commands (for all endpoints)

### DIFF
--- a/devicetypes/smartthings/zwave-multi-metering-switch.src/zwave-multi-metering-switch.groovy
+++ b/devicetypes/smartthings/zwave-multi-metering-switch.src/zwave-multi-metering-switch.groovy
@@ -285,7 +285,7 @@ def refresh(endpoints = [1], includeMeterGet = true) {
 		}
 	}
 
-	delayBetween(cmds, 500)
+	delayBetween(cmds, 200)
 }
 
 private resetAll() {

--- a/devicetypes/smartthings/zwave-multi-metering-switch.src/zwave-multi-metering-switch.groovy
+++ b/devicetypes/smartthings/zwave-multi-metering-switch.src/zwave-multi-metering-switch.groovy
@@ -254,25 +254,37 @@ private onOffCmd(value, endpoint = 1) {
 }
 
 private refreshAll(includeMeterGet = true) {
-	childDevices.each { childRefresh(it.deviceNetworkId, includeMeterGet) }
-	sendHubCommand refresh(includeMeterGet)
+
+	def endpoints = [1]
+
+	childDevices.each {
+		def switchId = getSwitchId(it.deviceNetworkId)
+		if (switchId != null) {
+			endpoints << switchId
+		}
+	}
+	sendHubCommand refresh(endpoints,includeMeterGet)
 }
 
 def childRefresh(deviceNetworkId, includeMeterGet = true) {
 	def switchId = getSwitchId(deviceNetworkId)
 	if (switchId != null) {
-		sendHubCommand refresh(switchId,includeMeterGet)
+		sendHubCommand refresh([switchId],includeMeterGet)
 	}
 }
 
-def refresh(endpoint = 1, includeMeterGet = true) {
+def refresh(endpoints = [1], includeMeterGet = true) {
 
-	def cmds = [encap(zwave.basicV1.basicGet(), endpoint)]
+	def cmds = []
 
-	if (includeMeterGet) {
-		cmds << encap(zwave.meterV3.meterGet(scale: 0), endpoint)
-		cmds << encap(zwave.meterV3.meterGet(scale: 2), endpoint)
+	endpoints.each {
+		cmds << [encap(zwave.basicV1.basicGet(), it)]
+		if (includeMeterGet) {
+			cmds << encap(zwave.meterV3.meterGet(scale: 0), it)
+			cmds << encap(zwave.meterV3.meterGet(scale: 2), it)
+		}
 	}
+
 	delayBetween(cmds, 500)
 }
 


### PR DESCRIPTION
@greens @kianooshST @MAblewiczS @ZWozniakS @MGoralczykS @PKacprowiczS 

Code refactoring - before: sendHubCommand () was invoked many times with a set of commands for each endpoint separately (the delay only worked on one separate sendHubCommand() call)
Now it is called once with a set of commands for all endpoints (the delay separates all commands at once).

Please, could You take a look ?