### PR TITLE
issue fix : ICP-12604: Supported temperature values ​​for the following options.

### DIFF
--- a/devicetypes/sinope-technologies/th1400zb-sinope-thermostat.src/th1400zb-sinope-thermostat.groovy
+++ b/devicetypes/sinope-technologies/th1400zb-sinope-thermostat.src/th1400zb-sinope-thermostat.groovy
@@ -26,12 +26,12 @@ metadata {
 			// input("PumpProtectionParam", "enum", titile: "Pump Protection (Default: Off)", options: ["On", "Off"], required: false 
 			// 	description: "Activate the main output 1 minute every 24 hours to ensure the hydronics system pump does not seize.")
 
-			input("FloorMaxAirTemperatureParam", "number", title:"Ambient limit (5C to 36C / 41F to 96)", range: "5..96",
-				description: "The maximum ambient temperature limit \nwhen in floor control mode.", required: false)
-			input("FloorLimitMinParam", "number", title:"Floor low limit (5C to 34C / 41F to 93F)", range: "5..93", 
-				description: "The minimum temperature limit of the floor when in ambient control mode.", required: false)
-			input("FloorLimitMaxParam", "number", title:"Floor high limit (7C to 36C / 45F to 96F)", range: "7..96", 
-				description: "The maximum temperature limit of the floor when in ambient control mode.", required: false)
+			input("FloorMaxAirTemperatureParam", "number", title:"Ambient limit in Celsius (5C to 36C)", range: "5..36",
+				description: "The maximum ambient temperature limit in Celsius when in floor control mode.", required: false)
+			input("FloorLimitMinParam", "number", title:"Floor low limit in Celsius (5C to 34C)", range: "5..34", 
+				description: "The minimum temperature limit in Celsius of the floor when in ambient control mode.", required: false)
+			input("FloorLimitMaxParam", "number", title:"Floor high limit in Celsius (7C to 36C)", range: "7..36", 
+				description: "The maximum temperature limit of the floor in Celsius when in ambient control mode.", required: false)
 			// input("AuxLoadParam", "number", title:"Auxiliary load value (Default: 0)", range:("0..65535"),
 			// 	description: "Enter the power in watts of the heating element connected to the auxiliary output.", required: false)
 			input("trace", "bool", title: "Trace", description: "Set it to true to enable tracing")
@@ -246,15 +246,15 @@ def updated() {
         if(FloorMaxAirTemperatureParam){
         	def MaxAirTemperatureValue
 			traceEvent(settings.logFilter,"FloorMaxAirTemperature param. scale: ${state?.scale}, Param value: ${FloorMaxAirTemperatureParam}",settings.trace)
-        	if(state?.scale == 'F')
+        	if(FloorMaxAirTemperatureParam >= 41)
             {
-            	MaxAirTemperatureValue = fahrenheitToCelsius(FloorMaxAirTemperatureParam).toInteger()
+            	MaxAirTemperatureValue = checkTemperature(FloorMaxAirTemperatureParam)//check if the temperature is between the maximum and minimum
+            	MaxAirTemperatureValue = fahrenheitToCelsius(MaxAirTemperatureValue).toInteger()
             }
             else//state?.scale == 'C'
             {
             	MaxAirTemperatureValue = FloorMaxAirTemperatureParam.toInteger()
             }
-            MaxAirTemperatureValue = checkTemperature(MaxAirTemperatureValue)//check if the temperature is between the maximum and minimum
             MaxAirTemperatureValue =  MaxAirTemperatureValue * 100
             cmds += zigbee.writeAttribute(0xFF01, 0x0108, 0x29, MaxAirTemperatureValue)
         }
@@ -266,15 +266,15 @@ def updated() {
         if(FloorLimitMinParam){
         	def FloorLimitMinValue
 			traceEvent(settings.logFilter,"FloorLimitMin param. scale: ${state?.scale}, Param value: ${FloorLimitMinParam}",settings.trace)
-            if(state?.scale == 'F')
+            if(FloorLimitMinParam >= 41)
             {
-            	FloorLimitMinValue = fahrenheitToCelsius(FloorLimitMinParam).toInteger()
+            	FloorLimitMinValue = checkTemperature(FloorLimitMinParam)//check if the temperature is between the maximum and minimum
+            	FloorLimitMinValue = fahrenheitToCelsius(FloorLimitMinValue).toInteger()
             }
         	else//state?.scale == 'C'
             {
             	FloorLimitMinValue = FloorLimitMinParam.toInteger()
             }
-            FloorLimitMinValue = checkTemperature(FloorLimitMinValue)//check if the temperature is between the maximum and minimum
             FloorLimitMinValue =  FloorLimitMinValue * 100
             cmds += zigbee.writeAttribute(0xFF01, 0x0109, 0x29, FloorLimitMinValue)
         }
@@ -286,15 +286,15 @@ def updated() {
         if(FloorLimitMaxParam){
         	def FloorLimitMaxValue
 			traceEvent(settings.logFilter,"FloorLimitMax param. scale: ${state?.scale}, Param value: ${FloorLimitMaxParam}",settings.trace)
-            if(state?.scale == 'F')
+            if(FloorLimitMaxParam >= 45)
             {
-            	FloorLimitMaxValue = fahrenheitToCelsius(FloorLimitMaxParam).toInteger()
+            	FloorLimitMaxValue = checkTemperature(FloorLimitMaxParam)//check if the temperature is between the maximum and minimum
+            	FloorLimitMaxValue = fahrenheitToCelsius(FloorLimitMaxValue).toInteger()
             }
             else//state?.scale == 'C'
             {
             	FloorLimitMaxValue = FloorLimitMaxParam.toInteger()
             }
-            FloorLimitMaxValue = checkTemperature(FloorLimitMaxValue)//check if the temperature is between the maximum and minimum
             FloorLimitMaxValue =  FloorLimitMaxValue * 100
             cmds += zigbee.writeAttribute(0xFF01, 0x010A, 0x29, FloorLimitMaxValue)
         }


### PR DESCRIPTION
@shrakuma 
ICP-12604: Supported temperature values ​​for the following options.
- Ambient limit - 5-36 degrees in Celsius, or 41-96 degrees in Fahrenheit.
- Floor high limit - 5-36 degrees in Celsius, or 41-96 degrees in Fahrenheit.
- Floor low limit - 5-36 degrees in Celsius, or 41-96 degrees in Fahrenheit.

In the ST application, we can enter from 5-96 (from 5 degrees Celsius to 96 degrees Fahrenheit) → this is confusing.
Sinope thermostats support Celsius and Fahrenheit unit systems - this option can be changed manually on the device.