### PR TITLE
ICP-11631 Refresh Yale lock battery value when replaced

### DIFF
--- a/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
+++ b/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
@@ -697,7 +697,7 @@ private queryBattery() {
 	if (!state.lastbatt || now() - state.lastbatt > 10*1000) {
 		log.debug "It's been more than 10s since battery was updated after a replacement. Querying battery."
 		runIn(10, "queryBattery", [overwrite: true, forceForLocallyExecuting: true])
-		response(secure(zwave.batteryV1.batteryGet()))
+		sendHubCommand(secure(zwave.batteryV1.batteryGet()))
 	}
 }
 

--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -1810,6 +1810,6 @@ private queryBattery() {
 	if (!state.lastbatt || now() - state.lastbatt > 10*1000) {
 		log.debug "It's been more than 10s since battery was updated after a replacement. Querying battery."
 		runIn(10, "queryBattery", [overwrite: true, forceForLocallyExecuting: true])
-		response(secure(zwave.batteryV1.batteryGet()))
+		sendHubCommand(secure(zwave.batteryV1.batteryGet()))
 	}
 }


### PR DESCRIPTION
Out-of-band queries require sendHubCommand calls