### PR TITLE
Battery powered wallswitch, not working.

### DIFF
--- a/devicetypes/smartthings/zwave-switch-secure.src/zwave-switch-secure.groovy
+++ b/devicetypes/smartthings/zwave-switch-secure.src/zwave-switch-secure.groovy
@@ -25,6 +25,7 @@ metadata {
 		fingerprint mfr: "0086", prod: "0003", model: "008B", deviceJoinName: "Aeon Labs Nano Switch"
 		fingerprint mfr: "0086", prod: "0103", model: "008B", deviceJoinName: "Aeon Labs Nano Switch"
 		fingerprint mfr: "027A", prod: "A000", model: "A001", deviceJoinName: "Zooz ZEN26 Switch"
+        fingerprint mfr: "0330", prod: "0003", model: "a310", deviceJoinName: "Z-Wave wall switch"
 	}
 
 	simulator {


### PR DESCRIPTION
Battery powered wall switch, with separate separate buttons (one for on, one for off). Also separate buttons for dimming. Today, the switch is seen by the smartthings hub and it connects. However, there is no way to configure the switch and the hub does not understand the buttons.