### PR TITLE
Child contact sensor for multi component devices

### DIFF
--- a/devicetypes/smartthings/child-contact-sensor.src/child-contact-sensor.groovy
+++ b/devicetypes/smartthings/child-contact-sensor.src/child-contact-sensor.groovy
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2018 SmartThings, RBoy Apps
+ *  Copyright 2019 SmartThings, RBoy Apps
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  *  in compliance with the License. You may obtain a copy of the License at:

--- a/devicetypes/smartthings/child-contact-sensor.src/child-contact-sensor.groovy
+++ b/devicetypes/smartthings/child-contact-sensor.src/child-contact-sensor.groovy
@@ -15,7 +15,6 @@ metadata {
 	definition(name: "Child Contact Sensor", namespace: "smartthings", author: "SmartThings", mnmn: "SmartThings", vid: "generic-contact", ocfDeviceType: "x.com.st.d.sensor.contact") {
 		capability "Contact Sensor"
 		capability "Sensor"
-		capability "Battery"
 		capability "Health Check"
 	}
 
@@ -26,12 +25,9 @@ metadata {
 				attributeState("closed", label: '${name}', icon: "st.contact.contact.closed", backgroundColor: "#00A0DC")
 			}
 		}
-		valueTile("battery", "device.battery", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
-			state "battery", label: 'Battery: ${currentValue}%', unit: ""
-		}
 
 		main "contact"
-		details(["contact", "battery"])
+		details(["contact"])
 	}
 }
 

--- a/devicetypes/smartthings/child-contact-sensor.src/child-contact-sensor.groovy
+++ b/devicetypes/smartthings/child-contact-sensor.src/child-contact-sensor.groovy
@@ -1,0 +1,61 @@
+/**
+ *  Copyright 2018 SmartThings, RBoy Apps
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at:
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ *  for the specific language governing permissions and limitations under the License.
+ *
+ */
+metadata {
+	definition(name: "Child Contact Sensor", namespace: "smartthings", author: "SmartThings", mnmn: "SmartThings", vid: "generic-contact", ocfDeviceType: "x.com.st.d.sensor.contact") {
+		capability "Contact Sensor"
+		capability "Sensor"
+		capability "Battery"
+		capability "Health Check"
+	}
+
+	tiles(scale: 2) {
+		multiAttributeTile(name: "contact", type: "generic", width: 6, height: 4, canChangeIcon: true) {
+			tileAttribute("device.contact", key: "PRIMARY_CONTROL") {
+				attributeState("open", label: '${name}', icon: "st.contact.contact.open", backgroundColor: "#e86d13")
+				attributeState("closed", label: '${name}', icon: "st.contact.contact.closed", backgroundColor: "#00A0DC")
+			}
+		}
+		valueTile("battery", "device.battery", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
+			state "battery", label: 'Battery: ${currentValue}%', unit: ""
+		}
+
+		main "contact"
+		details(["contact", "battery"])
+	}
+}
+
+def installed() {
+	configure()
+}
+
+def updated() {
+	configure()
+}
+
+def configure() {
+	parent.configureChild()
+	refresh()
+}
+
+def ping() {
+	refresh()
+}
+
+def refresh() {
+	parent.refreshChild()
+}
+
+def uninstalled() {
+	parent.deleteChild()
+}


### PR DESCRIPTION
Device handlers for multi endpoint devices which have contact sensors endopints require child contact sensor DTH's.
This generic child DTH serves the purpose and supports contact sensor, battery and health check.

@greens @tpmanley 

Follow up from previous discussion, ST already has generic child devices for switches and temperature sensor, it's missing a child device for contact sensors (like locks and multi sensor strips) used my multi endpoint DTH's. This will close that gap.