### PR TITLE
DVCSMP-4823 Fibaro Single Switch sending events encapsulated

### DIFF
--- a/devicetypes/fibargroup/fibaro-single-switch-2-zw5.src/fibaro-single-switch-2-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-single-switch-2-zw5.src/fibaro-single-switch-2-zw5.groovy
@@ -310,6 +310,18 @@ def zwaveEvent(physicalgraph.zwave.commands.crc16encapv1.Crc16Encap cmd) {
     }
 }
 
+def zwaveEvent(physicalgraph.zwave.commands.multichannelv3.MultiChannelCmdEncap cmd) {
+    def encapsulatedCommand = cmd.encapsulatedCommand(cmdVersions())
+    if (encapsulatedCommand) {
+        logging("${device.displayName} - Parsed MultiChannelCmdEncap ${encapsulatedCommand}")
+        // this device sometimes sends events encapsulated.
+        if (cmd.sourceEndPoint as Integer == 0) zwaveEvent(encapsulatedCommand)
+        else log.warn "Received a multichannel event from an unsupported channel"
+    } else {
+        log.warn "Unable to extract MultiChannel command from $cmd"
+    }
+}
+
 def zwaveEvent(physicalgraph.zwave.Command cmd) {
     // Handles all Z-Wave commands we aren't interested in
     log.debug "Unhandled: ${cmd.toString()}"


### PR DESCRIPTION
Likely as a result of multichannel association changes, newly-added fibaro single switch devices have been communicating with some users using encapsulated messages. This should handle those messages.