### PR TITLE
[CHAD-4201] Aeon Minimote/Zigbee Multi Button: Fix display in the new app

### DIFF
--- a/devicetypes/smartthings/aeon-minimote.src/aeon-minimote.groovy
+++ b/devicetypes/smartthings/aeon-minimote.src/aeon-minimote.groovy
@@ -14,7 +14,7 @@ import groovy.json.JsonOutput
  *
  */
 metadata {
-	definition (name: "Aeon Minimote", namespace: "smartthings", author: "SmartThings", runLocally: true, minHubCoreVersion: '000.017.0012', executeCommandsLocally: false, mcdSync: true) {
+	definition (name: "Aeon Minimote", namespace: "smartthings", author: "SmartThings", runLocally: true, minHubCoreVersion: '000.017.0012', executeCommandsLocally: false, mcdSync: true, ocfDeviceType: "x.com.st.d.remotecontroller") {
 		capability "Actuator"
 		capability "Button"
 		capability "Holdable Button"

--- a/devicetypes/smartthings/zigbee-multi-button.src/zigbee-multi-button.groovy
+++ b/devicetypes/smartthings/zigbee-multi-button.src/zigbee-multi-button.groovy
@@ -18,7 +18,7 @@ import groovy.json.JsonOutput
 import physicalgraph.zigbee.zcl.DataType
 
 metadata {
-	definition (name: "Zigbee Multi Button", namespace: "smartthings", author: "SmartThings", mcdSync: true) {
+	definition (name: "Zigbee Multi Button", namespace: "smartthings", author: "SmartThings", mcdSync: true, ocfDeviceType: "x.com.st.d.remotecontroller") {
 		capability "Actuator"
 		capability "Battery"
 		capability "Button"


### PR DESCRIPTION
These two DTHs were missing the ocfDeviceType of x.com.st.d.remotecontroller.
The effect of that is they had the wrong icon and didn't show automations
in the device view.

https://smartthings.atlassian.net/browse/CHAD-4201