### PR TITLE
Update dawon-zwave-wall-smart-switch.groovy

### DIFF
--- a/devicetypes/smartthings/dawon-zwave-wall-smart-switch.src/dawon-zwave-wall-smart-switch.groovy
+++ b/devicetypes/smartthings/dawon-zwave-wall-smart-switch.src/dawon-zwave-wall-smart-switch.groovy
@@ -23,6 +23,9 @@ metadata {
 		fingerprint mfr: "018C", prod: "0061", model: "0001", deviceJoinName: "Dawon Temp/Humidity Sensor" // addChildDevice "Dawon Smart Switch${endpoint}" 1
 		fingerprint mfr: "018C", prod: "0062", model: "0001", deviceJoinName: "Dawon Temp/Humidity Sensor" // addChildDevice "Dawon Smart Switch${endpoint}" 2
 		fingerprint mfr: "018C", prod: "0063", model: "0001", deviceJoinName: "Dawon Temp/Humidity Sensor" // addChildDevice "Dawon Smart Switch${endpoint}" 3
+		fingerprint mfr: "018C", prod: "0064", model: "0001", deviceJoinName: "Dawon Temp/Humidity Sensor" // addChildDevice "Dawon Smart Switch${endpoint}" 1
+		fingerprint mfr: "018C", prod: "0065", model: "0001", deviceJoinName: "Dawon Temp/Humidity Sensor" // addChildDevice "Dawon Smart Switch${endpoint}" 2
+		fingerprint mfr: "018C", prod: "0066", model: "0001", deviceJoinName: "Dawon Temp/Humidity Sensor" // addChildDevice "Dawon Smart Switch${endpoint}" 3
 	}
 
 	preferences {
@@ -332,11 +335,11 @@ private changeSwitch(endpoint, value) {
 }
 
 private getNumberOfChildFromModel() {
-	if (zwaveInfo.prod.equals("0063")) {
+	if (zwaveInfo.prod.equals("0063")||zwaveInfo.prod.equals("0066")) {
 		return 3
-	} else if (zwaveInfo.prod.equals("0062")) {
+	} else if (zwaveInfo.prod.equals("0062")||zwaveInfo.prod.equals("0065")) {
 		return 2
-	} else if (zwaveInfo.prod.equals("0061")) {
+	} else if (zwaveInfo.prod.equals("0061")||zwaveInfo.prod.equals("0064")) {
 		return 1
 	} else {
 		return 0


### PR DESCRIPTION
Added fingerprints for Dawon Z-Wave Wall Smart Switches US version, previously sold at Amazon.com
https://www.amazon.com/gp/product/B07VSNPZGL
US version is currently discontinued.
They work as the same way as the Korean Version, only difference is the the Z-wave frequency, according to the country