### PR TITLE
ICP-12952 - removed the cause of duplicated events in the parent dth

### DIFF
--- a/devicetypes/smartthings/ikea-button.src/ikea-button.groovy
+++ b/devicetypes/smartthings/ikea-button.src/ikea-button.groovy
@@ -296,6 +296,10 @@ private Map getButtonEvent(Map descMap) {
 	}
 
 	if (buttonNumber != 0) {
+		// Create old style
+		def descriptionText = "${getButtonName(buttonNumber)} was $buttonState"
+		result = [name: "button", value: buttonState, data: [buttonNumber: buttonNumber], descriptionText: descriptionText, isStateChange: true, displayed: false]
+
 		// Create and send component event
 		sendButtonEvent(buttonNumber, buttonState)
 	}

--- a/devicetypes/smartthings/ikea-button.src/ikea-button.groovy
+++ b/devicetypes/smartthings/ikea-button.src/ikea-button.groovy
@@ -296,10 +296,6 @@ private Map getButtonEvent(Map descMap) {
 	}
 
 	if (buttonNumber != 0) {
-		// Create old style
-		def descriptionText = "${getButtonName(buttonNumber)} was $buttonState"
-		result = [name: "button", value: buttonState, data: [buttonNumber: buttonNumber], descriptionText: descriptionText, isStateChange: true]
-
 		// Create and send component event
 		sendButtonEvent(buttonNumber, buttonState)
 	}


### PR DESCRIPTION
ICP-12952 - removed the cause of duplicated events in the parent dth.

Right before sending a button event to a child device -> a redundant event in the parent Dth was created. That was a cause of duplicated events in the activity history.

@greens @dkirker 
Please, could You take a look at the code ?

@MWierzbinskaS @ZWozniakS @PKacprowiczS @BJanuszS @MGoralczykS 