### PR TITLE
[WWST-6729] Added fingerprint for Inovelli Dimmer LZW31-SN

### DIFF
--- a/devicetypes/smartthings/zwave-metering-dimmer.src/zwave-metering-dimmer.groovy
+++ b/devicetypes/smartthings/zwave-metering-dimmer.src/zwave-metering-dimmer.groovy
@@ -40,6 +40,7 @@ metadata {
 		fingerprint mfr:"0086", prod:"0203", model:"006F", deviceJoinName: "Aeotec Dimmer Switch" //AU //Aeotec Nano Dimmer
 		fingerprint mfr:"014F", prod:"5044", model:"3533", deviceJoinName: "GoControl Dimmer Switch" //GoControl Plug-in Dimmer
 		fingerprint mfr:"0159", prod:"0001", model:"0055", deviceJoinName: "Qubino Dimmer Switch" //Qubino Mini Dimmer ZMNHHD1
+		fingerprint mfr:"031E", prod:"0001", model:"0001", deviceJoinName: "Inovelli Dimmer Switch" //Inovelli Dimmer LZW31-SN
 	}
 
 	simulator {


### PR DESCRIPTION
WWST-6729 Added fingerprint for Inovelli Dimmer LZW31-SN
@greens @KKlimczukS @PKacprowiczS @MGoralczykS @ZWozniakS @BJanuszS 
Could you please take a look at the code?