### PR TITLE
[WWST-6439] Neo Coolcam Z-Wave Siren : Add fingerprint for NEO Coolcam Siren Alarm

### DIFF
--- a/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
+++ b/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
@@ -42,6 +42,7 @@ metadata {
 		fingerprint mfr: "0154", prod: "0004", model: "0002", deviceJoinName: "POPP Solar Outdoor Siren", vid: "generic-siren-12"
 		fingerprint mfr: "0109", prod: "2005", model: "0518", deviceJoinName: "Vision Outdoor Siren", vid: "generic-siren-12"
 		fingerprint mfr: "0258", prod: "0003", model: "6088", deviceJoinName: "NEO Coolcam Siren Alarm"//AU
+		fingerprint mfr: "0258", prod: "0600", model: "1028", deviceJoinName: "NEO Coolcam Siren Alarm"//MY
 	}
 
 	simulator {


### PR DESCRIPTION
Added FP:
fingerprint mfr: "0258", prod: "0600", model: "1028", deviceJoinName: "NEO Coolcam Siren Alarm"//MY

Raw description in IDE:
zw:F type:1005 mfr:0258 prod:0600 model:1028 ver:2.20 zwv:6.02 lib:06 cc:5E,9F,55,73,86,85,8E,59,72,5A,25,71,87,70,80,6C role:07 ff:8F00 ui:8F00

This is for MY region