### PR TITLE
ICP-12860, ICP-12861 - battery report and alarm length - fixes

### DIFF
--- a/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
+++ b/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
@@ -187,7 +187,7 @@ def getYaleDefaults() {
 	 4: false]
 }
 
-def getEverspringDefaults() {
+def getEverspringDefaultAlarmLength() {
 	[1: 180]
 }
 
@@ -238,8 +238,8 @@ def getConfigurationCommands() {
 	}
 
 	if(isEverspring()){
-		if (!state.alarmLength) state.alarmLength = everspringDefaults[1]
-		Short alarmLength = (settings.alarmLength as Short) ?: everspringDefaults[1]
+		if (!state.alarmLength) state.alarmLength = everspringDefaultAlarmLength[1]
+		Short alarmLength = (settings.alarmLength as Short) ?: everspringDefaultAlarmLength[1]
 
 		if(alarmLength != state.alarmLength) {
 			alarmLength = calculateLength(alarmLength)
@@ -485,7 +485,7 @@ private Boolean secondsPast(timestamp, seconds) {
 def calculateLength(int alarmLength){
 	//If the siren is Everspring then the alarm length can be set to 1, 2 or max 3 minutes
 	def map = [1:60, 2:120, 3:180]
-	if (alarmLength > 3) return everspringDefaults[1] else return map[alarmLength].value
+	if (alarmLength > 3) return map[3] else return map[alarmLength].value
 }
 
 def isYale() {

--- a/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
+++ b/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
@@ -188,7 +188,7 @@ def getYaleDefaults() {
 }
 
 def getEverspringDefaultAlarmLength() {
-	[1: 180]
+	return 180
 }
 
 def getConfigurationCommands() {
@@ -238,8 +238,8 @@ def getConfigurationCommands() {
 	}
 
 	if(isEverspring()){
-		if (!state.alarmLength) state.alarmLength = everspringDefaultAlarmLength[1]
-		Short alarmLength = (settings.alarmLength as Short) ?: everspringDefaultAlarmLength[1]
+		if (!state.alarmLength) state.alarmLength = everspringDefaultAlarmLength
+		Short alarmLength = (settings.alarmLength as Short) ?: everspringDefaultAlarmLength
 
 		if(alarmLength != state.alarmLength) {
 			alarmLength = calculateLength(alarmLength)
@@ -485,7 +485,7 @@ private Boolean secondsPast(timestamp, seconds) {
 def calculateLength(int alarmLength){
 	//If the siren is Everspring then the alarm length can be set to 1, 2 or max 3 minutes
 	def map = [1:60, 2:120, 3:180]
-	if (alarmLength > 3) return map[3] else return map[alarmLength].value
+	if (alarmLength > 3) return everspringDefaultAlarmLength else return map[alarmLength].value
 }
 
 def isYale() {

--- a/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
+++ b/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
@@ -237,12 +237,14 @@ def getConfigurationCommands() {
 		state.configured = true
 	}
 
-	if(isEverspring()){
-		if (!state.alarmLength) state.alarmLength = everspringDefaultAlarmLength
+	if (isEverspring()) {
+		if (!state.alarmLength) {
+            state.alarmLength = everspringDefaultAlarmLength
+        }
 		Short alarmLength = (settings.alarmLength as Short) ?: everspringDefaultAlarmLength
 
-		if(alarmLength != state.alarmLength) {
-			alarmLength = calculateLength(alarmLength)
+		if (alarmLength != state.alarmLength) {
+			alarmLength = calcEverspringAlarmLen(alarmLength)
 			state.alarmLength = alarmLength
 			log.debug "alarm settings: ${alarmLength}"
 		}
@@ -482,10 +484,14 @@ private Boolean secondsPast(timestamp, seconds) {
 	return (new Date().time - timestamp) > (seconds * 1000)
 }
 
-def calculateLength(int alarmLength){
+def calcEverspringAlarmLen(int alarmLength) {
 	//If the siren is Everspring then the alarm length can be set to 1, 2 or max 3 minutes
 	def map = [1:60, 2:120, 3:180]
-	if (alarmLength > 3) return everspringDefaultAlarmLength else return map[alarmLength].value
+	if (alarmLength > 3) {
+        return everspringDefaultAlarmLength
+    } else {
+        return map[alarmLength].value
+    }
 }
 
 def isYale() {

--- a/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
+++ b/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
@@ -488,9 +488,9 @@ def calcEverspringAlarmLen(int alarmLength) {
 	//If the siren is Everspring then the alarm length can be set to 1, 2 or max 3 minutes
 	def map = [1:60, 2:120, 3:180]
 	if (alarmLength > 3) {
-        return everspringDefaultAlarmLength
+		return everspringDefaultAlarmLength
     } else {
-        return map[alarmLength].value
+		return map[alarmLength].value
     }
 }
 

--- a/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
+++ b/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
@@ -134,7 +134,7 @@ def initialize() {
 		log.warn "Initializition of ${device.displayName} has failed with too many attempts"
 		return
 	}
-	
+
 	def cmds = []
 
 	if (!device.currentState("alarm")) {
@@ -144,7 +144,7 @@ def initialize() {
 		}
 	}
 	if (!device.currentState("battery")) {
-		if (zwaveInfo?.cc?.contains("80")) {
+		if (zwaveInfo?.cc?.contains("80") || zwaveInfo?.sec?.contains("80")) {
 			cmds << secure(zwave.batteryV1.batteryGet())
 		} else {
 			// Right now this DTH assumes all devices are battery powered, in the event a device is wall powered we should populate something
@@ -185,6 +185,10 @@ def getYaleDefaults() {
 	 2: true,
 	 3: 0,
 	 4: false]
+}
+
+def getEverspringDefaults() {
+	[1: 180]
 }
 
 def getConfigurationCommands() {
@@ -232,6 +236,19 @@ def getConfigurationCommands() {
 		// if there's nothing to configure, we're configured
 		state.configured = true
 	}
+
+	if(isEverspring()){
+		if (!state.alarmLength) state.alarmLength = everspringDefaults[1]
+		Short alarmLength = (settings.alarmLength as Short) ?: everspringDefaults[1]
+
+		if(alarmLength != state.alarmLength) {
+			alarmLength = calculateLength(alarmLength)
+			state.alarmLength = alarmLength
+			log.debug "alarm settings: ${alarmLength}"
+		}
+		cmds << secure(zwave.configurationV2.configurationSet(parameterNumber: 1, size: 2, configurationValue: [0,alarmLength]))
+	}
+
 	if (cmds.size > 0) {
 		// send this last to confirm we were heard
 		cmds << secure(zwave.configurationV2.configurationGet(parameterNumber: 1))
@@ -321,11 +338,11 @@ def parse(String description) {
 			result = createEvent(descriptionText: description, displayed: false)
 		} else {
 			result = createEvent(
-				descriptionText: "This device failed to complete the network security key exchange. If you are unable to control it via SmartThings, you must remove it from your network and add it again.",
-				eventType: "ALERT",
-				name: "secureInclusion",
-				value: "failed",
-				displayed: true,
+					descriptionText: "This device failed to complete the network security key exchange. If you are unable to control it via SmartThings, you must remove it from your network and add it again.",
+					eventType: "ALERT",
+					name: "secureInclusion",
+					value: "failed",
+					displayed: true,
 			)
 		}
 	} else {
@@ -371,6 +388,7 @@ def zwaveEvent(physicalgraph.zwave.commands.configurationv2.ConfigurationReport 
 	} else {
 		state.configured = true
 	}
+	log.debug "configuration report: ${cmd}"
 	return [:]
 }
 
@@ -441,7 +459,7 @@ def zwaveEvent(physicalgraph.zwave.commands.notificationv3.NotificationReport cm
 			case 0x03: //Tamper switch is pressed more than 3 sec and released
 				result << createEvent([name: "tamper", value: "detected"])
 				result << createEvent([name: "alarm", value: "both"])
-			break
+				break
 		}
 	}
 	result
@@ -462,6 +480,12 @@ private Boolean secondsPast(timestamp, seconds) {
 		}
 	}
 	return (new Date().time - timestamp) > (seconds * 1000)
+}
+
+def calculateLength(int alarmLength){
+	//If the siren is Everspring then the alarm length can be set to 1, 2 or max 3 minutes
+	def map = [1:60, 2:120, 3:180]
+	if (alarmLength > 3) return everspringDefaults[1] else return map[alarmLength].value
 }
 
 def isYale() {

--- a/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
+++ b/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
@@ -239,8 +239,8 @@ def getConfigurationCommands() {
 
 	if (isEverspring()) {
 		if (!state.alarmLength) {
-            state.alarmLength = everspringDefaultAlarmLength
-        }
+			state.alarmLength = everspringDefaultAlarmLength
+		}
 		Short alarmLength = (settings.alarmLength as Short) ?: everspringDefaultAlarmLength
 
 		if (alarmLength != state.alarmLength) {
@@ -257,7 +257,6 @@ def getConfigurationCommands() {
 	}
 	cmds
 }
-
 
 def poll() {
 	if (secondsPast(state.lastbatt, 36 * 60 * 60)) {
@@ -489,9 +488,9 @@ def calcEverspringAlarmLen(int alarmLength) {
 	def map = [1:60, 2:120, 3:180]
 	if (alarmLength > 3) {
 		return everspringDefaultAlarmLength
-    } else {
+	} else {
 		return map[alarmLength].value
-    }
+	}
 }
 
 def isYale() {


### PR DESCRIPTION
ICP-12860, ICP-12861 - fixes

The following issues have been fixed:

1) Due to the lack of one condition the DTH has failed to get a correct battery level value after initialization of the device which has led to creating a faulty event with hardcoded "100%" value. This resulted in inaccurate reading on mobile app. It has been fixed by checking security encapsulated command. 

2) One preference for Everspring Siren (alarm length) has not been included. Now the alarm length can also be set for the Everspring Siren (1-3 min). 

@tpmanley @greens @dkirker @MWierzbinskaS @PKacprowiczS @ZWozniakS @MGoralczykS @KKlimczukS
I would appreciate if you could review my changes.