### PR TITLE
CHAD-4880 Fix MultiChannel for Fibaro Dimmer 2

### DIFF
--- a/devicetypes/fibargroup/fibaro-dimmer-2-zw5.src/fibaro-dimmer-2-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-dimmer-2-zw5.src/fibaro-dimmer-2-zw5.groovy
@@ -391,7 +391,7 @@ def zwaveEvent(physicalgraph.zwave.commands.multichannelv3.MultiChannelCmdEncap 
 		cmd.command = cmd.parameter[1]
 		cmd.parameter = cmd.parameter.drop(2)
 	}
-	def encapsulatedCommand = cmd.encapsulatedCommand(commandClassVersions)
+	def encapsulatedCommand = cmd.encapsulatedCommand(cmdVersions())
 	log.debug "Command from endpoint ${cmd.sourceEndPoint}: ${encapsulatedCommand}"
 	if (encapsulatedCommand) {
 		result = zwaveEvent(encapsulatedCommand)


### PR DESCRIPTION
During testing, we found there was an issue in prod while the Self Published DTH was working, we noticed the difference in `MultiChannelCmdEncap` Handler. 