### PR TITLE
[CHAD-4341] Add a generic Z-Wave Light bulb DTH for Z-Wave Light bulbs

### DIFF
--- a/devicetypes/smartthings/aeon-led-bulb.src/aeon-led-bulb.groovy
+++ b/devicetypes/smartthings/aeon-led-bulb.src/aeon-led-bulb.groovy
@@ -27,10 +27,6 @@ metadata {
 		capability "Sensor"
 
 		command "reset"
-
-		fingerprint inClusters: "0x26,0x33,0x98"
-		fingerprint deviceId: "0x11", inClusters: "0x98,0x33"
-		fingerprint deviceId: "0x1102", inClusters: "0x98"
 	}
 
 	simulator {


### PR DESCRIPTION
This commit amends the generic Z-Wave RGBW bulb driver, rgbw-light.groovy, with addition of these fingerprints:

Specific fingerprints:

```
fingerprint deviceId: "0x1101", inClusters: "0x26,0x33", deviceJoinName: "Z-Wave RGBW Bulb"
fingerprint deviceId: "0x1102", inClusters: "0x26,0x33", deviceJoinName: "Z-Wave RGBW Bulb"
fingerprint mfr: "031E", prod: "0005", model: "0001", deviceJoinName: "ilumin RGBW Bulb"
```

Per agreement with the reviewers, this fingerprint is removed from rgbw-light.groovy, as any bulb that supports command class 0x33 must also support 0x26.  With the inClusters: "0x26,0x33", we don't expect this fingerprint to ever actually be needed:

```
fingerprint inClusters: "0x33"
```

Finally, all non-Aeon-specific fingerprints are removed from aeon-led-bulb.groovy.  This was done to ensure that non-Aeon bulbs match to the rgbw-light.groovy driver, which should better support them.  Note that with this, aeon-led-bulb.groovy no longer has any fingerprints.  The Aeon bulbs for which that driver was written appear to already be matching to rgbw-light.groovy with Aoen-specific fingerprints there.