### PR TITLE
ONEAPP-21289 Update metadata for Aeon Panic Button to use a vid that has a single button icon

### DIFF
--- a/devicetypes/smartthings/aeon-key-fob.src/aeon-key-fob.groovy
+++ b/devicetypes/smartthings/aeon-key-fob.src/aeon-key-fob.groovy
@@ -24,7 +24,7 @@ metadata {
 
 		fingerprint deviceId: "0x0101", inClusters: "0x86,0x72,0x70,0x80,0x84,0x85"
 		fingerprint mfr: "0086", prod: "0101", model: "0058", deviceJoinName: "Aeotec Key Fob"
-		fingerprint mfr: "0086", prod: "0001", model: "0026", deviceJoinName: "Aeotec Panic Button"
+		fingerprint mfr: "0086", prod: "0001", model: "0026", deviceJoinName: "Aeotec Panic Button", mnmn: "SmartThings", vid: "generic-button-2"
 	}
 
 	simulator {


### PR DESCRIPTION
This coincides with a metadata update to add the icon to some single button metadata. generic-button-2 is similar to the metadata that the device uses now (just without the "Holdable Button" capability with is deprecated and which features are supported by Button), but with an updated icon that is a single button.