### PR TITLE
[WWST-6544] Fingerprint for Aurora AOne 13A Smart Plug

### DIFF
--- a/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
+++ b/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
@@ -33,6 +33,7 @@ metadata {
 		fingerprint profileId: "0104", inClusters: "0000,0003,0006,0009,0B04", outClusters: "0019", manufacturer: "Samjin", model: "outlet", deviceJoinName: "Outlet"
 		fingerprint profileId: "0010", inClusters: "0000 0003 0004 0005 0006 0008 0702 0B05", outClusters: "0019", manufacturer: "innr", model: "SP 120", deviceJoinName: "Innr Smart Plug"
 		fingerprint profileId: "0104", inClusters: "0000,0002,0003,0004,0005,0006,0009,0B04,0702", outClusters: "0019,000A,0003,0406", manufacturer: "Aurora", model: "SmartPlug51AU", deviceJoinName: "Aurora SmartPlug"
+		fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0008,0B04", outClusters: "0019", manufacturer: "Aurora", model: "SingleSocket50AU", deviceJoinName: "Aurora SmartPlug"
 		fingerprint profileId: "0104", inClusters: "0000,0003,0004,0005,0006,0702,0B04,0B05,FC03", outClusters: "0019", manufacturer: "CentraLite", model: "3210-L", deviceJoinName: "Iris Smart Plug"
 		fingerprint profileId: "0104", inClusters: "0000,0001,0003,0004,0005,0006,0B04,0B05,0702", outClusters: "0003,000A,0B05,0019", manufacturer: " Sercomm Corp.", model: "SZ-ESW01-AU", deviceJoinName: "Sercomm Smart Power Plug"
 	}

--- a/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
+++ b/devicetypes/smartthings/smartpower-outlet.src/smartpower-outlet.groovy
@@ -89,8 +89,10 @@ def parse(String description) {
 
 	if (event) {
 		if (event.name == "power") {
-			def value = (event.value as Integer) / 10
-			event = createEvent(name: event.name, value: value, descriptionText: '{{ device.displayName }} power is {{ value }} Watts', translatable: true)
+			def div = device.getDataValue("divisor")
+			div = div ? (div as int) : 10
+			def powerValue = (event.value as Integer)/div
+			event = createEvent(name: event.name, value: powerValue, descriptionText: '{{ device.displayName }} power is {{ value }} Watts', translatable: true)
 		} else if (event.name == "switch") {
 			def descriptionText = event.value == "on" ? '{{ device.displayName }} is On' : '{{ device.displayName }} is Off'
 			event = createEvent(name: event.name, value: event.value, descriptionText: descriptionText, translatable: true)
@@ -133,6 +135,11 @@ def refresh() {
 }
 
 def configure() {
+	// Setting proper divisor for Aurora AOne 13A Smart Plug
+	def deviceModel = device.getDataValue("model")
+	def divisorValue = deviceModel == "SingleSocket50AU" ? "1" : "10"
+	device.updateDataValue("divisor", divisorValue)
+
 	// Device-Watch allows 2 check-in misses from device + ping (plus 1 min lag time)
 	// enrolls with default periodic reporting until newer 5 min interval is confirmed
 	sendEvent(name: "checkInterval", value: 2 * 10 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])


### PR DESCRIPTION
Added fingerprint for Aurora AOne 13A Smart Plug
@greens  @tpmanley @KKlimczukS  @ZWozniakS  @MGoralczykS @PKacprowiczS 

Please take a look at the code.

DTH works this way that usage of 60W light bulb is seen as 6W in both Smartthings apps, thats because in parse method for this DTH in line 92 there is: def value = (event.value as Integer) / 10 . I do not know why there is this division by ten (it works the same way in local execution mode).

I think that this might be a bug. Could you check it so that we can be sure that everything works as intended? Or please tell me if there is anything that could be done about this issue?