### PR TITLE
CHAD-5172 Send follow-ups to verify that window shade level changes o…

### DIFF
--- a/devicetypes/smartthings/springs-window-fashions-shade.src/springs-window-fashions-shade.groovy
+++ b/devicetypes/smartthings/springs-window-fashions-shade.src/springs-window-fashions-shade.groovy
@@ -272,7 +272,7 @@ def levelChangeFollowUp(expectedLevel) {
 def checkLevelReport(value) {
     if (state.expectedValue != null) {
         if ((state.expectedValue == 99 && value >= 99) ||
-                (state.expectedValue >= value - 2 && state.expectedValue <= value + 2 )) {
+                (value >= state.expectedValue - 2 && value <= state.expectedValue + 2)) {
             unschedule("checkLevel")
         }
     }

--- a/devicetypes/smartthings/springs-window-fashions-shade.src/springs-window-fashions-shade.groovy
+++ b/devicetypes/smartthings/springs-window-fashions-shade.src/springs-window-fashions-shade.groovy
@@ -266,7 +266,7 @@ def refresh() {
 def levelChangeFollowUp(expectedLevel) {
     state.expectedValue = expectedLevel
     state.levelChecks = 0
-    runIn(5, "checkLevel")
+    runIn(5, "checkLevel", [overwrite: true])
 }
 
 def checkLevelReport(value) {
@@ -281,7 +281,7 @@ def checkLevelReport(value) {
 def checkLevel() {
     if (state.levelChecks != null && state.levelChecks < 5) {
         state.levelChecks += 1
-        runIn(5, "checkLevel")
+        runIn(5, "checkLevel", [overwrite: true])
         sendHubCommand(zwave.switchMultilevelV1.switchMultilevelGet())
     } else {
         unschedule("checkLevel")

--- a/devicetypes/smartthings/springs-window-fashions-shade.src/springs-window-fashions-shade.groovy
+++ b/devicetypes/smartthings/springs-window-fashions-shade.src/springs-window-fashions-shade.groovy
@@ -270,8 +270,8 @@ def levelChangeFollowUp(expectedLevel) {
 }
 
 def checkLevelReport(value) {
-    if (state.expectedValue) {
-        if ((state.expectedValue == 99 && value > 99) ||
+    if (state.expectedValue != null) {
+        if ((state.expectedValue == 99 && value >= 99) ||
                 state.expectedValue == value) {
             unschedule("checkLevel")
         }

--- a/devicetypes/smartthings/springs-window-fashions-shade.src/springs-window-fashions-shade.groovy
+++ b/devicetypes/smartthings/springs-window-fashions-shade.src/springs-window-fashions-shade.groovy
@@ -164,6 +164,7 @@ private handleLevelReport(physicalgraph.zwave.Command cmd) {
         shadeValue = "partially open"
         descriptionText = "${device.displayName} shade is ${level}% open"
     }
+    checkLevelReport(level)
     def levelEvent = createEvent(name: "level", value: level, unit: "%", displayed: false)
     def stateEvent = createEvent(name: "windowShade", value: shadeValue, descriptionText: descriptionText, isStateChange: levelEvent.isStateChange)
 
@@ -179,15 +180,6 @@ private handleLevelReport(physicalgraph.zwave.Command cmd) {
 def zwaveEvent(physicalgraph.zwave.commands.switchmultilevelv3.SwitchMultilevelStopLevelChange cmd) {
     [ createEvent(name: "windowShade", value: "partially open", displayed: false, descriptionText: "$device.displayName shade stopped"),
       response(zwave.switchMultilevelV1.switchMultilevelGet().format()) ]
-}
-
-def zwaveEvent(physicalgraph.zwave.commands.manufacturerspecificv2.ManufacturerSpecificReport cmd) {
-    def msr = String.format("%04X-%04X-%04X", cmd.manufacturerId, cmd.productTypeId, cmd.productId)
-    updateDataValue("MSR", msr)
-    if (cmd.manufacturerName) {
-        updateDataValue("manufacturer", cmd.manufacturerName)
-    }
-    createEvent([descriptionText: "$device.displayName MSR: $msr", isStateChange: false])
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.batteryv1.BatteryReport cmd) {
@@ -222,6 +214,7 @@ def zwaveEvent(physicalgraph.zwave.Command cmd) {
 def open() {
     log.debug "open()"
     def level = switchDirection ? 0 : 99
+    levelChangeFollowUp(level)
     zwave.basicV1.basicSet(value: level).format()
     // zwave.basicV1.basicSet(value: 0xFF).format()
 }
@@ -229,6 +222,7 @@ def open() {
 def close() {
     log.debug "close()"
     def level = switchDirection ? 99 : 0
+    levelChangeFollowUp(level)
     zwave.basicV1.basicSet(value: level).format()
     //zwave.basicV1.basicSet(value: 0).format()
 }
@@ -239,6 +233,7 @@ def setLevel(value, duration = null) {
     level = switchDirection ? 99-level : level
     if (level < 0) level = 0
     if (level > 99) level = 99
+    levelChangeFollowUp(level)
     zwave.basicV1.basicSet(value: level).format()
 }
 
@@ -266,4 +261,29 @@ def refresh() {
             zwave.switchMultilevelV1.switchMultilevelGet().format(),
             zwave.batteryV1.batteryGet().format()
     ], 1500)
+}
+
+def levelChangeFollowUp(expectedLevel) {
+    state.expectedValue = expectedLevel
+    state.levelChecks = 0
+    runIn(5, "checkLevel")
+}
+
+def checkLevelReport(value) {
+    if (state.expectedValue) {
+        if ((state.expectedValue == 99 && value > 99) ||
+                state.expectedValue == value) {
+            unschedule("checkLevel")
+        }
+    }
+}
+
+def checkLevel() {
+    if (state.levelChecks != null && state.levelChecks < 5) {
+        state.levelChecks += 1
+        runIn(5, "checkLevel")
+        response(zwave.switchMultilevelV1.switchMultilevelGet())
+    } else {
+        unschedule("checkLevel")
+    }
 }

--- a/devicetypes/smartthings/springs-window-fashions-shade.src/springs-window-fashions-shade.groovy
+++ b/devicetypes/smartthings/springs-window-fashions-shade.src/springs-window-fashions-shade.groovy
@@ -282,7 +282,7 @@ def checkLevel() {
     if (state.levelChecks != null && state.levelChecks < 5) {
         state.levelChecks += 1
         runIn(5, "checkLevel")
-        response(zwave.switchMultilevelV1.switchMultilevelGet())
+        sendHubCommand(zwave.switchMultilevelV1.switchMultilevelGet())
     } else {
         unschedule("checkLevel")
     }

--- a/devicetypes/smartthings/springs-window-fashions-shade.src/springs-window-fashions-shade.groovy
+++ b/devicetypes/smartthings/springs-window-fashions-shade.src/springs-window-fashions-shade.groovy
@@ -272,7 +272,7 @@ def levelChangeFollowUp(expectedLevel) {
 def checkLevelReport(value) {
     if (state.expectedValue != null) {
         if ((state.expectedValue == 99 && value >= 99) ||
-                state.expectedValue == value) {
+                (state.expectedValue >= value - 2 && state.expectedValue <= value + 2 )) {
             unschedule("checkLevel")
         }
     }

--- a/devicetypes/smartthings/springs-window-fashions-shade.src/springs-window-fashions-shade.groovy
+++ b/devicetypes/smartthings/springs-window-fashions-shade.src/springs-window-fashions-shade.groovy
@@ -280,7 +280,7 @@ def checkLevelReport(value) {
 
 def checkLevel() {
     if (state.levelChecks != null && state.levelChecks < 5) {
-        state.levelChecks += 1
+        state.levelChecks = state.levelChecks + 1
         runIn(5, "checkLevel", [overwrite: true])
         sendHubCommand(zwave.switchMultilevelV1.switchMultilevelGet())
     } else {

--- a/devicetypes/smartthings/zwave-window-shade.src/zwave-window-shade.groovy
+++ b/devicetypes/smartthings/zwave-window-shade.src/zwave-window-shade.groovy
@@ -249,7 +249,7 @@ def levelChangeFollowUp(expectedLevel) {
 def checkLevelReport(value) {
     if (state.expectedValue != null) {
         if ((state.expectedValue == 99 && value >= 99) ||
-                state.expectedValue == value) {
+                (state.expectedValue >= value - 2 && state.expectedValue <= value + 2 )) {
             unschedule("checkLevel")
         }
     }

--- a/devicetypes/smartthings/zwave-window-shade.src/zwave-window-shade.groovy
+++ b/devicetypes/smartthings/zwave-window-shade.src/zwave-window-shade.groovy
@@ -149,6 +149,7 @@ private handleLevelReport(physicalgraph.zwave.Command cmd) {
         shadeValue = "partially open"
         descriptionText = "${device.displayName} shade is ${level}% open"
     }
+    checkLevelReport(level)
     def levelEvent = createEvent(name: "level", value: level, unit: "%", displayed: false)
     def stateEvent = createEvent(name: "windowShade", value: shadeValue, descriptionText: descriptionText, isStateChange: levelEvent.isStateChange)
 
@@ -164,15 +165,6 @@ private handleLevelReport(physicalgraph.zwave.Command cmd) {
 def zwaveEvent(physicalgraph.zwave.commands.switchmultilevelv3.SwitchMultilevelStopLevelChange cmd) {
     [ createEvent(name: "windowShade", value: "partially open", displayed: false, descriptionText: "$device.displayName shade stopped"),
       response(zwave.switchMultilevelV1.switchMultilevelGet().format()) ]
-}
-
-def zwaveEvent(physicalgraph.zwave.commands.manufacturerspecificv2.ManufacturerSpecificReport cmd) {
-    def msr = String.format("%04X-%04X-%04X", cmd.manufacturerId, cmd.productTypeId, cmd.productId)
-    updateDataValue("MSR", msr)
-    if (cmd.manufacturerName) {
-        updateDataValue("manufacturer", cmd.manufacturerName)
-    }
-    createEvent([descriptionText: "$device.displayName MSR: $msr", isStateChange: false])
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.batteryv1.BatteryReport cmd) {
@@ -194,6 +186,7 @@ def zwaveEvent(physicalgraph.zwave.Command cmd) {
 }
 
 def open() {
+    levelChangeFollowUp(99)
     log.debug "open()"
     /*delayBetween([
             zwave.basicV1.basicSet(value: 0xFF).format(),
@@ -203,6 +196,7 @@ def open() {
 }
 
 def close() {
+    levelChangeFollowUp(0)
     log.debug "close()"
     /*delayBetween([
             zwave.basicV1.basicSet(value: 0x00).format(),
@@ -216,10 +210,8 @@ def setLevel(value, duration = null) {
     Integer level = value as Integer
     if (level < 0) level = 0
     if (level > 99) level = 99
-    delayBetween([
-            zwave.basicV1.basicSet(value: level).format(),
-            zwave.switchMultilevelV1.switchMultilevelGet().format()
-    ])
+    levelChangeFollowUp(level)
+    zwave.basicV1.basicSet(value: level).format()
 }
 
 def presetPosition() {
@@ -246,4 +238,29 @@ def refresh() {
             zwave.switchMultilevelV1.switchMultilevelGet().format(),
             zwave.batteryV1.batteryGet().format()
     ], 1500)
+}
+
+def levelChangeFollowUp(expectedLevel) {
+    state.expectedValue = expectedLevel
+    state.levelChecks = 0
+    runIn(5, "checkLevel")
+}
+
+def checkLevelReport(value) {
+    if (state.expectedValue) {
+        if ((state.expectedValue == 99 && value > 99) ||
+                state.expectedValue == value) {
+            unschedule("checkLevel")
+        }
+    }
+}
+
+def checkLevel() {
+    if (state.levelChecks != null && state.levelChecks < 5) {
+        state.levelChecks += 1
+        runIn(5, "checkLevel")
+        response(zwave.switchMultilevelV1.switchMultilevelGet())
+    } else {
+        unschedule("checkLevel")
+    }
 }

--- a/devicetypes/smartthings/zwave-window-shade.src/zwave-window-shade.groovy
+++ b/devicetypes/smartthings/zwave-window-shade.src/zwave-window-shade.groovy
@@ -257,7 +257,7 @@ def checkLevelReport(value) {
 
 def checkLevel() {
     if (state.levelChecks != null && state.levelChecks < 5) {
-        state.levelChecks += 1
+        state.levelChecks = state.levelChecks + 1
         runIn(5, "checkLevel", [overwrite: true])
         sendHubCommand(zwave.switchMultilevelV1.switchMultilevelGet())
     } else {

--- a/devicetypes/smartthings/zwave-window-shade.src/zwave-window-shade.groovy
+++ b/devicetypes/smartthings/zwave-window-shade.src/zwave-window-shade.groovy
@@ -249,7 +249,7 @@ def levelChangeFollowUp(expectedLevel) {
 def checkLevelReport(value) {
     if (state.expectedValue != null) {
         if ((state.expectedValue == 99 && value >= 99) ||
-                (state.expectedValue >= value - 2 && state.expectedValue <= value + 2 )) {
+                (value >= state.expectedValue - 2 && value <= state.expectedValue + 2)) {
             unschedule("checkLevel")
         }
     }

--- a/devicetypes/smartthings/zwave-window-shade.src/zwave-window-shade.groovy
+++ b/devicetypes/smartthings/zwave-window-shade.src/zwave-window-shade.groovy
@@ -243,7 +243,7 @@ def refresh() {
 def levelChangeFollowUp(expectedLevel) {
     state.expectedValue = expectedLevel
     state.levelChecks = 0
-    runIn(5, "checkLevel")
+    runIn(5, "checkLevel", [overwrite: true])
 }
 
 def checkLevelReport(value) {
@@ -258,7 +258,7 @@ def checkLevelReport(value) {
 def checkLevel() {
     if (state.levelChecks != null && state.levelChecks < 5) {
         state.levelChecks += 1
-        runIn(5, "checkLevel")
+        runIn(5, "checkLevel", [overwrite: true])
         sendHubCommand(zwave.switchMultilevelV1.switchMultilevelGet())
     } else {
         unschedule("checkLevel")

--- a/devicetypes/smartthings/zwave-window-shade.src/zwave-window-shade.groovy
+++ b/devicetypes/smartthings/zwave-window-shade.src/zwave-window-shade.groovy
@@ -247,8 +247,8 @@ def levelChangeFollowUp(expectedLevel) {
 }
 
 def checkLevelReport(value) {
-    if (state.expectedValue) {
-        if ((state.expectedValue == 99 && value > 99) ||
+    if (state.expectedValue != null) {
+        if ((state.expectedValue == 99 && value >= 99) ||
                 state.expectedValue == value) {
             unschedule("checkLevel")
         }

--- a/devicetypes/smartthings/zwave-window-shade.src/zwave-window-shade.groovy
+++ b/devicetypes/smartthings/zwave-window-shade.src/zwave-window-shade.groovy
@@ -259,7 +259,7 @@ def checkLevel() {
     if (state.levelChecks != null && state.levelChecks < 5) {
         state.levelChecks += 1
         runIn(5, "checkLevel")
-        response(zwave.switchMultilevelV1.switchMultilevelGet())
+        sendHubCommand(zwave.switchMultilevelV1.switchMultilevelGet())
     } else {
         unschedule("checkLevel")
     }


### PR DESCRIPTION
…ccurred

We noticed what seems to be a device bug when window shades send us unsolicited battery reports at the same time they are told to open/close. This seems to cause them to send us immediate position updates rather than waiting until the action is completed. This change should send periodic gets until we see the value we want, up to 5 times, or about 25s after the intial command.