### PR TITLE
CHAD-4340 Update Window Shade devices to use Window Shade Level

### DIFF
--- a/devicetypes/qubino/qubino-flush-shutter.src/qubino-flush-shutter.groovy
+++ b/devicetypes/qubino/qubino-flush-shutter.src/qubino-flush-shutter.groovy
@@ -12,6 +12,7 @@
  *	for the specific language governing permissions and limitations under the License.
  *
  */
+import groovy.json.JsonOutput
 
 metadata {
 	definition (name: "Qubino Flush Shutter", namespace: "qubino", author: "SmartThings", ocfDeviceType: "oic.d.blind", mcdSync: true) {
@@ -92,7 +93,7 @@ def installed() {
 		state.currentPreferencesState."$it.key".status = "synced"
 	}
 	// Preferences template end
-	sendEvent(name: "supportedWindowShadeCommands", value: ["open", "close", "pause"])
+	sendEvent(name: "supportedWindowShadeCommands", value: JsonOutput.toJson(["open", "close", "pause"]))
 }
 
 def updated() {
@@ -251,7 +252,7 @@ def setShadeLevel(level) {
 }
 
 def setSlats(level) {
-	def time = (int) (state.timeOfVenetianMovement  * 1.1)
+	def time = (int) (state.timeOfVenetianMovement * 1.1)
 	sendHubCommand([
 			encap(zwave.switchMultilevelV3.switchMultilevelSet(value: Math.min(0x63, level)), 2),
 			"delay ${time}",

--- a/devicetypes/smartthings/springs-window-fashions-shade.src/springs-window-fashions-shade.groovy
+++ b/devicetypes/smartthings/springs-window-fashions-shade.src/springs-window-fashions-shade.groovy
@@ -15,275 +15,285 @@ import groovy.json.JsonOutput
 
 
 metadata {
-    definition (name: "Springs Window Fashions Shade", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.blind") {
-        capability "Window Shade"
-        capability "Window Shade Preset"
-        capability "Battery"
-        capability "Refresh"
-        capability "Health Check"
-        capability "Actuator"
-        capability "Sensor"
+	definition (name: "Springs Window Fashions Shade", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.blind") {
+		capability "Window Shade"
+		capability "Window Shade Level"
+		capability "Window Shade Preset"
+		capability "Switch Level"
+		capability "Battery"
+		capability "Refresh"
+		capability "Health Check"
+		capability "Actuator"
+		capability "Sensor"
 
-        command "stop"
+		command "stop"
 
-        capability "Switch Level"   // until we get a Window Shade Level capability
+		// This device handler is specifically for SWF window coverings
+		//
+		//fingerprint type: "0x1107", cc: "0x5E,0x26", deviceJoinName: "Window Shade"
+		//fingerprint type: "0x9A00", cc: "0x5E,0x26", deviceJoinName: "Window Shade"
+		fingerprint mfr:"026E", prod:"4353", model:"5A31", deviceJoinName: "Springs Window Treatment" //Window Shade
+		fingerprint mfr:"026E", prod:"5253", model:"5A31", deviceJoinName: "Springs Window Treatment" //Roller Shade
+	}
 
-        // This device handler is specifically for SWF window coverings
-        //
-//        fingerprint type: "0x1107", cc: "0x5E,0x26", deviceJoinName: "Window Shade"
-//        fingerprint type: "0x9A00", cc: "0x5E,0x26", deviceJoinName: "Window Shade"
-        fingerprint mfr:"026E", prod:"4353", model:"5A31", deviceJoinName: "Springs Window Treatment" //Window Shade
-        fingerprint mfr:"026E", prod:"5253", model:"5A31", deviceJoinName: "Springs Window Treatment" //Roller Shade
-    }
+	simulator {
+		status "open":  "command: 2603, payload: FF"
+		status "closed": "command: 2603, payload: 00"
+		status "10%": "command: 2603, payload: 0A"
+		status "66%": "command: 2603, payload: 42"
+		status "99%": "command: 2603, payload: 63"
+		status "battery 100%": "command: 8003, payload: 64"
+		status "battery low": "command: 8003, payload: FF"
 
-    simulator {
-        status "open":  "command: 2603, payload: FF"
-        status "closed": "command: 2603, payload: 00"
-        status "10%": "command: 2603, payload: 0A"
-        status "66%": "command: 2603, payload: 42"
-        status "99%": "command: 2603, payload: 63"
-        status "battery 100%": "command: 8003, payload: 64"
-        status "battery low": "command: 8003, payload: FF"
+		// reply messages
+		reply "2001FF,delay 1000,2602": "command: 2603, payload: 10 FF FE"
+		reply "200100,delay 1000,2602": "command: 2603, payload: 60 00 FE"
+		reply "200142,delay 1000,2602": "command: 2603, payload: 10 42 FE"
+		reply "200163,delay 1000,2602": "command: 2603, payload: 10 63 FE"
+	}
 
-        // reply messages
-        reply "2001FF,delay 1000,2602": "command: 2603, payload: 10 FF FE"
-        reply "200100,delay 1000,2602": "command: 2603, payload: 60 00 FE"
-        reply "200142,delay 1000,2602": "command: 2603, payload: 10 42 FE"
-        reply "200163,delay 1000,2602": "command: 2603, payload: 10 63 FE"
-    }
+	tiles(scale: 2) {
+		multiAttributeTile(name:"windowShade", type: "generic", width: 6, height: 4){
+			tileAttribute ("device.windowShade", key: "PRIMARY_CONTROL") {
+				attributeState "open", label:'${name}', action:"close", icon:"st.shades.shade-open", backgroundColor:"#00A0DC", nextState:"closing"
+				attributeState "closed", label:'${name}', action:"open", icon:"st.shades.shade-closed", backgroundColor:"#ffffff", nextState:"opening"
+				attributeState "partially open", label:'Open', action:"close", icon:"st.shades.shade-open", backgroundColor:"#00A0DC", nextState:"closing"
+				attributeState "opening", label:'${name}', action:"stop", icon:"st.shades.shade-opening", backgroundColor:"#00A0DC", nextState:"partially open"
+				attributeState "closing", label:'${name}', action:"stop", icon:"st.shades.shade-closing", backgroundColor:"#ffffff", nextState:"partially open"
+			}
+			tileAttribute ("device.windowShadeLevel", key: "SLIDER_CONTROL") {
+				attributeState "shadeLevel", action:"setShadeLevel"
+			}
+		}
 
-    tiles(scale: 2) {
-        multiAttributeTile(name:"windowShade", type: "generic", width: 6, height: 4){
-            tileAttribute ("device.windowShade", key: "PRIMARY_CONTROL") {
-                attributeState "open", label:'${name}', action:"close", icon:"st.shades.shade-open", backgroundColor:"#79b821", nextState:"closing"
-                attributeState "closed", label:'${name}', action:"open", icon:"st.shades.shade-closed", backgroundColor:"#ffffff", nextState:"opening"
-                attributeState "partially open", label:'Open', action:"close", icon:"st.shades.shade-open", backgroundColor:"#79b821", nextState:"closing"
-                attributeState "opening", label:'${name}', action:"stop", icon:"st.shades.shade-opening", backgroundColor:"#79b821", nextState:"partially open"
-                attributeState "closing", label:'${name}', action:"stop", icon:"st.shades.shade-closing", backgroundColor:"#ffffff", nextState:"partially open"
-            }
-            tileAttribute ("device.level", key: "SLIDER_CONTROL") {
-                attributeState "level", action:"setLevel"
-            }
-        }
+		standardTile("home", "device.level", width: 2, height: 2, decoration: "flat") {
+			state "default", label: "home", action:"presetPosition", icon:"st.Home.home2"
+		}
 
-        standardTile("home", "device.level", width: 2, height: 2, decoration: "flat") {
-            state "default", label: "home", action:"presetPosition", icon:"st.Home.home2"
-        }
+		standardTile("refresh", "device.refresh", width: 2, height: 2, inactiveLabel: false, decoration: "flat") {
+			state "default", label:'', action:"refresh.refresh", icon:"st.secondary.refresh", nextState: "disabled"
+			state "disabled", label:'', action:"", icon:"st.secondary.refresh"
+		}
 
-        standardTile("refresh", "device.refresh", width: 2, height: 2, inactiveLabel: false, decoration: "flat") {
-            state "default", label:'', action:"refresh.refresh", icon:"st.secondary.refresh", nextState: "disabled"
-            state "disabled", label:'', action:"", icon:"st.secondary.refresh"
-        }
+		valueTile("battery", "device.battery", decoration: "flat", inactiveLabel: false, width: 2, height: 2) {
+			state "battery", label:'batt.', unit:"",
+					backgroundColors:[
+							[value: 0, color: "#bc2323"],
+							[value: 6, color: "#44b621"]
+					]
+		}
 
-        valueTile("battery", "device.battery", decoration: "flat", inactiveLabel: false, width: 2, height: 2) {
-            state "battery", label:'batt.', unit:"",
-                    backgroundColors:[
-                            [value: 0, color: "#bc2323"],
-                            [value: 6, color: "#44b621"]
-                    ]
-        }
+		preferences {
+			input "switchDirection", "bool", title: "Flip the orientation of the shade", defaultValue: false, required: false, displayDuringSetup: false
+			//input "preset", "number", title: "Default half-open position (1-100). Springs Window Fashions users should consult their manuals.", defaultValue: 50, required: false, displayDuringSetup: false
+		}
 
-        preferences {
-            input "switchDirection", "bool", title: "Flip the orientation of the shade", defaultValue: false, required: false, displayDuringSetup: false
-//            input "preset", "number", title: "Default half-open position (1-100). Springs Window Fashions users should consult their manuals.", defaultValue: 50, required: false, displayDuringSetup: false
-        }
+		main(["windowShade"])
+		details(["windowShade", "home", "refresh", "battery"])
 
-        main(["windowShade"])
-        details(["windowShade", "home", "refresh", "battery"])
-
-    }
+	}
 }
 
 def parse(String description) {
-    def result = null
-    //if (description =~ /command: 2603, payload: ([0-9A-Fa-f]{6})/)
-    // TODO: Workaround manual parsing of v4 multilevel report
-    def cmd = zwave.parse(description, [0x20: 1, 0x26: 3])  // TODO: switch to SwitchMultilevel v4 and use target value
-    if (cmd) {
-        result = zwaveEvent(cmd)
-    }
-    log.debug "Parsed '$description' to ${result.inspect()}"
-    return result
+	def result = null
+
+	if (device.currentValue("shadeLevel") == null && device.currentValue("level") != null) {
+		sendEvent(name: "shadeLevel", value: device.currentValue("level"), unit: "%")
+	}
+
+	//if (description =~ /command: 2603, payload: ([0-9A-Fa-f]{6})/)
+	// TODO: Workaround manual parsing of v4 multilevel report
+	def cmd = zwave.parse(description, [0x20: 1, 0x26: 3])  // TODO: switch to SwitchMultilevel v4 and use target value
+	if (cmd) {
+		result = zwaveEvent(cmd)
+	}
+	log.debug "Parsed '$description' to ${result.inspect()}"
+	return result
 }
 
 def getCheckInterval() {
-    // These are battery-powered devices, and it's not very critical
-    // to know whether they're online or not – 12 hrs
-    4 * 60 * 60
+	// These are battery-powered devices, and it's not very critical
+	// to know whether they're online or not – 12 hrs
+	4 * 60 * 60
 }
 
 def installed() {
-    sendEvent(name: "checkInterval", value: checkInterval, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
-    sendEvent(name: "supportedWindowShadeCommands", value: JsonOutput.toJson(["open", "close", "pause"]), displayed: false)
-    response(refresh())
+	sendEvent(name: "checkInterval", value: checkInterval, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
+	sendEvent(name: "supportedWindowShadeCommands", value: JsonOutput.toJson(["open", "close", "pause"]), displayed: false)
+	response(refresh())
 }
 
 def updated() {
-    if (device.latestValue("checkInterval") != checkInterval) {
-        sendEvent(name: "checkInterval", value: checkInterval, displayed: false)
-    }
-    def cmds = []
-    if (!device.latestState("battery")) {
-        cmds << zwave.batteryV1.batteryGet().format()
-    }
+	if (device.latestValue("checkInterval") != checkInterval) {
+		sendEvent(name: "checkInterval", value: checkInterval, displayed: false)
+	}
+	def cmds = []
+	if (!device.latestState("battery")) {
+		cmds << zwave.batteryV1.batteryGet().format()
+	}
 
-    if (!device.getDataValue("MSR")) {
-        cmds << zwave.manufacturerSpecificV1.manufacturerSpecificGet().format()
-    }
+	if (!device.getDataValue("MSR")) {
+		cmds << zwave.manufacturerSpecificV1.manufacturerSpecificGet().format()
+	}
 
-    log.debug("Updated with settings $settings")
-    cmds << zwave.switchMultilevelV1.switchMultilevelGet().format()
-    response(cmds)
+	log.debug("Updated with settings $settings")
+	cmds << zwave.switchMultilevelV1.switchMultilevelGet().format()
+	response(cmds)
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.basicv1.BasicReport cmd) {
-    handleLevelReport(cmd)
+	handleLevelReport(cmd)
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.basicv1.BasicSet cmd) {
-    handleLevelReport(cmd)
+	handleLevelReport(cmd)
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.switchmultilevelv3.SwitchMultilevelReport cmd) {
-    handleLevelReport(cmd)
+	handleLevelReport(cmd)
 }
 
 private handleLevelReport(physicalgraph.zwave.Command cmd) {
-    def descriptionText = null
-    def shadeValue = null
+	def descriptionText = null
+	def shadeValue = null
 
-    def level = cmd.value as Integer
-    level = switchDirection ? 99-level : level
-    if (level >= 99) {
-        level = 100
-        shadeValue = "open"
-    } else if (level <= 0) {
-        level = 0  // unlike dimmer switches, the level isn't saved when closed
-        shadeValue = "closed"
-    } else {
-        shadeValue = "partially open"
-        descriptionText = "${device.displayName} shade is ${level}% open"
-    }
-    checkLevelReport(level)
-    def levelEvent = createEvent(name: "level", value: level, unit: "%", displayed: false)
-    def stateEvent = createEvent(name: "windowShade", value: shadeValue, descriptionText: descriptionText, isStateChange: levelEvent.isStateChange)
+	def level = cmd.value as Integer
+	level = switchDirection ? 99-level : level
+	if (level >= 99) {
+		level = 100
+		shadeValue = "open"
+	} else if (level <= 0) {
+		level = 0  // unlike dimmer switches, the level isn't saved when closed
+		shadeValue = "closed"
+	} else {
+		shadeValue = "partially open"
+		descriptionText = "${device.displayName} shade is ${level}% open"
+	}
+	checkLevelReport(level)
 
-    def result = [stateEvent, levelEvent]
-    if (!state.lastbatt || now() - state.lastbatt > 24 * 60 * 60 * 1000) {
-        log.debug "requesting battery"
-        state.lastbatt = (now() - 23 * 60 * 60 * 1000) // don't queue up multiple battery reqs in a row
-        result << response(["delay 15000", zwave.batteryV1.batteryGet().format()])
-    }
-    result
+	def levelEvent = createEvent(name: "level", value: level, unit: "%", displayed: false)
+	def shadeLevelEvent = createEvent(name: "shadeLevel", value: level, unit: "%")
+	def stateEvent = createEvent(name: "windowShade", value: shadeValue, descriptionText: descriptionText, isStateChange: shadeLevelEvent.isStateChange)
+
+	def result = [stateEvent, shadeLevelEvent, levelEvent]
+	if (!state.lastbatt || now() - state.lastbatt > 24 * 60 * 60 * 1000) {
+		log.debug "requesting battery"
+		state.lastbatt = (now() - 23 * 60 * 60 * 1000) // don't queue up multiple battery reqs in a row
+		result << response(["delay 15000", zwave.batteryV1.batteryGet().format()])
+	}
+	result
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.switchmultilevelv3.SwitchMultilevelStopLevelChange cmd) {
-    [ createEvent(name: "windowShade", value: "partially open", displayed: false, descriptionText: "$device.displayName shade stopped"),
-      response(zwave.switchMultilevelV1.switchMultilevelGet().format()) ]
+	[ createEvent(name: "windowShade", value: "partially open", displayed: false, descriptionText: "$device.displayName shade stopped"),
+	  response(zwave.switchMultilevelV1.switchMultilevelGet().format()) ]
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.batteryv1.BatteryReport cmd) {
-    def map = [ name: "battery", unit: "%" ]
-    if (cmd.batteryLevel == 0xFF || cmd.batteryLevel == 0) {
-        map.value = 1
-        map.descriptionText = "${device.displayName} has a low battery"
-        map.isStateChange = true
-    } else {
-        map.value = cmd.batteryLevel
-    }
-    state.lastbatt = now()
-    if (map.value <= 1 && device.latestValue("battery") != null && device.latestValue("battery") - map.value > 20) {
-        // Springs shades sometimes erroneously report a low battery when rapidly actuated manually. They'll still
-        // refuse to actuate after one of these reports, but this will limit the bad data that gets surfaced
-        log.warn "Erroneous battery report dropped from ${device.latestValue("battery")} to $map.value. Not reporting"
-    } else {
-        createEvent(map)
-    }
+	def map = [ name: "battery", unit: "%" ]
+	if (cmd.batteryLevel == 0xFF || cmd.batteryLevel == 0) {
+		map.value = 1
+		map.descriptionText = "${device.displayName} has a low battery"
+		map.isStateChange = true
+	} else {
+		map.value = cmd.batteryLevel
+	}
+	state.lastbatt = now()
+	if (map.value <= 1 && device.latestValue("battery") != null && device.latestValue("battery") - map.value > 20) {
+		// Springs shades sometimes erroneously report a low battery when rapidly actuated manually. They'll still
+		// refuse to actuate after one of these reports, but this will limit the bad data that gets surfaced
+		log.warn "Erroneous battery report dropped from ${device.latestValue("battery")} to $map.value. Not reporting"
+	} else {
+		createEvent(map)
+	}
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.notificationv3.NotificationReport cmd) {
-    // the docs we got said that the device would send a notification report, but we've determined that
-    // is not true
+	// the docs we got said that the device would send a notification report, but we've determined that
+	// is not true
 }
 
 def zwaveEvent(physicalgraph.zwave.Command cmd) {
-    log.debug "unhandled $cmd"
-    return []
+	log.debug "unhandled $cmd"
+	return []
 }
 
 def open() {
-    log.debug "open()"
-    def level = switchDirection ? 0 : 99
-    levelChangeFollowUp(level)
-    zwave.basicV1.basicSet(value: level).format()
-    // zwave.basicV1.basicSet(value: 0xFF).format()
+	log.debug "open()"
+
+	setShadeLevel(99) // Handle switchDirection in setShadeLevel
 }
 
 def close() {
-    log.debug "close()"
-    def level = switchDirection ? 99 : 0
-    levelChangeFollowUp(level)
-    zwave.basicV1.basicSet(value: level).format()
-    //zwave.basicV1.basicSet(value: 0).format()
+	log.debug "close()"
+
+	setShadeLevel(0) // Handle switchDirection in setShadeLevel
 }
 
 def setLevel(value, duration = null) {
-    log.debug "setLevel(${value.inspect()})"
-    Integer level = value as Integer
-    level = switchDirection ? 99-level : level
-    if (level < 0) level = 0
-    if (level > 99) level = 99
-    levelChangeFollowUp(level)
-    zwave.basicV1.basicSet(value: level).format()
+	log.debug "setLevel($value)"
+
+	setShadeLevel(value)
+}
+
+def setShadeLevel(value) {
+	Integer level = Math.max(Math.min(value as Integer, 99), 0)
+
+	level = switchDirection ? 99-level : level
+
+	log.debug "setShadeLevel($value) -> $level"
+
+	levelChangeFollowUp(level) // Follow up in a few seconds to make sure the shades didn't "forget" to send us level updates
+	zwave.basicV1.basicSet(value: level).format()
 }
 
 def presetPosition() {
-    zwave.switchMultilevelV1.switchMultilevelSet(value: 0xFF).format()
+	zwave.switchMultilevelV1.switchMultilevelSet(value: 0xFF).format()
 }
 
 def pause() {
-    log.debug "pause()"
-    stop()
+	log.debug "pause()"
+	stop()
 }
 
 def stop() {
-    log.debug "stop()"
-    zwave.switchMultilevelV3.switchMultilevelStopLevelChange().format()
+	log.debug "stop()"
+	zwave.switchMultilevelV3.switchMultilevelStopLevelChange().format()
 }
 
 def ping() {
-    zwave.switchMultilevelV1.switchMultilevelGet().format()
+	zwave.switchMultilevelV1.switchMultilevelGet().format()
 }
 
 def refresh() {
-    log.debug "refresh()"
-    delayBetween([
-            zwave.switchMultilevelV1.switchMultilevelGet().format(),
-            zwave.batteryV1.batteryGet().format()
-    ], 1500)
+	log.debug "refresh()"
+	delayBetween([
+			zwave.switchMultilevelV1.switchMultilevelGet().format(),
+			zwave.batteryV1.batteryGet().format()
+	], 1500)
 }
 
 def levelChangeFollowUp(expectedLevel) {
-    state.expectedValue = expectedLevel
-    state.levelChecks = 0
-    runIn(5, "checkLevel", [overwrite: true])
+	state.expectedValue = expectedLevel
+	state.levelChecks = 0
+	runIn(5, "checkLevel", [overwrite: true])
 }
 
 def checkLevelReport(value) {
-    if (state.expectedValue != null) {
-        if ((state.expectedValue == 99 && value >= 99) ||
-                (value >= state.expectedValue - 2 && value <= state.expectedValue + 2)) {
-            unschedule("checkLevel")
-        }
-    }
+	if (state.expectedValue != null) {
+		if ((state.expectedValue == 99 && value >= 99) ||
+			(value >= state.expectedValue - 2 && value <= state.expectedValue + 2)) {
+			unschedule("checkLevel")
+		}
+	}
 }
 
 def checkLevel() {
-    if (state.levelChecks != null && state.levelChecks < 5) {
-        state.levelChecks = state.levelChecks + 1
-        runIn(5, "checkLevel", [overwrite: true])
-        sendHubCommand(zwave.switchMultilevelV1.switchMultilevelGet())
-    } else {
-        unschedule("checkLevel")
-    }
+	if (state.levelChecks != null && state.levelChecks < 5) {
+		state.levelChecks = state.levelChecks + 1
+		runIn(5, "checkLevel", [overwrite: true])
+		sendHubCommand(zwave.switchMultilevelV1.switchMultilevelGet())
+	} else {
+		unschedule("checkLevel")
+	}
 }

--- a/devicetypes/smartthings/zigbee-window-shade-battery.src/zigbee-window-shade-battery.groovy
+++ b/devicetypes/smartthings/zigbee-window-shade-battery.src/zigbee-window-shade-battery.groovy
@@ -11,6 +11,7 @@
  *	on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  *	for the specific language governing permissions and limitations under the License.
  */
+
 import groovy.json.JsonOutput
 import physicalgraph.zigbee.zcl.DataType
 
@@ -21,6 +22,7 @@ metadata {
 		capability "Configuration"
 		capability "Refresh"
 		capability "Window Shade"
+		capability "Window Shade Level"
 		capability "Window Shade Preset"
 		capability "Health Check"
 		capability "Switch Level"
@@ -36,13 +38,16 @@ metadata {
 	}
 
 	tiles(scale: 2) {
-		multiAttributeTile(name:"windowShade", type: "generic", width: 6, height: 4) {
+		multiAttributeTile(name:"windowShade", type: "lighting", width: 6, height: 4) {
 			tileAttribute("device.windowShade", key: "PRIMARY_CONTROL") {
-				attributeState "open", label: 'Open', action: "close", icon: "http://www.ezex.co.kr/img/st/window_open.png", backgroundColor: "#00A0DC", nextState: "closing"
-				attributeState "closed", label: 'Closed', action: "open", icon: "http://www.ezex.co.kr/img/st/window_close.png", backgroundColor: "#ffffff", nextState: "opening"
-				attributeState "partially open", label: 'Partially open', action: "close", icon: "http://www.ezex.co.kr/img/st/window_open.png", backgroundColor: "#d45614", nextState: "closing"
-				attributeState "opening", label: 'Opening', action: "pause", icon: "http://www.ezex.co.kr/img/st/window_open.png", backgroundColor: "#00A0DC", nextState: "partially open"
-				attributeState "closing", label: 'Closing', action: "pause", icon: "http://www.ezex.co.kr/img/st/window_close.png", backgroundColor: "#ffffff", nextState: "partially open"
+				attributeState "open", label: 'Open', action: "close", icon: "st.shades.shade-open", backgroundColor: "#00A0DC", nextState: "closing"
+				attributeState "closed", label: 'Closed', action: "open", icon: "st.shades.shade-closed", backgroundColor: "#ffffff", nextState: "opening"
+				attributeState "partially open", label: 'Partially open', action: "close", icon: "st.shades.shade-open", backgroundColor: "#00A0DC", nextState: "closing"
+				attributeState "opening", label: 'Opening', action: "pause", icon: "st.shades.shade-opening", backgroundColor: "#00A0DC", nextState: "partially open"
+				attributeState "closing", label: 'Closing', action: "pause", icon: "st.shades.shade-closing", backgroundColor: "#ffffff", nextState: "partially open"
+			}
+			tileAttribute ("device.windowShadeLevel", key: "SLIDER_CONTROL") {
+				attributeState "shadeLevel", action:"setShadeLevel"
 			}
 		}
 		standardTile("contPause", "device.switch", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
@@ -54,18 +59,12 @@ metadata {
 		standardTile("refresh", "device.refresh", inactiveLabel: false, decoration: "flat", width: 2, height: 1) {
 			state "default", label:"", action:"refresh.refresh", icon:"st.secondary.refresh"
 		}
-		valueTile("shadeLevel", "device.level", width: 4, height: 1) {
-			state "level", label: 'Shade is ${currentValue}% up', defaultState: true
-		}
 		valueTile("batteryLevel", "device.battery", width: 2, height: 2) {
 			state "battery", label:'${currentValue}% battery', unit:""
 		}
-		controlTile("levelSliderControl", "device.level", "slider", width:2, height: 1, inactiveLabel: false) {
-			state "level", action:"switch level.setLevel"
-		}
 
 		main "windowShade"
-		details(["windowShade", "contPause", "presetPosition", "shadeLevel", "levelSliderControl", "refresh", "batteryLevel"])
+		details(["windowShade", "contPause", "presetPosition", "refresh", "batteryLevel"])
 	}
 }
 
@@ -87,27 +86,31 @@ private List<Map> collectAttributes(Map descMap) {
 	if (descMap.additionalAttrs) {
 		descMaps.addAll(descMap.additionalAttrs)
 	}
-	return descMaps
-}
 
-def installed() {
-	log.debug "installed"
-	sendEvent(name: "supportedWindowShadeCommands", value: JsonOutput.toJson(["open", "close", "pause"]))
+	return descMaps
 }
 
 // Parse incoming device messages to generate events
 def parse(String description) {
 	log.debug "description:- ${description}"
+
+	if (device.currentValue("shadeLevel") == null && device.currentValue("level") != null) {
+		sendEvent(name: "shadeLevel", value: device.currentValue("level"), unit: "%")
+	}
+
 	if (description?.startsWith("read attr -")) {
 		Map descMap = zigbee.parseDescriptionAsMap(description)
+
 		if (isBindingTableMessage(description)) {
 			parseBindingTableMessage(description)
 		} else if (supportsLiftPercentage() && descMap?.clusterInt == CLUSTER_WINDOW_COVERING && descMap.value) {
 			log.debug "attr: ${descMap?.attrInt}, value: ${descMap?.value}, descValue: ${Integer.parseInt(descMap.value, 16)}, ${device.getDataValue("model")}"
 			List<Map> descMaps = collectAttributes(descMap)
 			def liftmap = descMaps.find { it.attrInt == ATTRIBUTE_POSITION_LIFT }
+
 			if (liftmap && liftmap.value) {
 				def newLevel = zigbee.convertHexToInt(liftmap.value)
+
 				if (shouldInvertLiftPercentage()) {
 					// some devices report % level of being closed (instead of % level of being opened)
 					// inverting that logic is needed here to avoid a code duplication
@@ -121,18 +124,23 @@ def parse(String description) {
 			levelEventHandler(valueInt)
 		} else if (reportsBatteryPercentage() && descMap?.clusterInt == zigbee.POWER_CONFIGURATION_CLUSTER && zigbee.convertHexToInt(descMap?.attrId) == BATTERY_PERCENTAGE_REMAINING && descMap.value) {
 			def batteryLevel = zigbee.convertHexToInt(descMap.value)
+
 			batteryPercentageEventHandler(batteryLevel)
 		}
 	}
 }
 
 def levelEventHandler(currentLevel) {
-	def lastLevel = device.currentValue("level")
+	def lastLevel = device.currentValue("shadeLevel") ?: device.currentValue("level") // Try shadeLevel, if not use level and pass to logic below
+
 	log.debug "levelEventHandle - currentLevel: ${currentLevel} lastLevel: ${lastLevel}"
+
 	if (lastLevel == "undefined" || currentLevel == lastLevel) { //Ignore invalid reports
 		log.debug "Ignore invalid reports"
 	} else {
-		sendEvent(name: "level", value: currentLevel)
+		sendEvent(name: "shadeLevel", value: currentLevel, unit: "%")
+		sendEvent(name: "level", value: currentLevel, unit: "%", displayed: false)
+
 		if (currentLevel == 0 || currentLevel == 100) {
 			sendEvent(name: "windowShade", value: currentLevel == 0 ? "closed" : "open")
 		} else {
@@ -147,8 +155,9 @@ def levelEventHandler(currentLevel) {
 }
 
 def updateFinalState() {
-	def level = device.currentValue("level")
+	def level = device.currentValue("shadeLevel")
 	log.debug "updateFinalState: ${level}"
+
 	if (level > 0 && level < 100) {
 		sendEvent(name: "windowShade", value: "partially open")
 	}
@@ -163,28 +172,40 @@ def batteryPercentageEventHandler(batteryLevel) {
 
 def close() {
 	log.info "close()"
-	setLevel(0)
+
+	setShadeLevel(0)
 }
 
 def open() {
 	log.info "open()"
-	setLevel(100)
+
+	setShadeLevel(100)
 }
 
-def setLevel(data, rate = null) {
-	log.info "setLevel()"
+def setLevel(value, rate = null) {
+	log.info "setLevel($value)"
+
+	setShadeLevel(value)
+}
+
+def setShadeLevel(value) {
+	log.info "setShadeLevel($value)"
+
+	Integer level = Math.max(Math.min(value as Integer, 100), 0)
 	def cmd
+
 	if (supportsLiftPercentage()) {
 		if (shouldInvertLiftPercentage()) {
 			// some devices keeps % level of being closed (instead of % level of being opened)
 			// inverting that logic is needed here
-			data = 100 - data
+			level = 100 - level
 		}
-		cmd = zigbee.command(CLUSTER_WINDOW_COVERING, COMMAND_GOTO_LIFT_PERCENTAGE, zigbee.convertToHexString(data, 2))
+		cmd = zigbee.command(CLUSTER_WINDOW_COVERING, COMMAND_GOTO_LIFT_PERCENTAGE, zigbee.convertToHexString(level, 2))
 	} else {
-		cmd = zigbee.command(zigbee.LEVEL_CONTROL_CLUSTER, COMMAND_MOVE_LEVEL_ONOFF, zigbee.convertToHexString(Math.round(data * 255 / 100), 2))
+		cmd = zigbee.command(zigbee.LEVEL_CONTROL_CLUSTER, COMMAND_MOVE_LEVEL_ONOFF, zigbee.convertToHexString(Math.round(level * 255 / 100), 2))
 	}
-	cmd
+
+	return cmd
 }
 
 def pause() {
@@ -197,7 +218,7 @@ def pause() {
 }
 
 def presetPosition() {
-    setLevel(preset ?: 50)
+	setShadeLevel(preset ?: 50)
 }
 
 /**
@@ -210,21 +231,32 @@ def ping() {
 def refresh() {
 	log.info "refresh()"
 	def cmds
+
 	if (supportsLiftPercentage()) {
 		cmds = zigbee.readAttribute(CLUSTER_WINDOW_COVERING, ATTRIBUTE_POSITION_LIFT)
 	} else {
 		cmds = zigbee.readAttribute(zigbee.LEVEL_CONTROL_CLUSTER, ATTRIBUTE_CURRENT_LEVEL)
 	}
+
 	return cmds
 }
 
+def installed() {
+	log.debug "installed"
+
+	sendEvent(name: "supportedWindowShadeCommands", value: JsonOutput.toJson(["open", "close", "pause"]), displayed: false)
+}
+
 def configure() {
-	// Device-Watch allows 2 check-in misses from device + ping (plus 2 min lag time)
+	def cmds
+
 	log.info "configure()"
+
+	// Device-Watch allows 2 check-in misses from device + ping (plus 2 min lag time)
 	sendEvent(name: "checkInterval", value: 2 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+
 	log.debug "Configuring Reporting and Bindings."
 
-	def cmds
 	if (supportsLiftPercentage()) {
 		cmds = zigbee.configureReporting(CLUSTER_WINDOW_COVERING, ATTRIBUTE_POSITION_LIFT, DataType.UINT8, 2, 600, null)
 	} else {
@@ -248,6 +280,7 @@ def usesLocalGroupBinding() {
 
 private def parseBindingTableMessage(description) {
 	Integer groupAddr = getGroupAddrFromBindingTable(description)
+
 	if (groupAddr) {
 		List cmds = addHubToGroup(groupAddr)
 		cmds?.collect { new physicalgraph.device.HubAction(it) }
@@ -258,7 +291,9 @@ private Integer getGroupAddrFromBindingTable(description) {
 	log.info "Parsing binding table - '$description'"
 	def btr = zigbee.parseBindingTableResponse(description)
 	def groupEntry = btr?.table_entries?.find { it.dstAddrMode == 1 }
+
 	log.info "Found ${groupEntry}"
+
 	!groupEntry?.dstAddr ?: Integer.parseInt(groupEntry.dstAddr, 16)
 }
 

--- a/devicetypes/smartthings/zigbee-window-shade.src/zigbee-window-shade.groovy
+++ b/devicetypes/smartthings/zigbee-window-shade.src/zigbee-window-shade.groovy
@@ -22,6 +22,7 @@ metadata {
 		capability "Configuration"
 		capability "Refresh"
 		capability "Window Shade"
+		capability "Window Shade Level"
 		capability "Window Shade Preset"
 		capability "Health Check"
 		capability "Switch Level"
@@ -41,13 +42,16 @@ metadata {
 	}
 
 	tiles(scale: 2) {
-		multiAttributeTile(name:"windowShade", type: "generic", width: 6, height: 4) {
+		multiAttributeTile(name:"windowShade", type: "lighting", width: 6, height: 4) {
 			tileAttribute("device.windowShade", key: "PRIMARY_CONTROL") {
 				attributeState "open", label: 'Open', action: "close", icon: "http://www.ezex.co.kr/img/st/window_open.png", backgroundColor: "#00A0DC", nextState: "closing"
 				attributeState "closed", label: 'Closed', action: "open", icon: "http://www.ezex.co.kr/img/st/window_close.png", backgroundColor: "#ffffff", nextState: "opening"
 				attributeState "partially open", label: 'Partially open', action: "close", icon: "http://www.ezex.co.kr/img/st/window_open.png", backgroundColor: "#d45614", nextState: "closing"
 				attributeState "opening", label: 'Opening', action: "pause", icon: "http://www.ezex.co.kr/img/st/window_open.png", backgroundColor: "#00A0DC", nextState: "partially open"
 				attributeState "closing", label: 'Closing', action: "pause", icon: "http://www.ezex.co.kr/img/st/window_close.png", backgroundColor: "#ffffff", nextState: "partially open"
+			}
+			tileAttribute ("device.windowShadeLevel", key: "SLIDER_CONTROL") {
+				attributeState "shadeLevel", action:"setShadeLevel"
 			}
 		}
 		standardTile("contPause", "device.switch", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
@@ -59,15 +63,9 @@ metadata {
 		standardTile("refresh", "device.refresh", inactiveLabel: false, decoration: "flat", width: 2, height: 1) {
 			state "default", label:"", action:"refresh.refresh", icon:"st.secondary.refresh"
 		}
-		valueTile("shadeLevel", "device.level", width: 4, height: 1) {
-			state "level", label: 'Shade is ${currentValue}% up', defaultState: true
-		}
-		controlTile("levelSliderControl", "device.level", "slider", width:2, height: 1, inactiveLabel: false) {
-			state "level", action:"switch level.setLevel"
-		}
 
 		main "windowShade"
-		details(["windowShade", "contPause", "presetPosition", "shadeLevel", "levelSliderControl", "refresh"])
+		details(["windowShade", "contPause", "presetPosition", "refresh"])
 	}
 }
 
@@ -89,22 +87,31 @@ private List<Map> collectAttributes(Map descMap) {
 	if (descMap.additionalAttrs) {
 		descMaps.addAll(descMap.additionalAttrs)
 	}
+
 	return descMaps
 }
 
 // Parse incoming device messages to generate events
 def parse(String description) {
 	log.debug "description:- ${description}"
+
+	if (device.currentValue("shadeLevel") == null && device.currentValue("level") != null) {
+		sendEvent(name: "shadeLevel", value: device.currentValue("level"), unit: "%")
+	}
+
 	if (description?.startsWith("read attr -")) {
 		Map descMap = zigbee.parseDescriptionAsMap(description)
+
 		if (isBindingTableMessage(description)) {
 			parseBindingTableMessage(description)
 		} else if (supportsLiftPercentage() && descMap?.clusterInt == CLUSTER_WINDOW_COVERING && descMap.value) {
 			log.debug "attr: ${descMap?.attrInt}, value: ${descMap?.value}, descValue: ${Integer.parseInt(descMap.value, 16)}, ${device.getDataValue("model")}"
 			List<Map> descMaps = collectAttributes(descMap)
 			def liftmap = descMaps.find { it.attrInt == ATTRIBUTE_POSITION_LIFT }
+
 			if (liftmap && liftmap.value) {
 				def newLevel = zigbee.convertHexToInt(liftmap.value)
+
 				if (shouldInvertLiftPercentage()) {
 					// some devices report % level of being closed (instead of % level of being opened)
 					// inverting that logic is needed here to avoid a code duplication
@@ -118,18 +125,23 @@ def parse(String description) {
 			levelEventHandler(valueInt)
 		} else if (reportsBatteryPercentage() && descMap?.clusterInt == zigbee.POWER_CONFIGURATION_CLUSTER && zigbee.convertHexToInt(descMap?.attrId) == BATTERY_PERCENTAGE_REMAINING && descMap.value) {
 			def batteryLevel = zigbee.convertHexToInt(descMap.value)
+
 			batteryPercentageEventHandler(batteryLevel)
 		}
 	}
 }
 
 def levelEventHandler(currentLevel) {
-	def lastLevel = device.currentValue("level")
+	def lastLevel = device.currentValue("shadeLevel") ?: device.currentValue("level") // Try shadeLevel, if not use level and pass to logic below
+
 	log.debug "levelEventHandle - currentLevel: ${currentLevel} lastLevel: ${lastLevel}"
+
 	if (lastLevel == "undefined" || currentLevel == lastLevel) { //Ignore invalid reports
 		log.debug "Ignore invalid reports"
 	} else {
-		sendEvent(name: "level", value: currentLevel)
+		sendEvent(name: "shadeLevel", value: currentLevel, unit: "%")
+		sendEvent(name: "level", value: currentLevel, unit: "%", displayed: false)
+
 		if (currentLevel == 0 || currentLevel == 100) {
 			sendEvent(name: "windowShade", value: currentLevel == 0 ? "closed" : "open")
 		} else {
@@ -144,8 +156,9 @@ def levelEventHandler(currentLevel) {
 }
 
 def updateFinalState() {
-	def level = device.currentValue("level")
+	def level = device.currentValue("shadeLevel")
 	log.debug "updateFinalState: ${level}"
+
 	if (level > 0 && level < 100) {
 		sendEvent(name: "windowShade", value: "partially open")
 	}
@@ -158,10 +171,6 @@ def batteryPercentageEventHandler(batteryLevel) {
 	}
 }
 
-def supportsLiftPercentage() {
-	device.getDataValue("manufacturer") != "Feibit Co.Ltd"
-}
-
 def close() {
 	log.info "close()"
 	zigbee.command(CLUSTER_WINDOW_COVERING, COMMAND_CLOSE)
@@ -172,19 +181,29 @@ def open() {
 	zigbee.command(CLUSTER_WINDOW_COVERING, COMMAND_OPEN)
 }
 
-def setLevel(data, rate = null) {
-	log.info "setLevel()"
+def setLevel(value, rate = null) {
+	log.info "setLevel($value)"
+
+	setShadeLevel(value)
+}
+
+def setShadeLevel(value) {
+	log.info "setShadeLevel($value)"
+
+	Integer level = Math.max(Math.min(value as Integer, 100), 0)
 	def cmd
+
 	if (supportsLiftPercentage()) {
 		if (shouldInvertLiftPercentage()) {
 			// some devices keeps % level of being closed (instead of % level of being opened)
 			// inverting that logic is needed here
-			data = 100 - data
+			level = 100 - level
 		}
-		cmd = zigbee.command(CLUSTER_WINDOW_COVERING, COMMAND_GOTO_LIFT_PERCENTAGE, zigbee.convertToHexString(data, 2))
+		cmd = zigbee.command(CLUSTER_WINDOW_COVERING, COMMAND_GOTO_LIFT_PERCENTAGE, zigbee.convertToHexString(level, 2))
 	} else {
-		cmd = zigbee.command(zigbee.LEVEL_CONTROL_CLUSTER, COMMAND_MOVE_LEVEL_ONOFF, zigbee.convertToHexString(Math.round(data * 255 / 100), 2))
+		cmd = zigbee.command(zigbee.LEVEL_CONTROL_CLUSTER, COMMAND_MOVE_LEVEL_ONOFF, zigbee.convertToHexString(Math.round(level * 255 / 100), 2))
 	}
+
 	return cmd
 }
 
@@ -194,7 +213,7 @@ def pause() {
 }
 
 def presetPosition() {
-	setLevel(preset ?: 50)
+	setShadeLevel(preset ?: 50)
 }
 
 /**
@@ -207,25 +226,32 @@ def ping() {
 def refresh() {
 	log.info "refresh()"
 	def cmds
+
 	if (supportsLiftPercentage()) {
 		cmds = zigbee.readAttribute(CLUSTER_WINDOW_COVERING, ATTRIBUTE_POSITION_LIFT)
 	} else {
 		cmds = zigbee.readAttribute(zigbee.LEVEL_CONTROL_CLUSTER, ATTRIBUTE_CURRENT_LEVEL)
 	}
+
 	return cmds
 }
 
 def installed() {
+	log.debug "installed"
+
 	sendEvent(name: "supportedWindowShadeCommands", value: JsonOutput.toJson(["open", "close", "pause"]), displayed: false)
 }
 
 def configure() {
-	// Device-Watch allows 2 check-in misses from device + ping (plus 2 min lag time)
+	def cmds
+
 	log.info "configure()"
+
+	// Device-Watch allows 2 check-in misses from device + ping (plus 2 min lag time)
 	sendEvent(name: "checkInterval", value: 2 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+
 	log.debug "Configuring Reporting and Bindings."
 
-	def cmds
 	if (supportsLiftPercentage()) {
 		cmds = zigbee.configureReporting(CLUSTER_WINDOW_COVERING, ATTRIBUTE_POSITION_LIFT, DataType.UINT8, 0, 600, null)
 	} else {
@@ -249,6 +275,7 @@ def usesLocalGroupBinding() {
 
 private def parseBindingTableMessage(description) {
 	Integer groupAddr = getGroupAddrFromBindingTable(description)
+
 	if (groupAddr) {
 		List cmds = addHubToGroup(groupAddr)
 		cmds?.collect { new physicalgraph.device.HubAction(it) }
@@ -259,7 +286,9 @@ private Integer getGroupAddrFromBindingTable(description) {
 	log.info "Parsing binding table - '$description'"
 	def btr = zigbee.parseBindingTableResponse(description)
 	def groupEntry = btr?.table_entries?.find { it.dstAddrMode == 1 }
+
 	log.info "Found ${groupEntry}"
+
 	!groupEntry?.dstAddr ?: Integer.parseInt(groupEntry.dstAddr, 16)
 }
 
@@ -269,6 +298,10 @@ private List addHubToGroup(Integer groupAddr) {
 
 private List readDeviceBindingTable() {
 	["zdo mgmt-bind 0x${device.deviceNetworkId} 0", "delay 200"]
+}
+
+def supportsLiftPercentage() {
+	device.getDataValue("manufacturer") != "Feibit Co.Ltd"
 }
 
 def shouldInvertLiftPercentage() {

--- a/devicetypes/smartthings/zwave-window-shade.src/zwave-window-shade.groovy
+++ b/devicetypes/smartthings/zwave-window-shade.src/zwave-window-shade.groovy
@@ -15,252 +15,262 @@ import groovy.json.JsonOutput
 
 
 metadata {
-    definition (name: "Z-Wave Window Shade", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.blind") {
-        capability "Window Shade"
-        capability "Window Shade Preset"
-        capability "Battery"
-        capability "Refresh"
-        capability "Health Check"
-        capability "Actuator"
-        capability "Sensor"
+	definition (name: "Z-Wave Window Shade", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.blind") {
+		capability "Window Shade"
+		capability "Window Shade Level"
+		capability "Window Shade Preset"
+		capability "Switch Level"
+		capability "Battery"
+		capability "Refresh"
+		capability "Health Check"
+		capability "Actuator"
+		capability "Sensor"
 
-        command "stop"
+		command "stop"
 
-        capability "Switch Level"   // until we get a Window Shade Level capability
+		// This device handler is specifically for non-SWF position-aware window coverings
+		//
+		fingerprint type: "0x1107", cc: "0x5E,0x26", deviceJoinName: "Window Treatment" //Window Shade
+		fingerprint type: "0x9A00", cc: "0x5E,0x26", deviceJoinName: "Window Treatment" //Window Shade
+//		fingerprint mfr:"026E", prod:"4353", model:"5A31", deviceJoinName: "Window Blinds"
+//		fingerprint mfr:"026E", prod:"5253", model:"5A31", deviceJoinName: "Roller Shade"
+	}
 
-        // This device handler is specifically for non-SWF position-aware window coverings
-        //
-        fingerprint type: "0x1107", cc: "0x5E,0x26", deviceJoinName: "Window Treatment" //Window Shade
-        fingerprint type: "0x9A00", cc: "0x5E,0x26", deviceJoinName: "Window Treatment" //Window Shade
-//        fingerprint mfr:"026E", prod:"4353", model:"5A31", deviceJoinName: "Window Blinds"
-//        fingerprint mfr:"026E", prod:"5253", model:"5A31", deviceJoinName: "Roller Shade"
-    }
+	simulator {
+		status "open":  "command: 2603, payload: FF"
+		status "closed": "command: 2603, payload: 00"
+		status "10%": "command: 2603, payload: 0A"
+		status "66%": "command: 2603, payload: 42"
+		status "99%": "command: 2603, payload: 63"
+		status "battery 100%": "command: 8003, payload: 64"
+		status "battery low": "command: 8003, payload: FF"
 
-    simulator {
-        status "open":  "command: 2603, payload: FF"
-        status "closed": "command: 2603, payload: 00"
-        status "10%": "command: 2603, payload: 0A"
-        status "66%": "command: 2603, payload: 42"
-        status "99%": "command: 2603, payload: 63"
-        status "battery 100%": "command: 8003, payload: 64"
-        status "battery low": "command: 8003, payload: FF"
+		// reply messages
+		reply "2001FF,delay 1000,2602": "command: 2603, payload: 10 FF FE"
+		reply "200100,delay 1000,2602": "command: 2603, payload: 60 00 FE"
+		reply "200142,delay 1000,2602": "command: 2603, payload: 10 42 FE"
+		reply "200163,delay 1000,2602": "command: 2603, payload: 10 63 FE"
+	}
 
-        // reply messages
-        reply "2001FF,delay 1000,2602": "command: 2603, payload: 10 FF FE"
-        reply "200100,delay 1000,2602": "command: 2603, payload: 60 00 FE"
-        reply "200142,delay 1000,2602": "command: 2603, payload: 10 42 FE"
-        reply "200163,delay 1000,2602": "command: 2603, payload: 10 63 FE"
-    }
+	tiles(scale: 2) {
+		multiAttributeTile(name:"windowShade", type: "lighting", width: 6, height: 4){
+			tileAttribute ("device.windowShade", key: "PRIMARY_CONTROL") {
+				attributeState "open", label:'${name}', action:"close", icon:"st.shades.shade-open", backgroundColor:"#00A0DC", nextState:"closing"
+				attributeState "closed", label:'${name}', action:"open", icon:"st.shades.shade-closed", backgroundColor:"#ffffff", nextState:"opening"
+				attributeState "partially open", label:'Open', action:"close", icon:"st.shades.shade-open", backgroundColor:"#00A0DC", nextState:"closing"
+				attributeState "opening", label:'${name}', action:"stop", icon:"st.shades.shade-opening", backgroundColor:"#00A0DC", nextState:"partially open"
+				attributeState "closing", label:'${name}', action:"stop", icon:"st.shades.shade-closing", backgroundColor:"#ffffff", nextState:"partially open"
+			}
+			tileAttribute ("device.windowShadeLevel", key: "SLIDER_CONTROL") {
+				attributeState "shadeLevel", action:"setShadeLevel"
+			}
+		}
 
-    tiles(scale: 2) {
-        multiAttributeTile(name:"windowShade", type: "lighting", width: 6, height: 4){
-            tileAttribute ("device.windowShade", key: "PRIMARY_CONTROL") {
-                attributeState "open", label:'${name}', action:"close", icon:"st.shades.shade-open", backgroundColor:"#79b821", nextState:"closing"
-                attributeState "closed", label:'${name}', action:"open", icon:"st.shades.shade-closed", backgroundColor:"#ffffff", nextState:"opening"
-                attributeState "partially open", label:'Open', action:"close", icon:"st.shades.shade-open", backgroundColor:"#79b821", nextState:"closing"
-                attributeState "opening", label:'${name}', action:"stop", icon:"st.shades.shade-opening", backgroundColor:"#79b821", nextState:"partially open"
-                attributeState "closing", label:'${name}', action:"stop", icon:"st.shades.shade-closing", backgroundColor:"#ffffff", nextState:"partially open"
-            }
-            tileAttribute ("device.level", key: "SLIDER_CONTROL") {
-                attributeState "level", action:"setLevel"
-            }
-        }
+		standardTile("home", "device.level", width: 2, height: 2, decoration: "flat") {
+			state "default", label: "home", action:"presetPosition", icon:"st.Home.home2"
+		}
 
-        standardTile("home", "device.level", width: 2, height: 2, decoration: "flat") {
-            state "default", label: "home", action:"presetPosition", icon:"st.Home.home2"
-        }
+		standardTile("refresh", "device.refresh", width: 2, height: 2, inactiveLabel: false, decoration: "flat") {
+			state "default", label:'', action:"refresh.refresh", icon:"st.secondary.refresh", nextState: "disabled"
+			state "disabled", label:'', action:"", icon:"st.secondary.refresh"
+		}
 
-        standardTile("refresh", "device.refresh", width: 2, height: 2, inactiveLabel: false, decoration: "flat") {
-            state "default", label:'', action:"refresh.refresh", icon:"st.secondary.refresh", nextState: "disabled"
-            state "disabled", label:'', action:"", icon:"st.secondary.refresh"
-        }
+		valueTile("battery", "device.battery", decoration: "flat", inactiveLabel: false, width: 2, height: 2) {
+			state "battery", label:'${currentValue}% battery', unit:""
+		}
 
-        valueTile("battery", "device.battery", decoration: "flat", inactiveLabel: false, width: 2, height: 2) {
-            state "battery", label:'${currentValue}% battery', unit:""
-        }
+		preferences {
+			input "preset", "number", title: "Preset position", description: "Set the window shade preset position", defaultValue: 50, range: "1..100", required: false, displayDuringSetup: false
+		}
 
-        preferences {
-            input "preset", "number", title: "Preset position", description: "Set the window shade preset position", defaultValue: 50, range: "1..100", required: false, displayDuringSetup: false
-        }
+		main(["windowShade"])
+		details(["windowShade", "home", "refresh", "battery"])
 
-        main(["windowShade"])
-        details(["windowShade", "home", "refresh", "battery"])
-
-    }
+	}
 }
 
 def parse(String description) {
-    def result = null
-    //if (description =~ /command: 2603, payload: ([0-9A-Fa-f]{6})/)
-    // TODO: Workaround manual parsing of v4 multilevel report
-    def cmd = zwave.parse(description, [0x20: 1, 0x26: 3])  // TODO: switch to SwitchMultilevel v4 and use target value
-    if (cmd) {
-        result = zwaveEvent(cmd)
-    }
-    log.debug "Parsed '$description' to ${result.inspect()}"
-    return result
+	def result = null
+
+	if (device.currentValue("shadeLevel") == null && device.currentValue("level") != null) {
+		sendEvent(name: "shadeLevel", value: device.currentValue("level"), unit: "%")
+	}
+
+	//if (description =~ /command: 2603, payload: ([0-9A-Fa-f]{6})/)
+	// TODO: Workaround manual parsing of v4 multilevel report
+	def cmd = zwave.parse(description, [0x20: 1, 0x26: 3])  // TODO: switch to SwitchMultilevel v4 and use target value
+	if (cmd) {
+		result = zwaveEvent(cmd)
+	}
+	log.debug "Parsed '$description' to ${result.inspect()}"
+	return result
 }
 
 def getCheckInterval() {
-    // These are battery-powered devices, and it's not very critical
-    // to know whether they're online or not – 12 hrs
-    4 * 60 * 60
+	// These are battery-powered devices, and it's not very critical
+	// to know whether they're online or not – 12 hrs
+	4 * 60 * 60
 }
 
 def installed() {
-    sendEvent(name: "checkInterval", value: checkInterval, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
-    sendEvent(name: "supportedWindowShadeCommands", value: JsonOutput.toJson(["open", "close", "pause"]), displayed: false)
-    response(refresh())
+	sendEvent(name: "checkInterval", value: checkInterval, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
+	sendEvent(name: "supportedWindowShadeCommands", value: JsonOutput.toJson(["open", "close", "pause"]), displayed: false)
+	response(refresh())
 }
 
 def updated() {
-    if (device.latestValue("checkInterval") != checkInterval) {
-        sendEvent(name: "checkInterval", value: checkInterval, displayed: false)
-    }
-    if (!device.latestState("battery")) {
-        response(zwave.batteryV1.batteryGet())
-    }
+	if (device.latestValue("checkInterval") != checkInterval) {
+		sendEvent(name: "checkInterval", value: checkInterval, displayed: false)
+	}
+	if (!device.latestState("battery")) {
+		response(zwave.batteryV1.batteryGet())
+	}
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.basicv1.BasicReport cmd) {
-    handleLevelReport(cmd)
+	handleLevelReport(cmd)
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.basicv1.BasicSet cmd) {
-    handleLevelReport(cmd)
+	handleLevelReport(cmd)
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.switchmultilevelv3.SwitchMultilevelReport cmd) {
-    handleLevelReport(cmd)
+	handleLevelReport(cmd)
 }
 
 private handleLevelReport(physicalgraph.zwave.Command cmd) {
-    def descriptionText = null
-    def shadeValue = null
+	def descriptionText = null
+	def shadeValue = null
 
-    def level = cmd.value as Integer
-    if (level >= 99) {
-        level = 100
-        shadeValue = "open"
-    } else if (level <= 0) {
-        level = 0  // unlike dimmer switches, the level isn't saved when closed
-        shadeValue = "closed"
-    } else {
-        shadeValue = "partially open"
-        descriptionText = "${device.displayName} shade is ${level}% open"
-    }
-    checkLevelReport(level)
-    def levelEvent = createEvent(name: "level", value: level, unit: "%", displayed: false)
-    def stateEvent = createEvent(name: "windowShade", value: shadeValue, descriptionText: descriptionText, isStateChange: levelEvent.isStateChange)
+	def level = cmd.value as Integer
+	if (level >= 99) {
+		level = 100
+		shadeValue = "open"
+	} else if (level <= 0) {
+		level = 0  // unlike dimmer switches, the level isn't saved when closed
+		shadeValue = "closed"
+	} else {
+		shadeValue = "partially open"
+		descriptionText = "${device.displayName} shade is ${level}% open"
+	}
+	checkLevelReport(level)
 
-    def result = [stateEvent, levelEvent]
-    if (!state.lastbatt || now() - state.lastbatt > 24 * 60 * 60 * 1000) {
-        log.debug "requesting battery"
-        state.lastbatt = (now() - 23 * 60 * 60 * 1000) // don't queue up multiple battery reqs in a row
-        result << response(["delay 15000", zwave.batteryV1.batteryGet().format()])
-    }
-    result
+	def levelEvent = createEvent(name: "level", value: level, unit: "%", displayed: false)
+	def shadeLevelEvent = createEvent(name: "shadeLevel", value: level, unit: "%")
+	def stateEvent = createEvent(name: "windowShade", value: shadeValue, descriptionText: descriptionText, isStateChange: shadeLevelEvent.isStateChange)
+
+	def result = [stateEvent, shadeLevelEvent, levelEvent]
+	if (!state.lastbatt || now() - state.lastbatt > 24 * 60 * 60 * 1000) {
+		log.debug "requesting battery"
+		state.lastbatt = (now() - 23 * 60 * 60 * 1000) // don't queue up multiple battery reqs in a row
+		result << response(["delay 15000", zwave.batteryV1.batteryGet().format()])
+	}
+	result
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.switchmultilevelv3.SwitchMultilevelStopLevelChange cmd) {
-    [ createEvent(name: "windowShade", value: "partially open", displayed: false, descriptionText: "$device.displayName shade stopped"),
-      response(zwave.switchMultilevelV1.switchMultilevelGet().format()) ]
+	[ createEvent(name: "windowShade", value: "partially open", displayed: false, descriptionText: "$device.displayName shade stopped"),
+	  response(zwave.switchMultilevelV1.switchMultilevelGet().format()) ]
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.batteryv1.BatteryReport cmd) {
-    def map = [ name: "battery", unit: "%" ]
-    if (cmd.batteryLevel == 0xFF) {
-        map.value = 1
-        map.descriptionText = "${device.displayName} has a low battery"
-        map.isStateChange = true
-    } else {
-        map.value = cmd.batteryLevel
-    }
-    state.lastbatt = now()
-    createEvent(map)
+	def map = [ name: "battery", unit: "%" ]
+
+	if (cmd.batteryLevel == 0xFF) {
+		map.value = 1
+		map.descriptionText = "${device.displayName} has a low battery"
+		map.isStateChange = true
+	} else {
+		map.value = cmd.batteryLevel
+	}
+
+	state.lastbatt = now()
+
+	createEvent(map)
 }
 
 def zwaveEvent(physicalgraph.zwave.Command cmd) {
-    log.debug "unhandled $cmd"
-    return []
+	log.debug "unhandled $cmd"
+	return []
 }
 
 def open() {
-    levelChangeFollowUp(99)
-    log.debug "open()"
-    /*delayBetween([
-            zwave.basicV1.basicSet(value: 0xFF).format(),
-            zwave.switchMultilevelV1.switchMultilevelGet().format()
-    ], 1000)*/
-    zwave.basicV1.basicSet(value: 99).format()
+	log.debug "open()"
+
+	setShadeLevel(99)
 }
 
 def close() {
-    levelChangeFollowUp(0)
-    log.debug "close()"
-    /*delayBetween([
-            zwave.basicV1.basicSet(value: 0x00).format(),
-            zwave.switchMultilevelV1.switchMultilevelGet().format()
-    ], 1000)*/
-    zwave.basicV1.basicSet(value: 0).format()
+	log.debug "close()"
+
+	setShadeLevel(0)
 }
 
 def setLevel(value, duration = null) {
-    log.debug "setLevel(${value.inspect()})"
-    Integer level = value as Integer
-    if (level < 0) level = 0
-    if (level > 99) level = 99
-    levelChangeFollowUp(level)
-    zwave.basicV1.basicSet(value: level).format()
+	log.debug "setLevel($value)"
+
+	setShadeLevel(value)
+}
+
+def setShadeLevel(value) {
+	Integer level = Math.max(Math.min(value as Integer, 99), 0)
+
+	log.debug "setShadeLevel($value) -> $level"
+
+	levelChangeFollowUp(level) // Follow up in a few seconds to make sure the shades didn't "forget" to send us level updates
+	zwave.basicV1.basicSet(value: level).format()
 }
 
 def presetPosition() {
-    setLevel(preset ?: state.preset ?: 50)
+	setLevel(preset ?: state.preset ?: 50)
 }
 
 def pause() {
-    log.debug "pause()"
-    stop()
+	log.debug "pause()"
+
+	stop()
 }
 
 def stop() {
-    log.debug "stop()"
-    zwave.switchMultilevelV3.switchMultilevelStopLevelChange().format()
+	log.debug "stop()"
+
+	zwave.switchMultilevelV3.switchMultilevelStopLevelChange().format()
 }
 
 def ping() {
-    zwave.switchMultilevelV1.switchMultilevelGet().format()
+	zwave.switchMultilevelV1.switchMultilevelGet().format()
 }
 
 def refresh() {
-    log.debug "refresh()"
-    delayBetween([
-            zwave.switchMultilevelV1.switchMultilevelGet().format(),
-            zwave.batteryV1.batteryGet().format()
-    ], 1500)
+	log.debug "refresh()"
+	delayBetween([
+			zwave.switchMultilevelV1.switchMultilevelGet().format(),
+			zwave.batteryV1.batteryGet().format()
+	], 1500)
 }
 
 def levelChangeFollowUp(expectedLevel) {
-    state.expectedValue = expectedLevel
-    state.levelChecks = 0
-    runIn(5, "checkLevel", [overwrite: true])
+	state.expectedValue = expectedLevel
+	state.levelChecks = 0
+	runIn(5, "checkLevel", [overwrite: true])
 }
 
 def checkLevelReport(value) {
-    if (state.expectedValue != null) {
-        if ((state.expectedValue == 99 && value >= 99) ||
-                (value >= state.expectedValue - 2 && value <= state.expectedValue + 2)) {
-            unschedule("checkLevel")
-        }
-    }
+	if (state.expectedValue != null) {
+		if ((state.expectedValue == 99 && value >= 99) ||
+			(value >= state.expectedValue - 2 && value <= state.expectedValue + 2)) {
+			unschedule("checkLevel")
+		}
+	}
 }
 
 def checkLevel() {
-    if (state.levelChecks != null && state.levelChecks < 5) {
-        state.levelChecks = state.levelChecks + 1
-        runIn(5, "checkLevel", [overwrite: true])
-        sendHubCommand(zwave.switchMultilevelV1.switchMultilevelGet())
-    } else {
-        unschedule("checkLevel")
-    }
+	if (state.levelChecks != null && state.levelChecks < 5) {
+		state.levelChecks = state.levelChecks + 1
+		runIn(5, "checkLevel", [overwrite: true])
+		sendHubCommand(zwave.switchMultilevelV1.switchMultilevelGet())
+	} else {
+		unschedule("checkLevel")
+	}
 }


### PR DESCRIPTION
`Window Shade Level` is the preferred capability for Window Shade devices expressing a level value.

The first step is to add this capability to the devices which use it. The next step is to look in to considering removing the `Switch Level` capability. For now we will leave it in the DTH, but remove it from the metadata.

Locally executing integrations will need to be considered, too.