### PR TITLE
Add Rooms Beautiful Range Extender to Zigbee Range Extender DTH

### DIFF
--- a/devicetypes/smartthings/zigbee-range-extender.src/zigbee-range-extender.groovy
+++ b/devicetypes/smartthings/zigbee-range-extender.src/zigbee-range-extender.groovy
@@ -18,6 +18,7 @@ metadata {
 
 		fingerprint profileId: "0104", inClusters: "0000, 0003, 0009, 0B05, 1000, FC7C", outClusters: "0019, 0020, 1000",  manufacturer: "IKEA of Sweden",  model: "TRADFRI signal repeater", deviceJoinName: "TRÅDFRI Signal Repeater"
 		fingerprint profileId: "0104", inClusters: "0000, 0003", outClusters: "0019",  manufacturer: "Smartenit, Inc",  model: "ZB3RE", deviceJoinName: "Smartenit Range Extender"
+		fingerprint profileId: "0104", inClusters: "0000, 0003, DC00, FC01", manufacturer: "Rooms Beautiful",  model: "R001", deviceJoinName: "Range Extender"
 	}
 
 	tiles(scale: 2) {


### PR DESCRIPTION
Place the Rooms Beautiful Range Extender fingerprint in to the Zigbee Range Extender DTH. See the original PR: https://github.com/SmartThingsCommunity/SmartThingsPublic/pull/11253 