### PR TITLE
CHAD-4316 Remove "alarmState" custom attribute from zwave smoke alarm

### DIFF
--- a/devicetypes/smartthings/zwave-smoke-alarm.src/zwave-smoke-alarm.groovy
+++ b/devicetypes/smartthings/zwave-smoke-alarm.src/zwave-smoke-alarm.groovy
@@ -19,8 +19,6 @@ metadata {
 		capability "Battery"
 		capability "Health Check"
 
-		attribute "alarmState", "string"
-
 		fingerprint mfr:"0138", prod:"0001", model:"0002", deviceJoinName: "First Alert Smoke Detector and Carbon Monoxide Alarm (ZCOMBO)"
 		fingerprint mfr:"0138", prod:"0001", model:"0003", deviceJoinName: "First Alert Smoke Detector and Carbon Monoxide Alarm (ZCOMBO)"
 	}
@@ -37,12 +35,16 @@ metadata {
 
 	tiles (scale: 2){
 		multiAttributeTile(name:"smoke", type: "lighting", width: 6, height: 4){
-			tileAttribute ("device.alarmState", key: "PRIMARY_CONTROL") {
+			tileAttribute ("device.smoke", key: "PRIMARY_CONTROL") {
 				attributeState("clear", label:"clear", icon:"st.alarm.smoke.clear", backgroundColor:"#ffffff")
-				attributeState("smoke", label:"SMOKE", icon:"st.alarm.smoke.smoke", backgroundColor:"#e86d13")
-				attributeState("carbonMonoxide", label:"MONOXIDE", icon:"st.alarm.carbon-monoxide.carbon-monoxide", backgroundColor:"#e86d13")
+				attributeState("detected", label:"SMOKE", icon:"st.alarm.smoke.smoke", backgroundColor:"#e86d13")
 				attributeState("tested", label:"TEST", icon:"st.alarm.smoke.test", backgroundColor:"#e86d13")
 			}
+		}
+		standardTile("co", "device.carbonMonoxide", width:6, height:4, inactiveLabel: false, decoration: "flat") {
+			state("clear", label:"clear", icon:"st.alarm.smoke.clear", backgroundColor:"#ffffff")
+			state("detected", label:"SMOKE", icon:"st.alarm.smoke.smoke", backgroundColor:"#e86d13")
+			state("tested", label:"TEST", icon:"st.alarm.smoke.test", backgroundColor:"#e86d13")
 		}
 		valueTile("battery", "device.battery", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
 			state "battery", label:'${currentValue}% battery', unit:""
@@ -121,8 +123,7 @@ def createSmokeOrCOEvents(name, results) {
 			name = "clear"
 			break
 	}
-	// This composite event is used for updating the tile
-	results << createEvent(name: "alarmState", value: name, descriptionText: text)
+	results
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.alarmv2.AlarmReport cmd, results) {

--- a/devicetypes/smartthings/zwave-smoke-alarm.src/zwave-smoke-alarm.groovy
+++ b/devicetypes/smartthings/zwave-smoke-alarm.src/zwave-smoke-alarm.groovy
@@ -51,7 +51,7 @@ metadata {
 		}
 
 		main "smoke"
-		details(["smoke", "battery"])
+		details(["smoke", "co", "battery"])
 	}
 }
 


### PR DESCRIPTION
We're moving away from custom attributes. This PR should match the work done to remove this attribute from hubcore.