### PR TITLE
Fixes for ICP-13200, ICP-13202

### DIFF
--- a/devicetypes/fibargroup/fibaro-walli-double-switch.src/fibaro-walli-double-switch.groovy
+++ b/devicetypes/fibargroup/fibaro-walli-double-switch.src/fibaro-walli-double-switch.groovy
@@ -195,13 +195,15 @@ private getPreferenceValue(preference, value = "default") {
 private getCommandValue(preference) {
 	def parameterKey = preference.key
 	switch (preference.type) {
+		// boolean and boolRange values are strings in the UI
 		case "boolean":
-			return settings."$parameterKey" ? preference.optionActive : preference.optionInactive
+			return settings."$parameterKey" == 'true' ? preference.optionActive : preference.optionInactive
 		case "boolRange":
 			def parameterKeyBoolean = parameterKey + "Boolean"
-			return settings."$parameterKeyBoolean" ? settings."$parameterKey" : preference.disableValue
+			return settings."$parameterKeyBoolean" ==  'true' ? settings."$parameterKey" : preference.disableValue
 		default:
-			return Integer.parseInt(settings."$parameterKey")
+			// to deal with numbers and number as string it's needed to wrap it in quotes and then parse
+			return Integer.parseInt("${settings."$parameterKey"}")
 	}
 }
 
@@ -381,10 +383,7 @@ def childOnOff(deviceNetworkId, value) {
 private onOffCmd(value, endpoint = 1) {
 	delayBetween([
 		encap(zwave.basicV1.basicSet(value: value), endpoint),
-		encap(zwave.basicV1.basicGet(), endpoint),
-		"delay 3000",
-		encap(zwave.meterV3.meterGet(scale: 0), endpoint),
-		encap(zwave.meterV3.meterGet(scale: 2), endpoint)
+		encap(zwave.basicV1.basicGet(), endpoint)
 	])
 }
 

--- a/devicetypes/fibargroup/fibaro-walli-double-switch.src/fibaro-walli-double-switch.groovy
+++ b/devicetypes/fibargroup/fibaro-walli-double-switch.src/fibaro-walli-double-switch.groovy
@@ -115,7 +115,7 @@ def installed() {
 	parameterMap.each {
 		state.currentPreferencesState."$it.key" = [:]
 		state.currentPreferencesState."$it.key".value = getPreferenceValue(it)
-        state.currentPreferencesState."$it.key".status = "synced"
+		state.currentPreferencesState."$it.key".status = "synced"
 	}
 	// Preferences template end
 }
@@ -166,12 +166,12 @@ private getCommandValue(preference) {
 	def parameterKey = preference.key
 	switch (preference.type) {
 		case "boolean":
-            // boolean values are returned as strings from the UI preferences
-            return settings."$parameterKey" == 'true' ? preference.optionActive : preference.optionInactive
-        case "range":
-            return settings."$parameterKey"
+		// boolean values are returned as strings from the UI preferences
+			return settings."$parameterKey" == 'true' ? preference.optionActive : preference.optionInactive
+		case "range":
+			return settings."$parameterKey"
 		default:
-            return Integer.parseInt(settings."$parameterKey")
+			return Integer.parseInt(settings."$parameterKey")
 	}
 }
 

--- a/devicetypes/fibargroup/fibaro-walli-double-switch.src/fibaro-walli-double-switch.groovy
+++ b/devicetypes/fibargroup/fibaro-walli-double-switch.src/fibaro-walli-double-switch.groovy
@@ -165,12 +165,13 @@ private getPreferenceValue(preference, value = "default") {
 private getCommandValue(preference) {
 	def parameterKey = preference.key
 	switch (preference.type) {
-		// boolean values are returned as strings from the UI preferences
 		case "boolean":
-			return settings."$parameterKey" == 'true' ? preference.optionActive : preference.optionInactive
+            // boolean values are returned as strings from the UI preferences
+            return settings."$parameterKey" == 'true' ? preference.optionActive : preference.optionInactive
+        case "range":
+            return settings."$parameterKey"
 		default:
-			// to deal with numbers and number as string it's needed to wrap it in quotes and then parse
-			return Integer.parseInt("${settings."$parameterKey"}")
+            return Integer.parseInt(settings."$parameterKey")
 	}
 }
 


### PR DESCRIPTION
- Removed unnecessary calls of meterGet.
- Fixes for setting device preferences (ICP-13200, ICP-13202)
- Removed boolRange boilerplate code - since device settings of that type are not exposed in those DTHs
@greens @dkirker Please, could You take a look at the code ?

cc: @MWierzbinskaS @ZWozniakS @PKacprowiczS @BJanuszS @MGoralczykS 