### PR TITLE
[ICP-12815] Quick fix for Fibaro Motion Sensor's settings

### DIFF
--- a/devicetypes/fibargroup/fibaro-motion-sensor-zw5.src/fibaro-motion-sensor-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-motion-sensor-zw5.src/fibaro-motion-sensor-zw5.groovy
@@ -85,7 +85,7 @@ metadata {
 			title: "Fibaro Motion Sensor settings",
 			description: "Device's settings update is executed when device wakes up.\n" +
 					"It may take up to 2 hours (for default wake up interval). \n" +
-					"If you want immediate change, manually wake up device by clicking B-button thrice.",
+					"If you want immediate change, manually wake up device by clicking B-button once.",
 			type: "paragraph",
 			element: "paragraph"
 		)


### PR DESCRIPTION
@greens @KKlimczukS @MGoralczykS @ZWozniakS @MWierzbinskaS @BJanuszS
Manual has fooled me, there was wrong information about waking up device by clicking button three times (but further it was stated that clicking once is enough, unfortunately I hadn't reached that far).