### PR TITLE
WWST-6203-DTH-Fibaro KeyFob-FGKF-601 AU

### DIFF
--- a/devicetypes/smartthings/zwave-multi-button.src/zwave-multi-button.groovy
+++ b/devicetypes/smartthings/zwave-multi-button.src/zwave-multi-button.groovy
@@ -31,6 +31,7 @@ metadata {
 		fingerprint mfr: "0371", prod: "0002", model: "0003", deviceJoinName: "Aeotec NanoMote Quad", mnmn: "SmartThings", vid: "generic-4-button" //EU
 		fingerprint mfr: "0086", prod: "0101", model: "0058", deviceJoinName: "Aeotec KeyFob", mnmn: "SmartThings", vid: "generic-4-button" //US
 		fingerprint mfr: "0086", prod: "0001", model: "0058", deviceJoinName: "Aeotec KeyFob", mnmn: "SmartThings", vid: "generic-4-button" //EU
+		fingerprint mfr: "010F", prod: "1001", model: "3000", deviceJoinName: "Fibaro KeyFob", mnmn: "SmartThings", vid: "generic-6-button" //AU
 	}
 
 	tiles(scale: 2) {


### PR DESCRIPTION
WWST-6203-DTH-Fibaro KeyFob-FGKF-601 AU

From the existing DTH, extra one line FP is added 

FP:  
fingerprint mfr: "010F", prod: "1001", model: "3000", deviceJoinName: "Fibaro KeyFob", mnmn: "SmartThings", vid: "generic-6-button" //AU

Kindly review and approve.

Thanks
