### PR TITLE
ICP-11703 - increased a "minimum number of seconds between reports"

### DIFF
--- a/devicetypes/smartthings/zigbee-window-shade-battery.src/zigbee-window-shade-battery.groovy
+++ b/devicetypes/smartthings/zigbee-window-shade-battery.src/zigbee-window-shade-battery.groovy
@@ -210,7 +210,7 @@ def configure() {
 
 	def cmds
 	if (supportsLiftPercentage()) {
-		cmds = zigbee.configureReporting(CLUSTER_WINDOW_COVERING, ATTRIBUTE_POSITION_LIFT, DataType.UINT8, 0, 600, null)
+		cmds = zigbee.configureReporting(CLUSTER_WINDOW_COVERING, ATTRIBUTE_POSITION_LIFT, DataType.UINT8, 2, 600, null)
 	} else {
 		cmds = zigbee.levelConfig()
 	}


### PR DESCRIPTION
**Ikea shade was reporting too often** and the DTH was sending "jumping events" (opening, opening, closing, opening) because the device sometimes **was sending values in wrong order** (for example: 89, 86, 88, 84, 83 etc) , so the "minimum number of seconds between reports" was increased in configuration.
@tpmanley @MAblewiczS @ZWozniakS @MGoralczykS @PKacprowiczS 
Please, take a look at the code.