### PR TITLE
Update Sinope Zigbee TH1123ZB-TH1124ZB.groovy to version 1.1.1

### DIFF
--- a/devicetypes/sinope-technologies/th1123zb-th1124zb-sinope-thermostat.src/th1123zb-th1124zb-sinope-thermostat.groovy
+++ b/devicetypes/sinope-technologies/th1123zb-th1124zb-sinope-thermostat.src/th1123zb-th1124zb-sinope-thermostat.groovy
@@ -1,7 +1,6 @@
 /**
-
-Copyright Sinopé Technologies 2019
-1.1.0
+Copyright Sinopé Technologies
+1.1.1
 SVN-571
  *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
  *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
@@ -189,6 +188,7 @@ void initialize() {
         sendEvent(name: "heatingSetpointRangeHigh", value: 86, scale: scale)
     }
     sendEvent(name: "lock", value: "unlocked")
+	refresh();
 }
 
 def ping() {
@@ -731,4 +731,4 @@ def traceEvent(logFilter, message, displayEvent = false, traceLevel = 4, sendMes
 			if (sendMessage) sendEvent(results)
 		} /* end if displayEvent*/
 	}
-}
+} 


### PR DESCRIPTION
Driver update : 
Bug : The reporting of the device doesn't work properly.
Fix : Configuration of the zigbee reporting after the initialization of a device.