### PR TITLE
ICP-12599 Added preference to reset energy consumption value

### DIFF
--- a/devicetypes/smartthings/zwave-metering-dimmer.src/zwave-metering-dimmer.groovy
+++ b/devicetypes/smartthings/zwave-metering-dimmer.src/zwave-metering-dimmer.groovy
@@ -93,6 +93,10 @@ metadata {
 
 	main(["switch","power","energy"])
 	details(["switch", "power", "energy", "refresh", "reset"])
+
+	preferences {
+		input name: "resetPowerMeterValues", type: "bool", title: "Reset Energy Consumption", description: "Reset the accumulated energy consumption value"
+	}
 }
 
 def getCommandClassVersions() {
@@ -113,7 +117,12 @@ def installed() {
 def updated() {
 	// Device-Watch simply pings if no device events received for 32min(checkInterval)
 	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
-	response(refresh())
+	def cmd = []
+	if (settings.resetPowerMeterValues) {
+		cmd += reset()
+	}
+	cmd += refresh()
+	response(cmd)
 }
 
 // parse events into attributes
@@ -250,6 +259,7 @@ def configure() {
 }
 
 def reset() {
+	log.debug "reset()"
 	encapSequence([
 		meterReset(),
 		meterGet(scale: 0)


### PR DESCRIPTION
**ICP-12599**
**Added preference to reset energy consumption value**

- The energy consumption value was not cleared after device factory reset

- The preference for triggering the meter reset command has been added

@greens @dkirker @tpmanley could you please take a look at the code?

@KKlimczukS @MWierzbinskaS @PKacprowiczS @MGoralczykS @ZWozniakS 