### PR TITLE
[WWST-2347] Aeon Minimote: Don't create child devices if they already exist

### DIFF
--- a/devicetypes/smartthings/aeon-minimote.src/aeon-minimote.groovy
+++ b/devicetypes/smartthings/aeon-minimote.src/aeon-minimote.groovy
@@ -120,7 +120,9 @@ def configure() {
 
 def installed() {
 	initialize()
-	createChildDevices()
+	if (!childDevices) {
+		createChildDevices()
+	}
 }
 
 def updated() {


### PR DESCRIPTION
If a minimote is joined with a different DTH that creates child devices and
then is switched to the Aeon Minimote DTH it was getting an exception because
it was trying to recreate the child devices. This change prevents it from
recreating the child devices when 'installed' is called.