### PR TITLE
[CHAD-4456] Ozom Smart Siren: Fix functionality when used with SmartThings Home Monitor

### DIFF
--- a/devicetypes/smartthings/ozom-smart-siren.src/ozom-smart-siren.groovy
+++ b/devicetypes/smartthings/ozom-smart-siren.src/ozom-smart-siren.groovy
@@ -125,9 +125,18 @@ def configure() {
 	return cmds	
 }
 
+def both() {
+	log.debug "both()"
+	on()
+}
+
 def siren() {
 	log.debug "siren()"
 	on()
+}
+
+def strobe() {
+	log.warn "strobe() is not supported by this device"
 }
 
 def on() {


### PR DESCRIPTION
This DTH declares support for the "Alarm" capability but it did not include implementations for either the `both` or `strobe` commands that are part of that capability. STHM uses the `both` command and since it was missing from this DTH any device using this DTH could not be used with STHM. The fix is to implement the missing commands.

https://smartthings.atlassian.net/browse/CHAD-4456