### PR TITLE
[CHAD-4782] Add fibaro manufacturer information to door/window sensor fingerprint

### DIFF
--- a/devicetypes/fibargroup/fibaro-door-window-sensor-zw5.src/fibaro-door-window-sensor-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-door-window-sensor-zw5.src/fibaro-door-window-sensor-zw5.groovy
@@ -18,11 +18,12 @@ metadata {
 		capability "Battery"
 		capability "Contact Sensor"
 		capability "Sensor"
-        capability "Configuration"
-        capability "Tamper Alert"
+        	capability "Configuration"
+        	capability "Tamper Alert"
 		capability "Health Check"
 
-        fingerprint deviceId: "0x0701", inClusters: "0x5E, 0x85, 0x59, 0x22, 0x20, 0x80, 0x70, 0x56, 0x5A, 0x7A, 0x72, 0x8E, 0x71, 0x73, 0x98, 0x2B, 0x9C, 0x30, 0x86, 0x84", outClusters: ""
+		fingerprint mfr: "010F", prod: "0700"
+		fingerprint mfr: "010F", prod: "0701"
 	}
 
 	simulator {


### PR DESCRIPTION
Some version of fibaro open/close sensor need manufacturer information for matching dth.

product type id : 0x0700
https://products.z-wavealliance.org/products/1077?selectedFrequencyId=-1

product type id : 0x0701
https://products.z-wavealliance.org/products/1620?selectedFrequencyId=-1
