### PR TITLE
ICP-12842 Changed wakeUpNotification interval and checkInterval for Water Sensors and Motion Light Sensors + added icon for Motion Sensors

### DIFF
--- a/devicetypes/smartthings/zwave-motion-light-sensor.src/zwave-motion-light-sensor.groovy
+++ b/devicetypes/smartthings/zwave-motion-light-sensor.src/zwave-motion-light-sensor.groovy
@@ -89,10 +89,6 @@ def updated() {
 def configure() {
 	// Device wakes up every 8 hours (+ 2 minutes), this interval allows us to miss one wakeup notification before marking offline
 	sendEvent(name: "checkInterval", value: 8 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
-	// Setting wakeUpNotification interval for NEO Coolcam and Dome devices
-	if (isNeoCoolcam() || isDome()) {
-		zwave.wakeUpV2.wakeUpIntervalSet(seconds: 4 * 3600, nodeid: zwaveHubNodeId).format()
-	}
 }
 
 private getCommandClassVersions() {
@@ -200,12 +196,4 @@ def sensorMotionEvent(value) {
 		result << createEvent(name: "motion", value: "inactive", descriptionText: "$device.displayName motion has stopped")
 	}
 	return result
-}
-
-private isDome() {
-	zwaveInfo.mfr == "021F" && zwaveInfo.model == "0083"
-}
-
-private isNeoCoolcam() {
-	zwaveInfo.mfr == "0258" && (zwaveInfo.model == "108D" || zwaveInfo.model == "008D")
 }

--- a/devicetypes/smartthings/zwave-motion-light-sensor.src/zwave-motion-light-sensor.groovy
+++ b/devicetypes/smartthings/zwave-motion-light-sensor.src/zwave-motion-light-sensor.groovy
@@ -17,7 +17,7 @@
  */
 
 metadata {
-	definition(name: "Z-Wave Motion/Light Sensor", namespace: "smartthings", author: "SmartThings") {
+	definition(name: "Z-Wave Motion/Light Sensor", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "x.com.st.d.sensor.motion") {
 		capability "Motion Sensor"
 		capability "Illuminance Measurement"
 		capability "Battery"
@@ -87,23 +87,12 @@ def updated() {
 }
 
 def configure() {
-	// Device wakes up every deviceCheckInterval hours, this interval allows us to miss one wakeup notification before marking offline
-	sendEvent(name: "checkInterval", value: 2 * deviceWakeUpInterval * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
-}
-
-def getDeviceWakeUpInterval() {
-	def deviceWakeIntervalValue = 4
-	switch (zwaveInfo?.mfr) {
-		case "021F":
-			deviceWakeIntervalValue = 12 // Dome reports once in 12h
-			break
-		case "0258":
-			deviceWakeIntervalValue = 12 // NEO Coolcam reports once in 12h
-			break
-		default:
-			deviceWakeIntervalValue = 4 // Default Z-Wave battery device reports once in 4h
+	// Device wakes up every 8 hours (+ 2 minutes), this interval allows us to miss one wakeup notification before marking offline
+	sendEvent(name: "checkInterval", value: 8 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
+	// Setting wakeUpNotification interval for NEO Coolcam and Dome devices
+	if (isNeoCoolcam() || isDome()) {
+		zwave.wakeUpV2.wakeUpIntervalSet(seconds: 4 * 3600, nodeid: zwaveHubNodeId).format()
 	}
-	return deviceWakeIntervalValue
 }
 
 private getCommandClassVersions() {
@@ -211,4 +200,12 @@ def sensorMotionEvent(value) {
 		result << createEvent(name: "motion", value: "inactive", descriptionText: "$device.displayName motion has stopped")
 	}
 	return result
+}
+
+private isDome() {
+	zwaveInfo.mfr == "021F" && zwaveInfo.model == "0083"
+}
+
+private isNeoCoolcam() {
+	zwaveInfo.mfr == "0258" && (zwaveInfo.model == "108D" || zwaveInfo.model == "008D")
 }

--- a/devicetypes/smartthings/zwave-motion-light-sensor.src/zwave-motion-light-sensor.groovy
+++ b/devicetypes/smartthings/zwave-motion-light-sensor.src/zwave-motion-light-sensor.groovy
@@ -89,6 +89,10 @@ def updated() {
 def configure() {
 	// Device wakes up every 8 hours (+ 2 minutes), this interval allows us to miss one wakeup notification before marking offline
 	sendEvent(name: "checkInterval", value: 8 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
+	// Setting wakeUpNotification interval for NEO Coolcam and Dome devices
+	if (isNeoCoolcam() || isDome()) {
+		zwave.wakeUpV2.wakeUpIntervalSet(seconds: 4 * 3600, nodeid: zwaveHubNodeId).format()
+	}
 }
 
 private getCommandClassVersions() {
@@ -196,4 +200,11 @@ def sensorMotionEvent(value) {
 		result << createEvent(name: "motion", value: "inactive", descriptionText: "$device.displayName motion has stopped")
 	}
 	return result
+}
+
+private isDome() {
+	zwaveInfo.mfr == "021F" && zwaveInfo.model == "0083"
+}
+private isNeoCoolcam() {
+	zwaveInfo.mfr == "0258" && (zwaveInfo.model == "108D" || zwaveInfo.model == "008D")
 }

--- a/devicetypes/smartthings/zwave-water-sensor.src/zwave-water-sensor.groovy
+++ b/devicetypes/smartthings/zwave-water-sensor.src/zwave-water-sensor.groovy
@@ -58,12 +58,12 @@ metadata {
 }
 
 def initialize() {
-	if (zwaveInfo.mfr.equals("0086"))
-		// 8 hour (+ 2 minutes) ping for Aeotec
+	if (zwaveInfo.mfr.equals("0086") || zwaveInfo.mfr.equals("021F") || zwaveInfo.mfr.equals("0258"))
+	// 8 hour (+ 2 minutes) ping for Aeotec, NEO Coolcam and Dome
 		sendEvent(name: "checkInterval", value: (8 * 60 * 60) + 120, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 	else
-		// 12 hours for other devices
-		sendEvent(name: "checkInterval", value: (2 * 12 + 2) * 60 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
+	// 12 hours (+ 2 minutes) for other devices
+		sendEvent(name: "checkInterval", value: (12 * 60 * 60) + 120, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 }
 
 def installed() {
@@ -84,6 +84,9 @@ def configure() {
 		// Tell sensor to send us battery information instead of USB power information
 		commands << encap(zwave.configurationV1.configurationSet(parameterNumber: 0x5E, scaledConfigurationValue: 1, size: 1))
 		response(delayBetween(commands, 1000) + ["delay 20000", encap(zwave.wakeUpV1.wakeUpNoMoreInformation())])
+	} else if (zwaveInfo.mfr.equals("021F") || zwaveInfo.mfr.equals("0258")) {
+		// wakeUpInterval set to 4 h for NEO Coolcam and Dome
+		zwave.wakeUpV1.wakeUpIntervalSet(seconds: 4 * 3600, nodeid: zwaveHubNodeId).format()
 	}
 }
 

--- a/devicetypes/smartthings/zwave-water-sensor.src/zwave-water-sensor.groovy
+++ b/devicetypes/smartthings/zwave-water-sensor.src/zwave-water-sensor.groovy
@@ -85,9 +85,6 @@ def configure() {
 		// Tell sensor to send us battery information instead of USB power information
 		commands << encap(zwave.configurationV1.configurationSet(parameterNumber: 0x5E, scaledConfigurationValue: 1, size: 1))
 		response(delayBetween(commands, 1000) + ["delay 20000", encap(zwave.wakeUpV1.wakeUpNoMoreInformation())])
-	} else if (isNeoCoolcam() || isDome()) {
-		// wakeUpInterval set to 4 h for NEO Coolcam, Dome
-		zwave.wakeUpV1.wakeUpIntervalSet(seconds: 4 * 3600, nodeid: zwaveHubNodeId).format()
 	}
 }
 

--- a/devicetypes/smartthings/zwave-water-sensor.src/zwave-water-sensor.groovy
+++ b/devicetypes/smartthings/zwave-water-sensor.src/zwave-water-sensor.groovy
@@ -85,6 +85,9 @@ def configure() {
 		// Tell sensor to send us battery information instead of USB power information
 		commands << encap(zwave.configurationV1.configurationSet(parameterNumber: 0x5E, scaledConfigurationValue: 1, size: 1))
 		response(delayBetween(commands, 1000) + ["delay 20000", encap(zwave.wakeUpV1.wakeUpNoMoreInformation())])
+	} else if (isNeoCoolcam() || isDome()) {
+		// wakeUpInterval set to 4 h for NEO Coolcam, Dome
+		zwave.wakeUpV1.wakeUpIntervalSet(seconds: 4 * 3600, nodeid: zwaveHubNodeId).format()
 	}
 }
 


### PR DESCRIPTION
@greens @tpmanley @dkirker  could you please review? 

**Added changes:**

**_zwave-water-sensor_**
- **ICP-12806** -> changed wakeUpNotification interval to 4h and checkInterval to 8h for Dome Water Sensor
- **ICP-12825** -> changed wakeUpNotification interval to 4h and checkInterval to 8h for Neo Coolcam Water Sensor

**_zwave-motion-light-sensor_** - included changes from closed #26626 PR
- **ICP-12842** -> changed wakeUpNotification interval to 4h and checkInterval to 8h for Neo Coolcam Motion Sensor
- **ICP-12880** -> changed wakeUpNotification interval to 4h and checkInterval to 8h for Dome Motion Senors
- **ICP-12889**, **ICP-12947** -> added icon for Motion Sensors

According to the certification team request and the fact that Leak Sensors and Motion Sensors are life safety devices I've changed the wakeUpNotification for Neo Coolcam and Dome to 4 hours and checkInterval to 8 hours. 

@KKlimczukS @PKacprowiczS @MGoralczykS @MWierzbinskaS @BJanuszS