### PR TITLE
ICP-11490 ilumin bulb reporting intermediate level change values

### DIFF
--- a/devicetypes/smartthings/aeon-multiwhite-bulb.src/aeon-multiwhite-bulb.groovy
+++ b/devicetypes/smartthings/aeon-multiwhite-bulb.src/aeon-multiwhite-bulb.groovy
@@ -184,7 +184,7 @@ def setLevel(level, duration) {
 	commands([
 		zwave.switchMultilevelV3.switchMultilevelSet(value: level, dimmingDuration: duration),
 		zwave.switchMultilevelV3.switchMultilevelGet(),
-	], (duration && duration < 12) ? (duration * 1000 + 500) : 3500)
+	], (duration && duration < 12) ? (duration * 1000 + 2000) : 3500)
 }
 
 def setColorTemperature(temp) {

--- a/devicetypes/smartthings/aeon-multiwhite-bulb.src/aeon-multiwhite-bulb.groovy
+++ b/devicetypes/smartthings/aeon-multiwhite-bulb.src/aeon-multiwhite-bulb.groovy
@@ -184,7 +184,7 @@ def setLevel(level, duration) {
 	commands([
 		zwave.switchMultilevelV3.switchMultilevelSet(value: level, dimmingDuration: duration),
 		zwave.switchMultilevelV3.switchMultilevelGet(),
-	], (duration && duration < 12) ? (duration * 1000) : 3500)
+	], (duration && duration < 12) ? (duration * 1000 + 500) : 3500)
 }
 
 def setColorTemperature(temp) {


### PR DESCRIPTION
I think we're just querying for the level value too soon after setting it. This just adds in a small static delay to account for transmission time.