### PR TITLE
Fixed variable typo in buildColorHSMap

### DIFF
--- a/devicetypes/smartthings/testing/simulated-rgbw-bulb.src/simulated-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/testing/simulated-rgbw-bulb.src/simulated-rgbw-bulb.groovy
@@ -505,7 +505,7 @@ private Map buildColorHSMap(hue, saturation) {
     } catch (NumberFormatException nfe) {
         log.warn "Couldn't transform one of hue ($hue) or saturation ($saturation) to integers: $nfe"
     }
-    return colorHSmap
+    return colorHSMap
 }
 
 /**


### PR DESCRIPTION
Fixed a minor capitalization typo in a variable in the `buildColorHSMap()` method that would cause the color to get nulled out if `setColor()`, `setSaturation()` or one of the other methods which ultimately calls `buildColorHSMap()` was used.