### PR TITLE
[ICP-11598] POPP Radiator Thermostat 'always online' workaround

### DIFF
--- a/devicetypes/smartthings/zwave-radiator-thermostat.src/zwave-radiator-thermostat.groovy
+++ b/devicetypes/smartthings/zwave-radiator-thermostat.src/zwave-radiator-thermostat.groovy
@@ -136,8 +136,10 @@ def zwaveEvent(physicalgraph.zwave.commands.securityv1.SecurityMessageEncapsulat
 
 def zwaveEvent(physicalgraph.zwave.commands.multicmdv1.MultiCmdEncap cmd) {
 	cmd.encapsulatedCommands().collect { encapsulatedCommand ->
-		isPoppRadiatorThermostat() ? zwaveEvent(encapsulatedCommand, true) : zwaveEvent(encapsulatedCommand) 	//in case any future device would support MultiCmdEncap
-	}.flatten()																									//and won't need any special handler, like POPP does
+		isPoppRadiatorThermostat() ? zwaveEvent(encapsulatedCommand, true) : zwaveEvent(encapsulatedCommand) 	
+		//in case any future device would support MultiCmdEncap
+		//and won't need any special handler, like POPP does
+	}.flatten()
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.wakeupv2.WakeUpNotification cmd) {

--- a/devicetypes/smartthings/zwave-radiator-thermostat.src/zwave-radiator-thermostat.groovy
+++ b/devicetypes/smartthings/zwave-radiator-thermostat.src/zwave-radiator-thermostat.groovy
@@ -176,7 +176,9 @@ def zwaveEvent(physicalgraph.zwave.commands.thermostatmodev2.ThermostatModeRepor
 
 def zwaveEvent(physicalgraph.zwave.commands.thermostatsetpointv2.ThermostatSetpointReport cmd) {
 	def deviceTemperatureScale = cmd.scale ? 'F' : 'C'
-	createEvent(name: "heatingSetpoint", value: convertTemperatureIfNeeded(cmd.scaledValue, deviceTemperatureScale, cmd.precision), unit: temperatureScale)
+	def setpoint = Float.parseFloat(convertTemperatureIfNeeded(cmd.scaledValue, deviceTemperatureScale, cmd.precision))
+	state.cachedSetpoint = setpoint
+	createEvent(name: "heatingSetpoint", value: setpoint, unit: temperatureScale)
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.sensormultilevelv5.SensorMultilevelReport cmd) {
@@ -227,7 +229,7 @@ def off() {
 }
 
 def setHeatingSetpoint(setpoint) {
-	if (isPoppRadiatorThermostat()) {
+	if (isPoppRadiatorThermostat() && device.status == "ONLINE") {
 		sendEvent(name: "heatingSetpoint", value: setpoint, unit: temperatureScale)
 	}
 	setpoint = temperatureScale == 'C' ? setpoint : fahrenheitToCelsius(setpoint)

--- a/devicetypes/smartthings/zwave-radiator-thermostat.src/zwave-radiator-thermostat.groovy
+++ b/devicetypes/smartthings/zwave-radiator-thermostat.src/zwave-radiator-thermostat.groovy
@@ -184,16 +184,10 @@ def updateSetpoint(cmd) {
 	createEvent(name: "heatingSetpoint", value: setpoint, unit: temperatureScale)
 }
 
-def zwaveEvent(physicalgraph.zwave.commands.thermostatsetpointv2.ThermostatSetpointReport cmd) {
+def zwaveEvent(physicalgraph.zwave.commands.thermostatsetpointv2.ThermostatSetpointReport cmd, isResponseOfWakeUp = false) {
 	if (!state.isSetpointChangeRequestedByController) {
 		updateSetpoint(cmd)
-	} else {
-		[:]
-	}
-}
-
-def zwaveEvent(physicalgraph.zwave.commands.thermostatsetpointv2.ThermostatSetpointReport cmd, isResponseOfWakeUp) {
-	if (state.isSetpointChangeRequestedByController) {
+	} else if (isResponseOfWakeUp) {
 		state.isSetpointChangeRequestedByController = false
 		updateSetpoint(cmd)
 	} else {


### PR DESCRIPTION
@greens @MAblewiczS @KKlimczukS @MGoralczykS @ZWozniakS 
In this PR I'm preventing "cached setpoint" event from being sent whenever user wants to change it through app, now it'll be sent only if device is online.

This also for ICP-11632.
When changing setpoint manually on a device, it sends _ThermostatSetpointReport_ with chosen value, but then it also sends _WakeUpNotification_, where in result, user's manually set value is being overwritten. Small code fix in _ThermostatSetpointReport_ handler prevents it.