### PR TITLE
ICP-12929 Standardize how Fibaro preference default text is created

### DIFF
--- a/devicetypes/fibargroup/fibaro-co-sensor-zw5.src/fibaro-co-sensor-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-co-sensor-zw5.src/fibaro-co-sensor-zw5.groovy
@@ -67,7 +67,7 @@ metadata {
 	}
 
 	preferences {
-		parameterMap().findAll{(it.num as Integer) != 54}.each {
+		parameterMap().each {
 			input (
 					title: "${it.num}. ${it.title}",
 					description: it.descr,
@@ -75,10 +75,12 @@ metadata {
 					element: "paragraph"
 			)
 
+			def defVal = it.def as Integer
+			def descrDefVal = it.options ? it.options.get(defVal) : defVal
 			input (
 					name: it.key,
 					title: null,
-					description: "Default: $it.def" ,
+					description: "$descrDefVal",
 					type: it.type,
 					options: it.options,
 					range: (it.min != null && it.max != null) ? "${it.min}..${it.max}" : null,

--- a/devicetypes/fibargroup/fibaro-door-window-sensor-2.src/fibaro-door-window-sensor-2.groovy
+++ b/devicetypes/fibargroup/fibaro-door-window-sensor-2.src/fibaro-door-window-sensor-2.groovy
@@ -101,7 +101,7 @@ metadata {
 			input (
 				name: it.key,
 				title: null,
-				description: "$DescrDefVal",
+				description: "$descrDefVal",
 				type: it.type,
 				options: it.options,
 				range: (it.min != null && it.max != null) ? "${it.min}..${it.max}" : null,

--- a/devicetypes/fibargroup/fibaro-door-window-sensor-2.src/fibaro-door-window-sensor-2.groovy
+++ b/devicetypes/fibargroup/fibaro-door-window-sensor-2.src/fibaro-door-window-sensor-2.groovy
@@ -89,18 +89,19 @@ metadata {
 			required: false 
 		)
 		
-		parameterMap().findAll{(it.num as Integer) != 54}.each {
+		parameterMap().each {
 			input (
 				title: "${it.num}. ${it.title}",
 				description: it.descr,
 				type: "paragraph",
 				element: "paragraph"
 			)
-			
+			def defVal = it.def as Integer
+			def descrDefVal = it.options ? it.options.get(defVal) : defVal
 			input (
 				name: it.key,
 				title: null,
-				description: "Default: $it.def" ,
+				description: "$DescrDefVal",
 				type: it.type,
 				options: it.options,
 				range: (it.min != null && it.max != null) ? "${it.min}..${it.max}" : null,

--- a/devicetypes/fibargroup/fibaro-double-switch-2-zw5.src/fibaro-double-switch-2-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-double-switch-2-zw5.src/fibaro-double-switch-2-zw5.groovy
@@ -50,11 +50,12 @@ metadata {
 					type: "paragraph",
 					element: "paragraph"
 			)
-
+			def defVal = it.def as Integer
+			def descrDefVal = it.options ? it.options.get(defVal) : defVal
 			input (
 					name: it.key,
 					title: null,
-					description: "Default: $it.def" ,
+					description: "$descrDefVal",
 					type: it.type,
 					options: it.options,
 					range: (it.min != null && it.max != null) ? "${it.min}..${it.max}" : null,

--- a/devicetypes/fibargroup/fibaro-motion-sensor-zw5.src/fibaro-motion-sensor-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-motion-sensor-zw5.src/fibaro-motion-sensor-zw5.groovy
@@ -89,7 +89,7 @@ metadata {
 			type: "paragraph",
 			element: "paragraph"
 		)
-		parameterMap().findAll { (it.num as Integer) != 54 }.each {
+		parameterMap().each {
 			input(
 				title: "${it.num}. ${it.title}",
 				description: it.descr,
@@ -101,7 +101,7 @@ metadata {
 			input(
 				name: it.key,
 				title: null,
-				description: "Default: $descrDefVal",
+				description: "$descrDefVal",
 				type: it.type,
 				options: it.options,
 				range: (it.min != null && it.max != null) ? "${it.min}..${it.max}" : null,

--- a/devicetypes/fibargroup/fibaro-single-switch-2-zw5.src/fibaro-single-switch-2-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-single-switch-2-zw5.src/fibaro-single-switch-2-zw5.groovy
@@ -52,11 +52,12 @@ metadata {
                     type: "paragraph",
                     element: "paragraph"
             )
-
+            def defVal = it.def as Integer
+            def descrDefVal = it.options ? it.options.get(defVal) : defVal
             input (
                     name: it.key,
                     title: null,
-                    description: "Default: $it.def" ,
+                    description: "$descrDefVal",
                     type: it.type,
                     options: it.options,
                     range: (it.min != null && it.max != null) ? "${it.min}..${it.max}" : null,

--- a/devicetypes/fibargroup/fibaro-wall-plug-eu-zw5.src/fibaro-wall-plug-eu-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-wall-plug-eu-zw5.src/fibaro-wall-plug-eu-zw5.groovy
@@ -52,11 +52,12 @@ metadata {
 					type: "paragraph",
 					element: "paragraph"
 			)
-
+			def defVal = it.def as Integer
+			def descrDefVal = it.options ? it.options.get(defVal) : defVal
 			input (
 					name: it.key,
 					title: null,
-					description: "Default: $it.def" ,
+					description: "$descrDefVal",
 					type: it.type,
 					options: it.options,
 					range: (it.min != null && it.max != null) ? "${it.min}..${it.max}" : null,


### PR DESCRIPTION
There was an existing pattern to to print the enum value of a preference rather than the raw enum, so I've just adopted it across all the fibaro DTHs that were using the incorrect method.