### PR TITLE
DTH for WWST-6054 & WWST-6055, Aeotec Siren 6 and Aeotec Doorbell 6

### DIFF
--- a/devicetypes/smartthings/aeotec-doorbell-siren-6.src/aeotec-doorbell-siren-6.groovy
+++ b/devicetypes/smartthings/aeotec-doorbell-siren-6.src/aeotec-doorbell-siren-6.groovy
@@ -25,6 +25,8 @@ metadata {
 		fingerprint mfr: "0371", prod: "0103", model: "00A2", deviceJoinName: "Aeotec Doorbell 6" //US
 		fingerprint mfr: "0371", prod: "0003", model: "00A4", deviceJoinName: "Aeotec Siren 6" //EU
 		fingerprint mfr: "0371", prod: "0103", model: "00A4", deviceJoinName: "Aeotec Siren 6" //US
+		fingerprint mfr: "0371", prod: "0203", model: "00A4", deviceJoinName: "Aeotec Siren 6" //AU
+		fingerprint mfr: "0371", prod: "0203", model: "00A2", deviceJoinName: "Aeotec Doorbell 6" //AU
 	}
 
 	tiles {
@@ -53,7 +55,8 @@ metadata {
 private getNumberOfSounds() {
 	def numberOfSounds = [
 			"0003" : 8, //Aeotec Doorbell/Siren EU
-			"0103" : 8 //Aeotec Doorbell/Siren US
+			"0103" : 8, //Aeotec Doorbell/Siren US
+			"0203" : 8 //Aeotec Doorbell/Siren AU
 	]
 	return numberOfSounds[zwaveInfo.prod] ?: 1
 }


### PR DESCRIPTION
Added below two FPs in file -> aeotec-doorbell-siren-6.groovy
FPs:	  
**fingerprint mfr: "0371", prod: "0203", model: "00A4", deviceJoinName: "Aeotec Siren 6" //AU
fingerprint mfr: "0371", prod: "0203", model: "00A2", deviceJoinName: "Aeotec Doorbell 6" //AU**

Also added entry for

 private getNumberOfSounds() {
	def numberOfSounds = [
			"0003" : 8, //Aeotec Doorbell/Siren EU
                        "0103" : 8, //Aeotec Doorbell/Siren US
                        **"0203" : 8 //Aeotec Doorbell/Siren AU**
	]
	return numberOfSounds[zwaveInfo.prod] ?: 1
}

Could you please review and approve this request.