### PR TITLE
CHAD-4651 Move Inovelli 2-Channel Smart Plug to new MCD experience

### DIFF
--- a/devicetypes/erocm123/inovelli-2-channel-smart-plug-mcd.src/inovelli-2-channel-smart-plug-mcd.groovy
+++ b/devicetypes/erocm123/inovelli-2-channel-smart-plug-mcd.src/inovelli-2-channel-smart-plug-mcd.groovy
@@ -1,6 +1,6 @@
 /**
  *
- *  Inovelli Smart Plug 2-Channel
+ *  Inovelli 2-Channel Smart Plug MCD
  *
  *  Copyright 2020 SmartThings
  *
@@ -22,7 +22,7 @@
  *
  */
 metadata {
-	definition(name: "Inovelli Smart Plug 2-Channel", namespace: "erocm123", author: "Eric Maycock", ocfDeviceType: "oic.d.smartplug", mcdSync: true) {
+	definition(name: "Inovelli 2-Channel Smart Plug MCD", namespace: "erocm123", author: "Eric Maycock", ocfDeviceType: "oic.d.smartplug", mcdSync: true) {
 		capability "Actuator"
 		capability "Sensor"
 		capability "Switch"

--- a/devicetypes/erocm123/inovelli-2-channel-smart-plug-mcd.src/inovelli-2-channel-smart-plug-mcd.groovy
+++ b/devicetypes/erocm123/inovelli-2-channel-smart-plug-mcd.src/inovelli-2-channel-smart-plug-mcd.groovy
@@ -71,12 +71,12 @@ def parse(String description) {
 	return result
 }
 def zwaveEvent(physicalgraph.zwave.commands.basicv1.BasicReport cmd, ep = null) {
-	logging("BasicReport ${cmd} - ep ${ep}", 2)
+	logging("BasicReport ${cmd} - outlet ${ep}", 2)
 	if (ep) {
 		def event
 		childDevices.each {
 			childDevice ->
-				if (childDevice.deviceNetworkId == "$device.deviceNetworkId-ep$ep") {
+				if (childDevice.deviceNetworkId == "$device.deviceNetworkId:outlet$ep") {
 					childDevice.sendEvent(name: "switch", value: cmd.value ? "on" : "off")
 				}
 		}
@@ -106,11 +106,11 @@ def zwaveEvent(physicalgraph.zwave.commands.basicv1.BasicSet cmd) {
 	return [result, response(commands(cmds))] // returns the result of reponse()
 }
 def zwaveEvent(physicalgraph.zwave.commands.switchbinaryv1.SwitchBinaryReport cmd, ep = null) {
-	logging("SwitchBinaryReport ${cmd} - ep ${ep}", 2)
+	logging("SwitchBinaryReport ${cmd} - outlet ${ep}", 2)
 	if (ep) {
 		def event
 		def childDevice = childDevices.find {
-			it.deviceNetworkId == "$device.deviceNetworkId-ep$ep"
+			it.deviceNetworkId == "$device.deviceNetworkId:outlet$ep"
 		}
 		if (childDevice) childDevice.sendEvent(name: "switch", value: cmd.value ? "on" : "off")
 		if (cmd.value) {
@@ -260,19 +260,19 @@ private commands(commands, delay = 1000) {
 	}, delay)
 }
 private channelNumber(String dni) {
-	dni.split("-ep")[-1] as Integer
+	dni.split(":outlet")[-1] as Integer
 }
 private void createChildDevices() {
 	state.oldLabel = device.label
 	for (i in 1..2) {
 		addChildDevice("Switch Child Device",
-				"${device.deviceNetworkId}-ep${i}",
+				"${device.deviceNetworkId}:outlet${i}",
 				device.hubId,
 				[completedSetup: true,
 				 label: "${device.displayName} (CH${i})",
 				 isComponent: true,
-				 componentName: "ep$i",
-				 componentLabel: "Channel $i"
+				 componentName: "outlet$i",
+				 componentLabel: "Outlet $i"
 		])
 	}
 }

--- a/devicetypes/erocm123/inovelli-2-channel-smart-plug-mcd.src/inovelli-2-channel-smart-plug-mcd.groovy
+++ b/devicetypes/erocm123/inovelli-2-channel-smart-plug-mcd.src/inovelli-2-channel-smart-plug-mcd.groovy
@@ -76,10 +76,8 @@ def parse(String description) {
 
 def handleSwitchEndpointEvent(cmd, ep) {
 	def event
+	def childDevice = childDevices.find { it.deviceNetworkId == "$device.deviceNetworkId:$ep" }
 
-	def childDevice = childDevices.find {
-			it.deviceNetworkId == "$device.deviceNetworkId:$ep"
-		}
 	childDevice?.sendEvent(name: "switch", value: cmd.value ? "on" : "off")
 
 	if (cmd.value) {
@@ -88,9 +86,9 @@ def handleSwitchEndpointEvent(cmd, ep) {
 		def allOff = true
 
 		childDevices.each { n ->
-				if (n.currentState("switch")?.value != "off")
-					allOff = false
-			}
+			if (n.currentState("switch")?.value != "off")
+				allOff = false
+		}
 
 		if (allOff) {
 			event = [createEvent([name: "switch", value: "off"])]

--- a/devicetypes/erocm123/inovelli-2-channel-smart-plug-mcd.src/inovelli-2-channel-smart-plug-mcd.groovy
+++ b/devicetypes/erocm123/inovelli-2-channel-smart-plug-mcd.src/inovelli-2-channel-smart-plug-mcd.groovy
@@ -259,7 +259,7 @@ def getCheckInterval() {
 def installed() {
 	log.debug "installed()"
 
-	sendEvent(name: "checkInterval", value: checkInterval, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
+	sendEvent(name: "checkInterval", value: checkInterval, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 
 	createChildDevices()
 	response(refresh())
@@ -279,8 +279,6 @@ def updated() {
 		}
 		state.oldLabel = device.label
 	}
-
-	sendEvent(name: "checkInterval", value: checkInterval, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.configurationv2.ConfigurationReport cmd) {

--- a/devicetypes/erocm123/inovelli-2-channel-smart-plug-mcd.src/inovelli-2-channel-smart-plug-mcd.groovy
+++ b/devicetypes/erocm123/inovelli-2-channel-smart-plug-mcd.src/inovelli-2-channel-smart-plug-mcd.groovy
@@ -327,6 +327,6 @@ private void createChildDevices() {
 				 componentLabel: "Outlet $i"
 		])
 
-		newDevice.sendEvent(name: "checkInterval", value: checkInterval, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
+		newDevice.sendEvent(name: "checkInterval", value: checkInterval, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 	}
 }

--- a/devicetypes/erocm123/inovelli-2-channel-smart-plug-mcd.src/inovelli-2-channel-smart-plug-mcd.groovy
+++ b/devicetypes/erocm123/inovelli-2-channel-smart-plug-mcd.src/inovelli-2-channel-smart-plug-mcd.groovy
@@ -272,10 +272,7 @@ def updated() {
 		createChildDevices()
 	} else if (device.label != state.oldLabel) {
 		childDevices.each {
-			if (it.label == "${state.oldLabel} (CH${channelNumber(it.deviceNetworkId)})") {
-				def newLabel = "${device.displayName} (CH${channelNumber(it.deviceNetworkId)})"
-				it.setLabel(newLabel)
-			}
+			it.setLabel("${device.displayName} Outlet ${channelNumber(it.deviceNetworkId)}")
 		}
 		state.oldLabel = device.label
 	}
@@ -319,7 +316,7 @@ private void createChildDevices() {
 				"${device.deviceNetworkId}:${i}",
 				device.hubId,
 				[completedSetup: true,
-				 label: "${device.displayName} (CH${i})",
+				 label: "${device.displayName} Outlet ${i}",
 				 isComponent: true,
 				 componentName: "outlet$i",
 				 componentLabel: "Outlet $i"

--- a/devicetypes/erocm123/inovelli-2-channel-smart-plug.src/inovelli-2-channel-smart-plug.groovy
+++ b/devicetypes/erocm123/inovelli-2-channel-smart-plug.src/inovelli-2-channel-smart-plug.groovy
@@ -27,7 +27,7 @@ metadata {
 		capability "Refresh"
 		capability "Health Check"
 
-		// Fingerprints moved to "Inovelli Smart Plug 2-Channel" for modern MCD experience.
+		// Fingerprints moved to "Inovelli 2-Channel Smart Plug MCD" for modern MCD experience.
 	}
 	simulator {}
 	preferences {}

--- a/devicetypes/erocm123/inovelli-smart-plug-2-channel.src/inovelli-smart-plug-2-channel.groovy
+++ b/devicetypes/erocm123/inovelli-smart-plug-2-channel.src/inovelli-smart-plug-2-channel.groovy
@@ -1,7 +1,10 @@
 /**
  *
- *  Inovelli 2-Channel Smart Plug
+ *  Inovelli Smart Plug 2-Channel
  *
+ *  Copyright 2020 SmartThings
+ *
+ *  Original integration:
  *  github: Eric Maycock (erocm123)
  *  Date: 2017-04-27
  *  Copyright Eric Maycock
@@ -19,7 +22,7 @@
  *
  */
 metadata {
-	definition(name: "Inovelli 2-Channel Smart Plug", namespace: "erocm123", author: "Eric Maycock", ocfDeviceType: "oic.d.smartplug", mnmn: "SmartThings", vid: "generic-switch") {
+	definition(name: "Inovelli Smart Plug 2-Channel", namespace: "erocm123", author: "Eric Maycock", ocfDeviceType: "oic.d.smartplug", mcdSync: true) {
 		capability "Actuator"
 		capability "Sensor"
 		capability "Switch"
@@ -27,7 +30,14 @@ metadata {
 		capability "Refresh"
 		capability "Health Check"
 
-		// Fingerprints moved to "Inovelli Smart Plug 2-Channel" for modern MCD experience.
+		fingerprint manufacturer: "015D", prod: "0221", model: "251C", deviceJoinName: "Show Home Outlet" //Show Home 2-Channel Smart Plug
+		fingerprint manufacturer: "0312", prod: "0221", model: "251C", deviceJoinName: "Inovelli Outlet" //Inovelli 2-Channel Smart Plug
+		fingerprint manufacturer: "0312", prod: "B221", model: "251C", deviceJoinName: "Inovelli Outlet" //Inovelli 2-Channel Smart Plug
+		fingerprint manufacturer: "0312", prod: "0221", model: "611C", deviceJoinName: "Inovelli Outlet" //Inovelli 2-Channel Outdoor Smart Plug
+		fingerprint manufacturer: "015D", prod: "0221", model: "611C", deviceJoinName: "Inovelli Outlet" //Inovelli 2-Channel Outdoor Smart Plug
+		fingerprint manufacturer: "015D", prod: "6100", model: "6100", deviceJoinName: "Inovelli Outlet" //Inovelli 2-Channel Outdoor Smart Plug
+		fingerprint manufacturer: "0312", prod: "6100", model: "6100", deviceJoinName: "Inovelli Outlet" //Inovelli 2-Channel Outdoor Smart Plug
+		fingerprint manufacturer: "015D", prod: "2500", model: "2500", deviceJoinName: "Inovelli Outlet" //Inovelli 2-Channel Smart Plug w/Scene
 	}
 	simulator {}
 	preferences {}


### PR DESCRIPTION
This removes the fingerprints from the old integration and moves them to a new DTH that has `mcdSync: true` added and UI metadata proper for a modern MCD experience.