### PR TITLE
[CHAD-4341] Update generic Z-Wave Light bulb DTH for Z-Wave Light bulbs

### DIFF
--- a/devicetypes/smartthings/aeon-led-bulb-6.src/aeon-led-bulb-6.groovy
+++ b/devicetypes/smartthings/aeon-led-bulb-6.src/aeon-led-bulb-6.groovy
@@ -27,9 +27,6 @@ metadata {
 		capability "Sensor"
 		capability "Health Check"
 		capability "Configuration"
-
-		fingerprint mfr: "0371", prod: "0103", model: "0002", deviceJoinName: "Aeon LED Bulb 6 Multi-Color" //US
-		fingerprint mfr: "0371", prod: "0003", model: "0002", deviceJoinName: "Aeon LED Bulb 6 Multi-Color" //EU
 	}
 
 	simulator {

--- a/devicetypes/smartthings/aeon-led-bulb.src/aeon-led-bulb.groovy
+++ b/devicetypes/smartthings/aeon-led-bulb.src/aeon-led-bulb.groovy
@@ -27,10 +27,6 @@ metadata {
 		capability "Sensor"
 
 		command "reset"
-
-		fingerprint inClusters: "0x26,0x33,0x98"
-		fingerprint deviceId: "0x11", inClusters: "0x98,0x33"
-		fingerprint deviceId: "0x1102", inClusters: "0x98"
 	}
 
 	simulator {

--- a/devicetypes/smartthings/rgbw-light.src/rgbw-light.groovy
+++ b/devicetypes/smartthings/rgbw-light.src/rgbw-light.groovy
@@ -27,15 +27,48 @@ metadata {
 		capability "Sensor"
 		capability "Health Check"
 
-		command "reset"
+		/*
+		 * Relevant device types:
+		 *
+		 * * 0x11 GENERIC_TYPE_SWITCH_MULTILEVEL
+		 * * 0x01 SPECIFIC_TYPE_POWER_SWITCH_MULTILEVEL
+		 * * 0x02 SPECIFIC_TYPE_COLOR_TUNABLE_MULTILEVEL
+		 *
+		 * Plausible command classes we might see in a color light bulb:
+		 *
+		 * 0x98 COMMAND_CLASS_SECURITY
+		 * 0x5E COMMAND_CLASS_ZWAVEPLUS_INFO_V2
+		 * 0x20 COMMAND_CLASS_BASIC
+		 * 0x26 COMMAND_CLASS_SWITCH_MULTILEVEL
+		 * 0X27 COMMAND_CLASS_SWITCH_ALL
+		 * 0x33 COMMAND_CLASS_SWITCH_COLOR
+		 * 0x70 COMMAND_CLASS_CONFIGURATION
+		 * 0x73 COMMAND_CLASS_POWERLEVEL
+		 *
+		 * Here are the command classes used by this driver that we can fingerprint against:
+		 *
+		 * * 0x26 COMMAND_CLASS_SWITCH_MULTILEVEL -> yes, it is dimmable
+		 * * 0x33 COMMAND_CLASS_SWITCH_COLOR -> yes, it has color control
+		 */
 
-		fingerprint inClusters: "0x26,0x33"
-		fingerprint inClusters: "0x33"
+		// dimmable, color control
+		fingerprint inClusters: "0x26,0x33", deviceJoinName: "Z-Wave RGBW Bulb"
+
+		// GENERIC_TYPE_SWITCH_MULTILEVEL:SPECIFIC_TYPE_POWER_SWITCH_MULTILEVEL
+		// dimmable, color control
+		fingerprint deviceId: "0x1101", inClusters: "0x26,0x33", deviceJoinName: "Z-Wave RGBW Bulb"
+
+		// GENERIC_TYPE_SWITCH_MULTILEVEL:SPECIFIC_TYPE_COLOR_TUNABLE_MULTILEVEL
+		// dimmable, color control
+		fingerprint deviceId: "0x1102", inClusters: "0x26,0x33", deviceJoinName: "Z-Wave RGBW Bulb"
+
+		// Manufacturer and model-specific fingerprints.
 		fingerprint mfr: "0086", prod: "0103", model: "0079", deviceJoinName: "Aeotec LED Strip" //US
 		fingerprint mfr: "0086", prod: "0003", model: "0079", deviceJoinName: "Aeotec LED Strip" //EU
 		fingerprint mfr: "0086", prod: "0003", model: "0062", deviceJoinName: "Aeotec LED Bulb" //EU
 		fingerprint mfr: "0086", prod: "0103", model: "0062", deviceJoinName: "Aeotec LED Bulb" //US
 		fingerprint mfr: "0300", prod: "0003", model: "0003", deviceJoinName: "ilumin RGBW Bulb"
+		fingerprint mfr: "031E", prod: "0005", model: "0001", deviceJoinName: "ilumin RGBW Bulb"
 	}
 
 	simulator {
@@ -60,17 +93,38 @@ metadata {
 		}
 	}
 
-	standardTile("reset", "device.reset", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
-		state "default", label:"Reset Color", action:"reset", icon:"st.lights.philips.hue-single"
-	}
-
 	controlTile("colorTempSliderControl", "device.colorTemperature", "slider", width: 4, height: 2, inactiveLabel: false, range:"(2700..6500)") {
 		state "colorTemperature", action:"color temperature.setColorTemperature"
 	}
 
 	main(["switch"])
-	details(["switch", "levelSliderControl", "rgbSelector", "colorTempSliderControl", "reset"])
+	details(["switch", "levelSliderControl", "colorTempSliderControl"])
 }
+
+private getCOLOR_TEMP_MIN() { 2700 }
+private getCOLOR_TEMP_MAX() { 6500 }
+// For Z-Wave devices, we control illumination by crossfading the cold and warm
+// white channels.  But for devices that only have single cold or warm white
+// illumination (as with many RGBW LED strips), we cannot dim either white
+// channel to 0, as this will then completely turn off illumination.
+// Therefore, we lower-bound both white channels to 1.  This will have no
+// perceptible impact for devices that actually support white temperature
+// cross-fading, but will keep devices that do not doing something sane from
+// the user perspective, which is to modify intensity for the single white
+private getWHITE_MIN() { 1 } // min for Z-Wave coldWhite and warmWhite paramaeters
+private getWHITE_MAX() { 255 } // max for Z-Wave coldWhite and warmWhite paramaeters
+private getCOLOR_TEMP_DIFF() { COLOR_TEMP_MAX - COLOR_TEMP_MIN }
+private getRED() { "red" }
+private getGREEN() { "green" }
+private getBLUE() { "blue" }
+private getWARM_WHITE() { "warmWhite" }
+private getCOLD_WHITE() { "coldWhite" }
+private getRGB_NAMES() { [RED, GREEN, BLUE] }
+private getWHITE_NAMES() { [WARM_WHITE, COLD_WHITE] }
+private getCOLOR_NAMES() { RGB_NAMES + WHITE_NAMES }
+private MIN(a, b) { a < b ? a : b }
+private MAX(a, b) { a > b ? a : b }
+private BOUND(x, floor, ceiling) { x < floor ? floor : x > ceiling ? ceiling : x }
 
 def updated() {
 	log.debug "updated().."
@@ -79,10 +133,12 @@ def updated() {
 
 def installed() {
 	log.debug "installed()..."
-	state.colorReceived = ["red": null, "green": null, "blue": null, "warmWhite": null, "coldWhite": null]
-	sendEvent(name: "checkInterval", value: 1860, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID, offlinePingable: "0"])
-	sendEvent(name: "level", value: 100, unit: "%")
-	response(refresh())
+	sendEvent(name: "checkInterval", value: 1860, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
+	sendEvent(name: "level", value: 100, unit: "%", displayed: false)
+	sendEvent(name: "colorTemperature", value: COLOR_TEMP_MIN, displayed: false)
+	sendEvent(name: "color", value: "#000000", displayed: false)
+	sendEvent(name: "hue", value: 0, displayed: false)
+	sendEvent(name: "saturation", value: 0, displayed: false)
 }
 
 def parse(description) {
@@ -115,39 +171,15 @@ def zwaveEvent(physicalgraph.zwave.commands.switchmultilevelv3.SwitchMultilevelR
 
 def zwaveEvent(physicalgraph.zwave.commands.switchcolorv3.SwitchColorReport cmd) {
 	log.debug "got SwitchColorReport: $cmd"
-	if (!state.colorReceived)
-		state.colorReceived = ["red": null, "green": null, "blue": null, "warmWhite": null, "coldWhite": null]
-	state.colorReceived[cmd.colorComponent] = cmd.value
 	def result = []
-	def rgbNames = ["red", "green", "blue"]
-	def tempNames = ["warmWhite", "coldWhite"]
-	// Check if we got all the RGB color components
-	if (rgbNames.every { state.colorReceived[it] != null }) {
-		def colors = rgbNames.collect { state.colorReceived[it] }
-		log.debug "colors: $colors"
-		// Send the color as hex format
-		def hexColor = "#" + colors.collect { Integer.toHexString(it).padLeft(2, "0") }.join("")
-		result << createEvent(name: "color", value: hexColor)
-		// Send the color as hue and saturation
-		def hsv = rgbToHSV(*colors)
-		result << createEvent(name: "hue", value: hsv.hue)
-		result << createEvent(name: "saturation", value: hsv.saturation)
-		// Reset the values
-		rgbNames.collect { state.colorReceived[it] = null}
-	}
-	// Check if we got all the color temperature values
-	if (tempNames.every { state.colorReceived[it] != null}) {
-		def warmWhite = state.colorReceived["warmWhite"]
-		def coldWhite = state.colorReceived["coldWhite"]
-		log.debug "warmWhite: $warmWhite, coldWhite: $coldWhite"
-		// When the device is first installed, warmWhite == coldWhite == 255
-		//  so default to mid-range color temp.
-		def colorTemp = COLOR_TEMP_MIN + (COLOR_TEMP_DIFF / 2)
-		if (warmWhite != coldWhite)
-			colorTemp = (COLOR_TEMP_MAX - (COLOR_TEMP_DIFF * warmWhite) / 255) as Integer
-		result << createEvent(name: "colorTemperature", value: colorTemp)
-		// Reset the values
-		tempNames.collect { state.colorReceived[it] = null }
+	if (state.staged != null && cmd.colorComponent in RGB_NAMES) {
+		// We use this as a callback from our color setter.
+		// Emit our color update event with our staged state.
+		state.staged.subMap("hue", "saturation", "color").each{ k, v -> result << createEvent(name: k, value: v) }
+	} else if (state.staged != null && cmd.colorComponent in WHITE_NAMES) {
+		// We use this as a callback from our temperature setter.
+		// Emit our color temperature update event with our staged state.
+		state.staged.subMap("colorTemperature").each{ k, v -> result << createEvent(name: k, value: v) }
 	}
 	result
 }
@@ -159,10 +191,6 @@ private dimmerEvents(physicalgraph.zwave.Command cmd) {
 		result << createEvent(name: "level", value: cmd.value == 99 ? 100 : cmd.value , unit: "%")
 	}
 	return result
-}
-
-def zwaveEvent(physicalgraph.zwave.commands.hailv1.Hail cmd) {
-	response(command(zwave.switchMultilevelV1.switchMultilevelGet()))
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.securityv1.SecurityMessageEncapsulation cmd) {
@@ -186,16 +214,22 @@ def zwaveEvent(physicalgraph.zwave.Command cmd) {
 	[linkText: linkText, descriptionText: "$linkText: $cmd", displayed: false]
 }
 
-def buildOffOnEvent(cmd){
-	[zwave.basicV1.basicSet(value: cmd), zwave.switchMultilevelV3.switchMultilevelGet()]
-}
-
 def on() {
-	commands(buildOffOnEvent(0xFF), 3500)
+	// Per Z-Wave spec, this multilevel switch set value commands state-transition
+	// to on.  This will restore the most-recent non-zero value cached in the device.
+	def ON = 0xFF
+	commands([zwave.switchMultilevelV3.switchMultilevelSet(value: ON),
+	         zwave.switchMultilevelV3.switchMultilevelGet(),
+	], 3500)
 }
 
 def off() {
-	commands(buildOffOnEvent(0x00), 3500)
+	// Per Z-Wave spec, this multilevel switch set value commands state-transition
+	// to off.  This will not clobber the most-recent non-zero value cached in the device.
+	def OFF = 0
+	commands([zwave.switchMultilevelV3.switchMultilevelSet(value: OFF),
+	         zwave.switchMultilevelV3.switchMultilevelGet(),
+	], 3500)
 }
 
 def refresh() {
@@ -207,17 +241,16 @@ def ping() {
 	refresh()
 }
 
-def setLevel(level) {
-	setLevel(level, 1)
-}
-
-def setLevel(level, duration) {
+def setLevel(level, duration=1) {
 	log.debug "setLevel($level, $duration)"
-	if(level > 99) level = 99
+	level = Math.max(Math.min(level, 99), 1) // See Z-Wave level encoding
+	duration = duration < 128 ? duration : 127 + Math.round(duration / 60) // See Z-Wave duration encodinbg
+	duration = Math.min(duration, 0xFE) // 0xFF is a special code for factory default; bound to 0xFE
+	def tcallback = Math.min(duration * 1000 + 2500, 12000) // how long should we wait to read back?  we can't wait forever
 	commands([
 		zwave.switchMultilevelV3.switchMultilevelSet(value: level, dimmingDuration: duration),
 		zwave.switchMultilevelV3.switchMultilevelGet(),
-	], (duration && duration < 12) ? (duration * 1000) : 3500)
+	], tcallback)
 }
 
 def setSaturation(percent) {
@@ -232,53 +265,54 @@ def setHue(value) {
 
 def setColor(value) {
 	log.debug "setColor($value)"
-	def result = []
+	def rgb
+	if (state.staged == null) {
+		state.staged = [:]
+	}
 	if (value.hex) {
-		def c = value.hex.findAll(/[0-9a-fA-F]{2}/).collect { Integer.parseInt(it, 16) }
-		result << zwave.switchColorV3.switchColorSet(red:c[0], green:c[1], blue:c[2], warmWhite:0, coldWhite:0)
+		state.staged << [color: value.hex] // stage ST RGB color attribute
+		def hsv = colorUtil.hexToHsv(value.hex) // convert to HSV
+		state.staged << [hue: hsv[0], saturation: hsv[1]] // stage ST hue and saturation attributes
+		rgb = value.hex.findAll(/[0-9a-fA-F]{2}/).collect { Integer.parseInt(it, 16) } // separate RGB elements for zwave setter
 	} else {
-		def rgb = huesatToRGB(value.hue, value.saturation)
-		result << zwave.switchColorV3.switchColorSet(red: rgb[0], green: rgb[1], blue: rgb[2], warmWhite:0, coldWhite:0)
+		state.staged << value.subMap("hue", "saturation") // stage ST hue and saturation attributes
+		def hex = colorUtil.hsvToHex(Math.round(value.hue) as int, Math.round(value.saturation) as int) // convert to hex
+		state.staged << [color: hex] // statge ST RGB color attribute
+		rgb = colorUtil.hexToRgb(hex) // separate RGB elements for zwave setter
 	}
-	if (device.currentValue("switch") != "on") {
-		result << zwave.basicV1.basicSet(value: 0xFF)
-		result << zwave.switchMultilevelV3.switchMultilevelGet()
-	}
-	result += queryAllColors()
-
-	commands(result)
+	commands([zwave.switchColorV3.switchColorSet(red: rgb[0], green: rgb[1], blue: rgb[2], warmWhite: 0, coldWhite: 0),
+	          zwave.switchColorV3.switchColorGet(colorComponent: RGB_NAMES[0]), // event-publish callback is on any of the RGB responses, so only need to GET one of these
+	], 3500)
 }
 
-private getCOLOR_TEMP_MAX() { 6500 }
-private getCOLOR_TEMP_MIN() { 2700 }
-private getCOLOR_TEMP_DIFF() { COLOR_TEMP_MAX - COLOR_TEMP_MIN }
+private tempToZwaveWarmWhite(temp) {
+	temp = BOUND(temp, COLOR_TEMP_MIN, COLOR_TEMP_MAX)
+	def warmValue = ((COLOR_TEMP_MAX - temp) / COLOR_TEMP_DIFF * WHITE_MAX) as Integer
+	warmValue = MAX(WHITE_MIN, warmValue)
+	warmValue
+}
+
+private tempToZwaveColdWhite(temp) {
+	def coldValue = (WHITE_MAX - tempToZwaveWarmWhite(temp))
+	coldValue = MAX(WHITE_MIN, coldValue)
+	coldValue
+}
 
 def setColorTemperature(temp) {
-	if(temp > COLOR_TEMP_MAX)
-		temp = COLOR_TEMP_MAX
-	else if(temp < COLOR_TEMP_MIN)
-		temp = COLOR_TEMP_MIN
 	log.debug "setColorTemperature($temp)"
-	def warmValue = ((COLOR_TEMP_MAX - temp) / COLOR_TEMP_DIFF * 255) as Integer
-	def coldValue = 255 - warmValue
-	def result = []
-	result << zwave.switchColorV3.switchColorSet(red: 0, green: 0, blue: 0, warmWhite: warmValue, coldWhite: coldValue)
-	if (device.currentValue("switch") != "on") {
-		result << zwave.basicV1.basicSet(value: 0xFF)
-		result << zwave.switchMultilevelV3.switchMultilevelGet()
+	def warmValue = tempToZwaveWarmWhite(temp)
+	def coldValue = tempToZwaveColdWhite(temp)
+	if (state.staged == null) {
+		state.staged = [:]
 	}
-	result += queryAllColors()
-	commands(result)
+	state.staged << [colorTemperature: temp] // stage ST colorTemperature attribute
+	commands([zwave.switchColorV3.switchColorSet(red: 0, green: 0, blue: 0, warmWhite: warmValue, coldWhite: coldValue),
+	          zwave.switchColorV3.switchColorGet(colorComponent: WHITE_NAMES[0]), // event-publish callback is on any of the while-level responses, so only need to GET one of these these
+	], 3500)
 }
 
 private queryAllColors() {
-	def colors = ["red", "green", "blue", "warmWhite", "coldWhite"]
-	colors.collect { zwave.switchColorV3.switchColorGet(colorComponent: it) }
-}
-
-def reset() {
-	log.debug "reset()"
-	setColorTemperature(COLOR_TEMP_MIN + (COLOR_TEMP_DIFF / 2))
+	COLOR_NAMES.collect { zwave.switchColorV3.switchColorGet(colorComponent: it) }
 }
 
 private secEncap(physicalgraph.zwave.Command cmd) {
@@ -301,15 +335,4 @@ private command(physicalgraph.zwave.Command cmd) {
 
 private commands(commands, delay=200) {
 	delayBetween(commands.collect{ command(it) }, delay)
-}
-
-def rgbToHSV(red, green, blue) {
-	def hex = colorUtil.rgbToHex(red as int, green as int, blue as int)
-	def hsv = colorUtil.hexToHsv(hex)
-	return [hue: hsv[0], saturation: hsv[1], value: hsv[2]]
-}
-
-def huesatToRGB(hue, sat) {
-	def color = colorUtil.hsvToHex(Math.round(hue) as int, Math.round(sat) as int)
-	return colorUtil.hexToRgb(color)
 }


### PR DESCRIPTION
This commit moves all devices currently matching aeon-led-bulb.groovy to
the generic Z-Wave RGBW color bulb DTH, rgbw-light.groovy by removal
of the generic device type / command-class fingerprints in the Aeon
driver and addition of appropriate device type / command class
fingerprints in the generic driver.  This is deemed appropriate because
the Aeon driver actually doesn't have any Aeon-specific manufacturer or
model fingerprinting.  In fact, the Aeon / Aeotec LED bulbs are already
matching to the generic driver with these fingerprints:

* fingerprint mfr: "0086", prod: "0003", model: "0062", deviceJoinName: "Aeotec LED Bulb" //EU
* fingerprint mfr: "0086", prod: "0103", model: "0062", deviceJoinName: "Aeotec LED Bulb" //US

This leaves only non-Aeon bulbs matching to the Aeon driver, and these
can be better supported in the generic driver.

The related aeon-led-bulb-6 driver is left intact though, as these bulbs
use non-standard commands for white temperature control, and thus are
incompatible with the generic driver.  It was verified on the bench that
temperature control for the Aeon / Aeotec LED Bulb 6 device does not work
properly with the generic RGBW DTH, but does work with the existing
model-specific aeon-led-bulb-6 DTH.

Additionally, some refinements are made to the RGBW driver to improve
reliability of event emission and state update after user-initiated color
and color temperatures changes.  Finally, we lower-bound cold and warm
white intensity from the color temperature event handler to 1.  Within
standard Z-wave, temperature is controlled by crossfading cold and warm
white channels.  But for devices that only have single cold or warm white
illumination (true for many RGBW LED strips), we cannot dim either white
channel to 0, as this will then completely turn off illumination.  The
lower bound of 1 gives more intuitive operation for these devices, whereby
temperature effectively becomes an intensity modifier for the single cold
or warm white channel.