### PR TITLE
Keep compatibility with existing SmartApps

### DIFF
--- a/devicetypes/smartthings/zwave-battery-thermostat.src/zwave-battery-thermostat.groovy
+++ b/devicetypes/smartthings/zwave-battery-thermostat.src/zwave-battery-thermostat.groovy
@@ -15,6 +15,7 @@ metadata {
 	definition (name: "Z-Wave Battery Thermostat", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.thermostat", genericHandler: "Z-Wave") {
 		capability "Actuator"
 		capability "Temperature Measurement"
+		capability "Thermostat"
 		capability "Thermostat Heating Setpoint"
 		capability "Thermostat Cooling Setpoint"
 		capability "Thermostat Operating State"


### PR DESCRIPTION
Add capability "Thermostat" so that devices are compatible with existing SmartApps