### PR TITLE
WWST-6234 Fibaro Flood Sensor checkinterval is too short

### DIFF
--- a/devicetypes/fibargroup/fibaro-flood-sensor-zw5.src/fibaro-flood-sensor-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-flood-sensor-zw5.src/fibaro-flood-sensor-zw5.groovy
@@ -86,7 +86,7 @@ metadata {
 }
 
 def installed(){
-  sendEvent(name: "checkInterval", value: 21600, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
+  sendEvent(name: "checkInterval", value: (21600*2)+10*60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 }
 
 //UI Support functions


### PR DESCRIPTION
The device's checkinterval was set to be identical to its reporting interval, which means that one missed checkin could mark the device offline.