### PR TITLE
[ICP-12393] Added metadata for Sinope Load Controller

### DIFF
--- a/devicetypes/sinope-technologies/rm3250zb-sinope-load-controller.src/rm3250zb-sinope-load-controller.groovy
+++ b/devicetypes/sinope-technologies/rm3250zb-sinope-load-controller.src/rm3250zb-sinope-load-controller.groovy
@@ -14,7 +14,7 @@ metadata {
 		// 	description: "1= ERROR only, 2= <1+WARNING>, 3= <2+INFO>, 4= <3+DEBUG>, 5= <4+TRACE>")
     }
     
-    definition (name: "RM3250ZB Sinope Load Controller", namespace: "Sinope Technologies", author: "Sinope Technologies", , ocfDeviceType: "oic.d.switch") {
+    definition (name: "RM3250ZB Sinope Load Controller", namespace: "Sinope Technologies", author: "Sinope Technologies", ocfDeviceType: "oic.d.switch", mnmn: "SmartThings", vid: "SmartThings-smartthings-ZigBee_Switch_Power") {
 
         capability "Refresh"
         capability "Switch"        


### PR DESCRIPTION
@greens @dkirker @tpmanley could you please review?

This fix addresses nine issues, all reported due to a lack of metadata for this device.

**NA**
[ICP-12393](https://smartthings.atlassian.net/browse/ICP-12393)
[ICP-12395](https://smartthings.atlassian.net/browse/ICP-12395)
[ICP-12398](https://smartthings.atlassian.net/browse/ICP-12398)

**EU**
[ICP-12441](https://smartthings.atlassian.net/browse/ICP-12441)
[ICP-12443](https://smartthings.atlassian.net/browse/ICP-12443)
[ICP-12450](https://smartthings.atlassian.net/browse/ICP-12450)

**AP**
[ICP-12475](https://smartthings.atlassian.net/browse/ICP-12475)
[ICP-12477](https://smartthings.atlassian.net/browse/ICP-12477)
[ICP-12478](https://smartthings.atlassian.net/browse/ICP-12478)

@KKlimczukS @PKacprowiczS @MGoralczykS @MWierzbinskaS @BJanuszS 