### PR TITLE
[WWST-6110, WWST-6146] EZEX fingerprint patch of zigbee-switch.groovy file.

### DIFF
--- a/devicetypes/smartthings/zigbee-switch.src/zigbee-switch.groovy
+++ b/devicetypes/smartthings/zigbee-switch.src/zigbee-switch.groovy
@@ -32,7 +32,7 @@ metadata {
 		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006", outClusters: "0000", manufacturer: "eWeLink", model: "SA-003-Zigbee", deviceJoinName: "eWeLink SmartPlug (SA-003)", ocfDeviceType: "oic.d.smartplug"
 
 		// EZEX
-		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0006", outClusters: "0006, 000A, 0019", manufacturer: "EZEX", model: "E220-KR1N0Z0-HA", deviceJoinName: "EZEX Switch"
+		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0006", outClusters: "0006, 000A, 0019", model: "E220-KR1N0Z0-HA", deviceJoinName: "EZEX Switch"
 
 		// GDKES
 		fingerprint profileId: "0104", inClusters: "0000, 0003, 0005, 0004, 0006", manufacturer: "REXENSE", model: "HY0001", deviceJoinName: "GDKES Smart Switch"


### PR DESCRIPTION

EZEX device raw data not include the manufacturer information.
So. This patch have remove the manufacturer field of EZEX finger print.

by WWST-6197 below comment.
======================================================================
Tom Manley

The device doesn’t report a manufacturer but the fingerprint specifies the manufacturer as EZEX. This is why it is joining as a Thing. You need to remove the manufacturer from the fingerprint and then it should join correctly.

For reference, here is the join message from Sumo logs showing the blank manufacturer:
...
================================