### PR TITLE
ICP-12957 ICP-12958 Fibaro walli dimmer: Added mnmn and VID to definition

### DIFF
--- a/devicetypes/fibargroup/fibaro-walli-dimmer-switch.src/fibaro-walli-dimmer-switch.groovy
+++ b/devicetypes/fibargroup/fibaro-walli-dimmer-switch.src/fibaro-walli-dimmer-switch.groovy
@@ -14,7 +14,7 @@
  *
  */
 metadata {
-	definition (name: "Fibaro Walli Dimmer Switch", namespace: "fibargroup", author: "SmartThings", ocfDeviceType: "oic.d.switch", runLocally: false, executeCommandsLocally: false) {
+	definition (name: "Fibaro Walli Dimmer Switch", namespace: "fibargroup", author: "SmartThings", mnmn: "SmartThings", vid: "generic-dimmer-power-energy", ocfDeviceType: "oic.d.switch", runLocally: false, executeCommandsLocally: false) {
 
 		capability "Actuator"
 		capability "Configuration"


### PR DESCRIPTION
Added mnmn and VID to a DTH definition.
That should fix the issues reported in ICP-12957 and ICP-12958.
@greens @dkirker Please, could You take a look at the code ?

@MWierzbinskaS @ZWozniakS @PKacprowiczS @BJanuszS @MGoralczykS 