### PR TITLE
WWST-6257, CHAD-4014 Update preference text for devices using Window Shade Preset

### DIFF
--- a/devicetypes/axis/axis-gear-st.src/axis-gear-st.groovy
+++ b/devicetypes/axis/axis-gear-st.src/axis-gear-st.groovy
@@ -84,7 +84,7 @@ metadata {
 			state "default", label: "Preset", action:"presetPosition", icon:"st.Home.home2"
 		}
 		preferences {
-			input "preset", "number", title: "Preset percentage (1-100) [Default - 50%]", defaultValue: 50, required: false, displayDuringSetup: true, range:"1..100"
+			input "preset", "number", title: "Preset position", description: "Set the window shade preset position", defaultValue: 50, required: false, displayDuringSetup: true, range:"1..100"
 		}
 		
 		main(["main"])

--- a/devicetypes/smartthings/zwave-window-shade.src/zwave-window-shade.groovy
+++ b/devicetypes/smartthings/zwave-window-shade.src/zwave-window-shade.groovy
@@ -80,7 +80,7 @@ metadata {
         }
 
         preferences {
-            input "preset", "number", title: "Preset position", defaultValue: 50, range: "1..100", required: false, displayDuringSetup: false
+            input "preset", "number", title: "Preset position", description: "Set the window shade preset position", defaultValue: 50, range: "1..100", required: false, displayDuringSetup: false
         }
 
         main(["windowShade"])


### PR DESCRIPTION
It was agreed by product that we should unify the device preferences for the window shade devices by using the following:
```
title: "Preset position", description: "Set the window shade preset position"
```