### PR TITLE
ICP-12644 Update metadata for IKEA window shades to show Window Shade Preset

### DIFF
--- a/devicetypes/smartthings/zigbee-window-shade-battery.src/zigbee-window-shade-battery.groovy
+++ b/devicetypes/smartthings/zigbee-window-shade-battery.src/zigbee-window-shade-battery.groovy
@@ -15,7 +15,7 @@ import groovy.json.JsonOutput
 import physicalgraph.zigbee.zcl.DataType
 
 metadata {
-	definition(name: "ZigBee Window Shade Battery", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.blind", mnmn: "SmartThings", vid: "generic-shade-2") {
+	definition(name: "ZigBee Window Shade Battery", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.blind", mnmn: "SmartThings", vid: "generic-shade-3") {
 		capability "Actuator"
 		capability "Battery"
 		capability "Configuration"


### PR DESCRIPTION
`generic-shade-3` has the Window Shade Preset capability and `generic-shade-2` does not. Now that there is code for Window Shade Preset we need to use that. I forgot to make this change in https://github.com/SmartThingsCommunity/SmartThingsPublic/pull/21405