### PR TITLE
[ICP-13322, ICP-13326, ICP-13336, ICP-13345, ICP-13346, ICP-13355] - fixes for Qubino Dimmers

### DIFF
--- a/devicetypes/qubino/qubino-dimmer.src/qubino-dimmer.groovy
+++ b/devicetypes/qubino/qubino-dimmer.src/qubino-dimmer.groovy
@@ -167,13 +167,13 @@ def excludeParameterFromSync(preference){
 	return exclude
 }
 
-private readConfigurationFromTheDevice() {
+private getReadConfigurationFromTheDeviceCommands() {
 	def commands = []
 	parameterMap.each {
 		state.currentPreferencesState."$it.key".status = "reverseSyncPending"
 		commands += zwave.configurationV2.configurationGet(parameterNumber: it.parameterNumber)
 	}
-	sendHubCommand(encapCommands(commands))
+	commands
 }
 
 private syncConfiguration() {
@@ -240,6 +240,7 @@ def configure() {
 	// Still, for users it will relatively be 1-100% on the UI and device will report it.
 	// Parameter no. 60 – Minimum dimming value
 	commands << zwave.configurationV2.configurationSet(scaledConfigurationValue: 2, parameterNumber: 60, size: 1)
+	commands + getReadConfigurationFromTheDeviceCommands()
 
 	encapCommands(commands)
 }

--- a/devicetypes/qubino/qubino-dimmer.src/qubino-dimmer.groovy
+++ b/devicetypes/qubino/qubino-dimmer.src/qubino-dimmer.groovy
@@ -582,11 +582,9 @@ private getParameterMap() {[
 		values: [
 			0: "Default value - Mono-stable switch type (push button) – button quick press turns between previous set dimmer value and zero)",
 			1: "Bi-stable switch type (on/off toggle switch)",
-			2: "Potentiometer (applies to Flush Dimmer 0-10V only, dimmer is using set value the last received from potentiometer or from z-wave controller)",
-			3: "0-10V Temperature sensor (regulated output, applies to Flush Dimmer 0-10V only)"
+			2: "Potentiometer (applies to Flush Dimmer 0-10V only, dimmer is using set value the last received from potentiometer or from z-wave controller)"
 		],
-		description: "Set input based on device type (switch, potentiometer, temperature sensor,..)." +
-			"After parameter change to value 3 first exclude module (without setting parameters to default value) then wait at least 30s and then re include the module! "
+		description: "Set input based on device type (mono-stable switch, bi-stable switch, potentiometer)."
 	],
 	[
 			name: "Input 2 switch type (applies to Qubino Flush Dimmer only)", key: "inputsSwitchTypes", type: "enum",

--- a/devicetypes/qubino/qubino-dimmer.src/qubino-dimmer.groovy
+++ b/devicetypes/qubino/qubino-dimmer.src/qubino-dimmer.groovy
@@ -490,6 +490,11 @@ def setLevel(value, duration = null) {
 	commands << zwave.switchMultilevelV3.switchMultilevelSet(value: level, dimmingDuration: dimmingDuration)
 	commands << zwave.switchMultilevelV3.switchMultilevelGet()
 
+	if(supportsPowerMeter()){
+		commands << zwave.meterV2.meterGet(scale: 0)
+		commands << zwave.meterV2.meterGet(scale: 2)
+	}
+
 	encapCommands(commands, getStatusDelay)
 }
 

--- a/devicetypes/qubino/qubino-dimmer.src/qubino-dimmer.groovy
+++ b/devicetypes/qubino/qubino-dimmer.src/qubino-dimmer.groovy
@@ -122,7 +122,6 @@ def installed() {
 		state.currentPreferencesState."$it.key".value = getPreferenceValue(it)
 		state.currentPreferencesState."$it.key".status = "synced"
 	}
-	readConfigurationFromTheDevice()
 	// Preferences template end
 }
 
@@ -232,7 +231,7 @@ def configure() {
 	commands << zwave.associationV1.associationSet(groupingIdentifier:5, nodeId:[zwaveHubNodeId])
 	commands << zwave.associationV1.associationSet(groupingIdentifier:6, nodeId:[zwaveHubNodeId])
 	commands << zwave.multiChannelV3.multiChannelEndPointGet()
-	commands + getRefreshCommands()
+	commands += getRefreshCommands()
 
 	// 1% is default Minimum dimming value for dimmers,
 	// when device is set to 1% - it turns off and device does not send any level reports
@@ -240,7 +239,7 @@ def configure() {
 	// Still, for users it will relatively be 1-100% on the UI and device will report it.
 	// Parameter no. 60 – Minimum dimming value
 	commands << zwave.configurationV2.configurationSet(scaledConfigurationValue: 2, parameterNumber: 60, size: 1)
-	commands + getReadConfigurationFromTheDeviceCommands()
+	commands += getReadConfigurationFromTheDeviceCommands()
 
 	encapCommands(commands)
 }

--- a/devicetypes/qubino/qubino-dimmer.src/qubino-dimmer.groovy
+++ b/devicetypes/qubino/qubino-dimmer.src/qubino-dimmer.groovy
@@ -114,7 +114,7 @@ private getINPUT_TYPE_TEMPERATURE_SENSOR() {3}
 def installed() {
 	// Device-Watch simply pings if no device events received for 32min(checkInterval)
 	sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
-	setInitialConfiguration()
+
 	// Preferences template begin
 	state.currentPreferencesState = [:]
 	parameterMap.each {
@@ -176,19 +176,6 @@ private readConfigurationFromTheDevice() {
 	sendHubCommand(encapCommands(commands))
 }
 
-private setInitialConfiguration() {
-	// 1% is default Minimum dimming value for dimmers,
-	// when device is set to 1% - it turns off and device does not send any level reports
-	// Minimum dimming value has to be set to 2%, so the device's internal range would be 2-100%
-	// Still, for users it will relatively be 1-100% on the UI and device will report it.
-
-	def commands = []
-	// Parameter no. 60 – Minimum dimming value
-	commands << zwave.configurationV2.configurationSet(scaledConfigurationValue: 2, parameterNumber: 60, size: 1)
-
-	sendHubCommand(encapCommands(commands))
-}
-
 private syncConfiguration() {
 	def commands = []
 	parameterMap.each {
@@ -246,6 +233,13 @@ def configure() {
 	commands << zwave.associationV1.associationSet(groupingIdentifier:6, nodeId:[zwaveHubNodeId])
 	commands << zwave.multiChannelV3.multiChannelEndPointGet()
 	commands + getRefreshCommands()
+
+	// 1% is default Minimum dimming value for dimmers,
+	// when device is set to 1% - it turns off and device does not send any level reports
+	// Minimum dimming value has to be set to 2%, so the device's internal range would be 2-100%
+	// Still, for users it will relatively be 1-100% on the UI and device will report it.
+	// Parameter no. 60 – Minimum dimming value
+	commands << zwave.configurationV2.configurationSet(scaledConfigurationValue: 2, parameterNumber: 60, size: 1)
 
 	encapCommands(commands)
 }


### PR DESCRIPTION
**ICP-13322, ICP-13355:**

1% is default Minimum dimming value for dimmers,
When device is set to 1% - it turns off and device does not send any level reports
Minimum dimming value has to be set to 2%, so the device's internal range would be 2-100%
Still, for users it will relatively be 1-100% on the UI and device will report it.

**ICP-13326:**
It turned out that response(zwave.switchMultilevelV3.switchMultilevelGet()) didn't work properly in that case. 
Switched to sendHubCommand(encap(zwave.switchMultilevelV3.switchMultilevelGet())).

**ICP-13336**
Removed option 3, because it does not apply to Qubino Temperature Sensor ZMNHEA1.

**ICP-13345, ICP-13346**
Added meterGet calls after switchMultilevel commands.

@greens @dkirker Please, could You take a look at the code ?

cc: @MWierzbinskaS @ZWozniakS @PKacprowiczS @BJanuszS @MGoralczykS 