### PR TITLE
[ICP-12696] Added readAttribute for colorTemp in the setColor method

### DIFF
--- a/devicetypes/smartthings/zll-rgbw-bulb.src/zll-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zll-rgbw-bulb.src/zll-rgbw-bulb.groovy
@@ -224,7 +224,9 @@ def setColorTemperature(value) {
 
 	zigbee.command(COLOR_CONTROL_CLUSTER, MOVE_TO_COLOR_TEMPERATURE_COMMAND, "$finalHex 0000") +
 	["delay 1500"] +
-	zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_COLOR_TEMPERATURE)
+	zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_COLOR_TEMPERATURE) +
+	zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE) +
+	zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION)
 }
 
 def setLevel(value, rate = null) {
@@ -246,7 +248,8 @@ def setColor(value){
 		getScaledHue(value.hue), getScaledSaturation(value.saturation), "0000") +
 	zigbee.onOffRefresh() +
 	zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_HUE) +
-	zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION)
+	zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_SATURATION) +
+	zigbee.readAttribute(COLOR_CONTROL_CLUSTER, ATTRIBUTE_COLOR_TEMPERATURE)
 }
 
 //Naming based on the wiki article here: http://en.wikipedia.org/wiki/Color_temperature


### PR DESCRIPTION
@greens @dkirker could you please review? I added changes to the setColor method to read the color temp attribute to fix the reported issue, and according to this logic, I thought we should be able to change the position of the color picker when changing the color temp. I am not sure if this is possible, but I tried to apply it in a similar way by reading the hue and saturation attributes in the setColorTemperature method. But ... it didn't work. Hue and saturation values ​​have not changed, they just kept their previous values. There is still a question, shouldn't this be possible?

@KKlimczukS @PKacprowiczS @MGoralczykS @MWierzbinskaS 