### PR TITLE
ICP-11631 Refresh Yale lock battery value after battery replacement

### DIFF
--- a/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
+++ b/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
@@ -95,7 +95,7 @@ def installed() {
  * and check again.
  */
 def scheduleInstalledCheck() {
-	runIn(120, installedCheck, [forceForLocallyExecuting: true])
+	runIn(120, "installedCheck", [forceForLocallyExecuting: true])
 }
 
 def installedCheck() {
@@ -406,7 +406,7 @@ private def handleBatteryAlarmReport(cmd) {
 	def map = null
 	switch (cmd.zwaveAlarmEvent) {
 		case 0x01: //power has been applied, check if the battery level updated
-			runIn(1, setQueryBattery, [overwrite: true, forceForLocallyExecuting: true])
+			runIn(1, "setQueryBattery", [overwrite: true, forceForLocallyExecuting: true])
 			result << response(secure(zwave.batteryV1.batteryGet()))
 			break;
 		case 0x0A:
@@ -613,7 +613,7 @@ def unlockWithTimeout() {
  */
 def ping() {
 	log.trace "[DTH] Executing ping() for device ${device.displayName}"
-	runIn(30, followupStateCheck)
+	runIn(30, "followupStateCheck")
 	if (zwaveInfo.mfr == "010E") {
 		secure(zwave.doorLockV1.doorLockOperationGet())
 	} else {
@@ -694,12 +694,12 @@ private Boolean secondsPast(timestamp, seconds) {
 
 private setQueryBattery() {
 	state.queryBattery = true
-	runIn(1, queryBattery, [overwrite: true, forceForLocallyExecuting: true])
+	runIn(1, "queryBattery", [overwrite: true, forceForLocallyExecuting: true])
 }
 
 private queryBattery() {
 	if (state.queryBattery) {
-		runIn(10, queryBattery, [overwrite: true, forceForLocallyExecuting: true])
+		runIn(10, "queryBattery", [overwrite: true, forceForLocallyExecuting: true])
 		response(secure(zwave.batteryV1.batteryGet()))
 	}
 }

--- a/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
+++ b/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
@@ -406,6 +406,7 @@ private def handleBatteryAlarmReport(cmd) {
 	def map = null
 	switch (cmd.zwaveAlarmEvent) {
 		case 0x01: //power has been applied, check if the battery level updated
+			log.debug "Batteries replaced. Queueing a battery get."
 			runIn(10, "queryBattery", [overwrite: true, forceForLocallyExecuting: true])
 			result << response(secure(zwave.batteryV1.batteryGet()))
 			break;
@@ -694,7 +695,7 @@ private Boolean secondsPast(timestamp, seconds) {
 private queryBattery() {
 	log.debug "Running queryBattery"
 	if (!state.lastbatt || now() - state.lastbatt > 10*1000) {
-		log.debug "It's been more than 10s since battery was updated after a replacment. Querying battery."
+		log.debug "It's been more than 10s since battery was updated after a replacement. Querying battery."
 		runIn(10, "queryBattery", [overwrite: true, forceForLocallyExecuting: true])
 		response(secure(zwave.batteryV1.batteryGet()))
 	}

--- a/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
+++ b/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
@@ -539,7 +539,6 @@ def zwaveEvent(physicalgraph.zwave.commands.batteryv1.BatteryReport cmd) {
 		map.value = cmd.batteryLevel
 	}
 	state.lastbatt = now()
-	state.queryBattery = false
 	unschedule("queryBattery")
 	if (cmd.batteryLevel == 0 && device.latestValue("battery") > 20) {
 		// Danalock reports 00 when batteries are changed. We do not know what is the real level at this point.

--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -133,7 +133,7 @@ def installed() {
  * and check again.
  */
 def scheduleInstalledCheck() {
-	runIn(120, installedCheck, [forceForLocallyExecuting: true])
+	runIn(120, "installedCheck", [forceForLocallyExecuting: true])
 }
 
 def installedCheck() {
@@ -631,7 +631,7 @@ private def handleBatteryAlarmReport(cmd) {
 	def map = null
 	switch(cmd.zwaveAlarmEvent) {
 		case 0x01: //power has been applied, check if the battery level updated
-			runIn(1, setQueryBattery, [overwrite: true, forceForLocallyExecuting: true])
+			runIn(1, "setQueryBattery", [overwrite: true, forceForLocallyExecuting: true])
 			result << response(secure(zwave.batteryV1.batteryGet()))
 			break;
 		case 0x0A:
@@ -769,7 +769,7 @@ private def handleAlarmReportUsingAlarmType(cmd) {
 			break
 		case 130:  // Batteries replaced
 			map = [ descriptionText: "Batteries replaced", isStateChange: true ]
-			runIn(1, setQueryBattery, [overwrite: true, forceForLocallyExecuting: true])
+			runIn(1, "setQueryBattery", [overwrite: true, forceForLocallyExecuting: true])
 			result << response(secure(zwave.batteryV1.batteryGet()))
 			break
 		case 131: // Disabled user entered at keypad
@@ -1161,7 +1161,7 @@ def unlockWithTimeout() {
  */
 def ping() {
 	log.trace "[DTH] Executing ping() for device ${device.displayName}"
-	runIn(30, followupStateCheck)
+	runIn(30, "followupStateCheck")
 	secure(zwave.doorLockV1.doorLockOperationGet())
 }
 
@@ -1806,12 +1806,12 @@ def readCodeSlotId(physicalgraph.zwave.commands.alarmv2.AlarmReport cmd) {
 
 private setQueryBattery() {
 	state.queryBattery = true
-	runIn(1, queryBattery, [overwrite: true, forceForLocallyExecuting: true])
+	runIn(1, "queryBattery", [overwrite: true, forceForLocallyExecuting: true])
 }
 
 private queryBattery() {
 	if (state.queryBattery) {
-		runIn(10, queryBattery, [overwrite: true, forceForLocallyExecuting: true])
+		runIn(10, "queryBattery", [overwrite: true, forceForLocallyExecuting: true])
 		response(secure(zwave.batteryV1.batteryGet()))
 	}
 }

--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -1808,7 +1808,7 @@ def readCodeSlotId(physicalgraph.zwave.commands.alarmv2.AlarmReport cmd) {
 private queryBattery() {
 	log.debug "Running queryBattery"
 	if (!state.lastbatt || now() - state.lastbatt > 10*1000) {
-		log.debug "It's been more than 10s since battery was updated after a replacment. Querying battery."
+		log.debug "It's been more than 10s since battery was updated after a replacement. Querying battery."
 		runIn(10, "queryBattery", [overwrite: true, forceForLocallyExecuting: true])
 		response(secure(zwave.batteryV1.batteryGet()))
 	}


### PR DESCRIPTION
Queues up a battery get after we see the battery changed notification from the lock. Previous implementation relied on sending gets whenever the lock received a new message in parse(), but locks run locally so this happend very rarely. New approach is to query on a regular timer until we get an update.