### PR TITLE
[ICP-12926, ICP-12927] Everspring Wall Switch: handled down_hold event and hid the buttons value for the Hisotry tab

### DIFF
--- a/devicetypes/smartthings/aeotec-wallmote.src/aeotec-wallmote.groovy
+++ b/devicetypes/smartthings/aeotec-wallmote.src/aeotec-wallmote.groovy
@@ -95,7 +95,7 @@ def zwaveEvent(physicalgraph.zwave.commands.centralscenev1.CentralSceneNotificat
 
     def child = getChildDevice(button)
     child?.sendEvent(name: "button", value: value, data: [buttonNumber: 1], descriptionText: "$child.displayName was $value", isStateChange: true)
-    createEvent(name: "button", value: value, data: [buttonNumber: button], descriptionText: "$device.displayName button $button was $value", isStateChange: true)
+    createEvent(name: "button", value: value, data: [buttonNumber: button], descriptionText: "$device.displayName button $button was $value", isStateChange: true, displayed: false)
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.securityv1.SecurityMessageEncapsulation cmd) {
@@ -169,7 +169,7 @@ def getChildDevice(button) {
 
 private getSupportedButtonValues() {
     if (isEverspring()) {
-        return ["pushed", "held", "double"]
+        return ["pushed", "held", "down_hold", "double"]
     } else {
         return ["pushed", "held"]
     }
@@ -178,7 +178,8 @@ private getSupportedButtonValues() {
 private getButtonAttributesMap() {
     if (isEverspring()) {[
             0: "pushed",
-            2: "held",
+            1: "held",
+            2: "down_hold",
             3: "double"
     ]}
     else {[

--- a/devicetypes/smartthings/aeotec-wallmote.src/aeotec-wallmote.groovy
+++ b/devicetypes/smartthings/aeotec-wallmote.src/aeotec-wallmote.groovy
@@ -92,10 +92,11 @@ def zwaveEvent(physicalgraph.zwave.commands.centralscenev1.CentralSceneNotificat
     def button = cmd.sceneNumber
 
     def value = buttonAttributesMap[(int)cmd.keyAttributes]
-
-    def child = getChildDevice(button)
-    child?.sendEvent(name: "button", value: value, data: [buttonNumber: 1], descriptionText: "$child.displayName was $value", isStateChange: true)
-    createEvent(name: "button", value: value, data: [buttonNumber: button], descriptionText: "$device.displayName button $button was $value", isStateChange: true, displayed: false)
+    if (value) {
+        def child = getChildDevice(button)
+        child?.sendEvent(name: "button", value: value, data: [buttonNumber: 1], descriptionText: "$child.displayName was $value", isStateChange: true)
+        createEvent(name: "button", value: value, data: [buttonNumber: button], descriptionText: "$device.displayName button $button was $value", isStateChange: true, displayed: false)
+    }
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.securityv1.SecurityMessageEncapsulation cmd) {
@@ -169,7 +170,7 @@ def getChildDevice(button) {
 
 private getSupportedButtonValues() {
     if (isEverspring()) {
-        return ["pushed", "held", "down_hold", "double"]
+        return ["pushed", "held", "double"]
     } else {
         return ["pushed", "held"]
     }
@@ -178,8 +179,7 @@ private getSupportedButtonValues() {
 private getButtonAttributesMap() {
     if (isEverspring()) {[
             0: "pushed",
-            1: "held",
-            2: "down_hold",
+            2: "held",
             3: "double"
     ]}
     else {[


### PR DESCRIPTION
@greens @dkirker @tpmanley 
could you please review this? 

Before I just did not handle the "release" event because I thought we are not supporting it, but then I realized that we made a similar workaround for the Aeotec NanoOne (release is handled as held and the held as held down). So here I tried to do this in the same way.

@KKlimczukS @PKacprowiczS @MGoralczykS @MWierzbinskaS @BJanuszS