### PR TITLE
WWST-6420 - Added a fingerprint for Gledopto RGB+CCT LED Controller

### DIFF
--- a/devicetypes/smartthings/zll-rgbw-bulb.src/zll-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zll-rgbw-bulb.src/zll-rgbw-bulb.groovy
@@ -35,6 +35,9 @@ metadata {
 		// AduroSmart
 		fingerprint profileId: "C05E", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 0300, FFFF, 0019", outClusters: "0019", deviceId: "0210", manufacturer: "AduroSmart Eria", model: "ZLL-ExtendedColor", deviceJoinName: "Eria ZLL RGBW Bulb"
 
+		// GLEDOPTO
+		fingerprint manufacturer: "GLEDOPTO", model: "GL-C-008", deviceJoinName: "Gledopto RGB+CCT LED Controller" // raw description 0B C05E 0210 02 07 0000 0003 0004 0005 0006 0008 0300 00
+
 		// INGENIUM
 		fingerprint profileId: "C05E", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 0300, FFFF", outClusters: "0019", manufacturer: "Megaman", model: "ZLL-ExtendedColor", deviceJoinName: "INGENIUM ZB RGBW Light"
 


### PR DESCRIPTION
Added a fingerprint for Gledopto RGB+CCT LED Controller
@tpmanley @MAblewiczS @ZWozniakS @MGoralczykS @PKacprowiczS
Please take a look at the code.