### PR TITLE
WWST-6527 - Added support for Danfoss Ally Radiator thermostat

### DIFF
--- a/devicetypes/smartthings/zigbee-thermostat.src/zigbee-thermostat.groovy
+++ b/devicetypes/smartthings/zigbee-thermostat.src/zigbee-thermostat.groovy
@@ -4,7 +4,7 @@
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  *  in compliance with the License. You may obtain a copy of the License at:
  *
- *		http://www.apache.org/licenses/LICENSE-2.0
+ *		    http://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
  *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
@@ -278,7 +278,7 @@ private parseAttrMessage(description) {
 def installed() {
 	sendEvent(name: "checkInterval", value: 2 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
 
-	if(isDanfossAlly()) {
+	if (isDanfossAlly()) {
 		state.supportedThermostatModes = ["heat"]
 	} else {
 		state.supportedThermostatModes = ["off", "heat", "cool", "emergency heat"]
@@ -301,9 +301,16 @@ def refresh() {
 			zigbee.readAttribute(THERMOSTAT_CLUSTER, THERMOSTAT_MODE) +
 			zigbee.readAttribute(THERMOSTAT_CLUSTER, THERMOSTAT_RUNNING_STATE) +
 			zigbee.readAttribute(FAN_CONTROL_CLUSTER, FAN_MODE) +
-			zigbee.readAttribute(zigbee.POWER_CONFIGURATION_CLUSTER, BATTERY_VOLTAGE) +
-			zigbee.readAttribute(zigbee.POWER_CONFIGURATION_CLUSTER, BATTERY_PERCENTAGE_REMAINING) +
-			zigbee.readAttribute(zigbee.POWER_CONFIGURATION_CLUSTER, BATTERY_ALARM_STATE)
+            zigbee.readAttribute(zigbee.POWER_CONFIGURATION_CLUSTER, BATTERY_ALARM_STATE) +
+            getBatteryRemainingCommand()
+}
+
+def getBatteryRemainingCommand() {
+    if (isDanfossAlly()) {
+        zigbee.readAttribute(zigbee.POWER_CONFIGURATION_CLUSTER, BATTERY_PERCENTAGE_REMAINING)
+    } else {
+        zigbee.readAttribute(zigbee.POWER_CONFIGURATION_CLUSTER, BATTERY_VOLTAGE)
+    }
 }
 
 def ping() {

--- a/devicetypes/smartthings/zigbee-thermostat.src/zigbee-thermostat.groovy
+++ b/devicetypes/smartthings/zigbee-thermostat.src/zigbee-thermostat.groovy
@@ -4,7 +4,7 @@
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  *  in compliance with the License. You may obtain a copy of the License at:
  *
- *			http://www.apache.org/licenses/LICENSE-2.0
+ *		http://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
  *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
@@ -36,7 +36,7 @@ metadata {
 
 		fingerprint profileId: "0104", inClusters: "0000,0001,0003,0004,0005,0020,0201,0202,0204,0B05", outClusters: "000A, 0019",  manufacturer: "LUX", model: "KONOZ", deviceJoinName: "LUX KONOz Thermostat"
 		fingerprint profileId: "0104", inClusters: "0000,0003,0020,0201,0202,0405", outClusters: "0019, 0402", manufacturer: "Umbrela", model: "Thermostat", deviceJoinName: "Umbrela UTee"
-		fingerprint manufacturer: "Danfoss", model: "eTRV0100", deviceJoinName: "Thermostat", vid: "generic-radiator-thermostat" //Danfoss Ally Radiator thermostat, Raw Description	01 0104 0301 01 08 0000 0001 0003 000A 0020 0201 0204 0B05 02 0000 0019
+		fingerprint manufacturer: "Danfoss", model: "eTRV0100", deviceJoinName: "Danfoss Thermostat", vid: "generic-radiator-thermostat" //Danfoss Ally Radiator thermostat, Raw Description	01 0104 0301 01 08 0000 0001 0003 000A 0020 0201 0204 0B05 02 0000 0019
 	}
 
 	tiles {
@@ -265,7 +265,6 @@ private parseAttrMessage(description) {
 			} else if (it.attribute == BATTERY_PERCENTAGE_REMAINING) {
 				map.name = "battery"
 				map.value = Math.min(100, Integer.parseInt(it.value, 16))
-				map.descriptionText = "${device.displayName} battery has ${map.value}%"
 			} else if (it.attribute == BATTERY_ALARM_STATE) {
 				map = getPowerSource(it.value)
 			}
@@ -355,7 +354,6 @@ def getBatteryPercentage(rawValue) {
 			roundedPct = 0
 		}
 		result.value = Math.min(100, roundedPct)
-		result.descriptionText = "${device.displayName} battery has ${result.value}%"
 	}
 
 	return result

--- a/devicetypes/smartthings/zigbee-thermostat.src/zigbee-thermostat.groovy
+++ b/devicetypes/smartthings/zigbee-thermostat.src/zigbee-thermostat.groovy
@@ -351,11 +351,12 @@ def getBatteryPercentage(rawValue, attribute) {
 				roundedPct = 0
 			}
 			result.value = Math.min(100, roundedPct)
+            result.descriptionText = "${device.displayName} battery has ${result?.value}%"
 		}
 	} else if (attribute == BATTERY_PERCENTAGE_REMAINING) {
 		result.value = Math.min(100, rawValue)
+        result.descriptionText = "${device.displayName} battery has ${result?.value}%"
 	}
-	result.descriptionText = "${device.displayName} battery has ${result?.value}%"
 
 	return result
 }


### PR DESCRIPTION
WWST-6527 - Added support for Danfoss Ally Radiator thermostat

https://zigbeealliance.org/zigbee_products/danfoss-ally-radiator-thermostat/
application: 02
endpointId: 01
manufacturer: Danfoss
model: eTRV0100
zigbeeNodeType: SLEEPY_END_DEVICE

Raw Description: 01 0104 0301 01 08 0000 0001 0003 000A 0020 0201 0204 0B05 02 0000 0019

@tpmanley @greens @dkirker @MWierzbinskaS @PKacprowiczS @ZWozniakS @MGoralczykS @BJanuszS
Please, take a look at the code.