### PR TITLE
[ONEIOT-108] Simulated Device Preferences: Fixed type of 'number' input

### DIFF
--- a/devicetypes/smartthings/testing/simulated-device-preferences.src/simulated-device-preferences.groovy
+++ b/devicetypes/smartthings/testing/simulated-device-preferences.src/simulated-device-preferences.groovy
@@ -59,11 +59,28 @@ metadata {
 					displayDuringSetup: false,
 					type: "paragraph",
 					element: "paragraph")
-			input("intInput", "integer",
-					title: "Integer Title",
-					description: "Integer Description",
+			input("numInput", "number",
+					title: "Number Title (range 1-10)",
+					description: "Number Description (range 1-10)",
 					defaultValue: 5,
 					range: "1..10",
+					required: false)
+			input("numInput2", "number",
+					title: "Number Title (range -10-10)",
+					description: "Number Description (range -10-10)",
+					defaultValue: 5,
+					range: "-10..10",
+					required: false)
+			input("numInput3", "number",
+					title: "Number Title (range *..*)",
+					description: "Number Description (range *..*)",
+					defaultValue: 5,
+					range: "*..*",
+					required: false)
+			input("numInput4", "number",
+					title: "Number Title (no range)",
+					description: "Number Description (no range)",
+					defaultValue: 5,
 					required: false)
 			input("decInput", "decimal",
 					title: "Decimal Title",
@@ -111,7 +128,10 @@ def updated() {
 		enumInput: enumInput,
 		enumInput2: enumInput2,
 		enumInput3: enumInput3,
-		intInput: intInput,
+		numInput: numInput,
+		numInput2: numInput2,
+		numInput3: numInput3,
+		numInput4: numInput4,
 		passInput: passInput,
 		textInput: textInput
 	]


### PR DESCRIPTION
The number input type was 'integer' but that's not a valid type of a device
preference. Fixed that and also added some additional number preferences
with different types of ranges.