### PR TITLE
[ICP-13278] Added preferences for Aeotec Nano Dimmer to adjusting the dimmer level

### DIFF
--- a/devicetypes/smartthings/zwave-metering-dimmer.src/zwave-metering-dimmer.groovy
+++ b/devicetypes/smartthings/zwave-metering-dimmer.src/zwave-metering-dimmer.groovy
@@ -104,7 +104,7 @@ metadata {
 				)
 				input(
 						title: "Set the MIN brightness level (Aeotec Nano Dimmer Only):",
-						description: "Adjust the minimum dimming level. This may be needed for incandescent and non-incandescent bulbs.",
+						description: "This may need to be adjusted for bulbs that are not dimming properly.",
 						name: "minDimmingLevel",
 						type: "number",
 						range: "0..99",
@@ -314,7 +314,6 @@ def getAeotecNanoDimmerConfigurationCommands() {
 		state.configured = false // this flag needs to be set to false when settings are changed (and the device was initially configured before)
 		result << encap(zwave.configurationV1.configurationSet(parameterNumber: 131, size: 1, scaledConfigurationValue: minDimmingLevel))
 		result << encap(zwave.configurationV1.configurationGet(parameterNumber: 131))
-		}
 	}
 
 	return result
@@ -323,7 +322,7 @@ def getAeotecNanoDimmerConfigurationCommands() {
 def zwaveEvent(physicalgraph.zwave.commands.configurationv1.ConfigurationReport cmd) {
 	if (isAeotecNanoDimmer()) {
 		if (cmd.parameterNumber == 131) {
-			state.minDimmingLevel = scaledConfigurationValue
+			state.minDimmingLevel = cmd.scaledConfigurationValue
 			state.configured = true
 		}
 

--- a/devicetypes/smartthings/zwave-metering-dimmer.src/zwave-metering-dimmer.groovy
+++ b/devicetypes/smartthings/zwave-metering-dimmer.src/zwave-metering-dimmer.groovy
@@ -264,14 +264,14 @@ def setLevel(level, rate = null) {
 def configure() {
 	log.debug "configure()"
 
+	def result = []
+
 	if (isAeotecNanoDimmer()) {
 		state.configured = false
-		state.minDimmingLevel = false
-		state.maxDimmingLevel = false
-		response(getAeotecNanoDimmerConfigurationCommands())
+		state.minLevelConfigured = false
+		state.maxLevelConfigured = false
+		result << response(getAeotecNanoDimmerConfigurationCommands())
 	}
-
-	def result = []
 
 	log.debug "Configure zwaveInfo: "+zwaveInfo
 
@@ -314,21 +314,21 @@ def normalizeLevel(level) {
 
 def getAeotecNanoDimmerDefaults() {
 	[
-		min: 0,
-		max: 99
+		"min": 0,
+		"max": 99
 	]
 }
 
 def getAeotecNanoDimmerConfigurationCommands() {
 	def result = []
-	Integer minDimmingLevel = (settings.minDimmingLevel as Integer) ?: aeotecNanoDimmerDefaults[min]
-	Integer maxDimmingLevel = (settings.maxDimmingLevel as Integer) ?: aeotecNanoDimmerDefaults[max]
+	Integer minDimmingLevel = (settings.minDimmingLevel as Integer) ?: aeotecNanoDimmerDefaults["min"]
+	Integer maxDimmingLevel = (settings.maxDimmingLevel as Integer) ?: aeotecNanoDimmerDefaults["max"]
 
 	if (!state.minDimmingLevel) {
-		state.minDimmingLevel = aeotecNanoDimmerDefaults[min]
+		state.minDimmingLevel = aeotecNanoDimmerDefaults["min"]
 	}
 	if (!state.maxDimmingLevel) {
-		state.maxDimmingLevel = aeotecNanoDimmerDefaults[max]
+		state.maxDimmingLevel = aeotecNanoDimmerDefaults["max"]
 	}
 
 	if (!state.configured || (minDimmingLevel != state.minDimmingLevel || maxDimmingLevel != state.maxDimmingLevel)) {

--- a/devicetypes/smartthings/zwave-metering-dimmer.src/zwave-metering-dimmer.groovy
+++ b/devicetypes/smartthings/zwave-metering-dimmer.src/zwave-metering-dimmer.groovy
@@ -141,12 +141,14 @@ def updated() {
 	// Device-Watch simply pings if no device events received for 32min(checkInterval)
 	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 
-	def additionalCmds = []
+	def results = []
+	results << refresh()
+
 	if (isAeotecNanoDimmer()) {
-		additionalCmds = getConfigurationCommands()
+		results << getConfigurationCommands()
 	}
 
-	response([refresh(), additionalCmds].flatten())
+	response(results)
 }
 
 // parse events into attributes
@@ -311,21 +313,22 @@ def normalizeLevel(level) {
 }
 
 def getAeotecNanoDimmerDefaults() {
-	[1:0,
-	2:99
+	[
+		min: 0,
+		max: 99
 	]
 }
 
 def getConfigurationCommands() {
 	def result = []
-	Integer minDimmingLevel = (settings.minDimmingLevel as Integer) ?: aeotecNanoDimmerDefaults[1]
-	Integer maxDimmingLevel = (settings.maxDimmingLevel as Integer) ?: aeotecNanoDimmerDefaults[2]
+	Integer minDimmingLevel = (settings.minDimmingLevel as Integer) ?: aeotecNanoDimmerDefaults[min]
+	Integer maxDimmingLevel = (settings.maxDimmingLevel as Integer) ?: aeotecNanoDimmerDefaults[max]
 
 	if (!state.minDimmingLevel) {
-		state.minDimmingLevel = aeotecNanoDimmerDefaults[1]
+		state.minDimmingLevel = aeotecNanoDimmerDefaults[min]
 	}
 	if (!state.maxDimmingLevel) {
-		state.maxDimmingLevel = aeotecNanoDimmerDefaults[2]
+		state.maxDimmingLevel = aeotecNanoDimmerDefaults[max]
 	}
 
 	if (!state.configured || (minDimmingLevel != state.minDimmingLevel || maxDimmingLevel != state.maxDimmingLevel)) {

--- a/devicetypes/smartthings/zwave-metering-dimmer.src/zwave-metering-dimmer.groovy
+++ b/devicetypes/smartthings/zwave-metering-dimmer.src/zwave-metering-dimmer.groovy
@@ -145,7 +145,7 @@ def updated() {
 	results << refresh()
 
 	if (isAeotecNanoDimmer()) {
-		results << getConfigurationCommands()
+		results << getAeotecNanoDimmerConfigurationCommands()
 	}
 
 	response(results)
@@ -268,7 +268,7 @@ def configure() {
 		state.configured = false
 		state.minDimmingLevel = false
 		state.maxDimmingLevel = false
-		response(getConfigurationCommands())
+		response(getAeotecNanoDimmerConfigurationCommands())
 	}
 
 	def result = []
@@ -319,7 +319,7 @@ def getAeotecNanoDimmerDefaults() {
 	]
 }
 
-def getConfigurationCommands() {
+def getAeotecNanoDimmerConfigurationCommands() {
 	def result = []
 	Integer minDimmingLevel = (settings.minDimmingLevel as Integer) ?: aeotecNanoDimmerDefaults[min]
 	Integer maxDimmingLevel = (settings.maxDimmingLevel as Integer) ?: aeotecNanoDimmerDefaults[max]


### PR DESCRIPTION
@greens @dkirker @tpmanley could you please take a look at the code?

We need to make available these two parameters for the users because the output for different bulbs may need higher minimum settings - it was our case in SRPOL office.

@KKlimczukS @PKacprowiczS @MGoralczykS @MWierzbinskaS @BJanuszS 