### PR TITLE
CHAD-5280 Cap number of battery queries

### DIFF
--- a/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
+++ b/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
@@ -697,7 +697,7 @@ private queryBattery() {
 	if ((!state.lastbatt || now() - state.lastbatt > 10*1000) && (state.batteryQueries != null && state.batteryQueries < 5)) {
 		log.debug "It's been more than 10s since battery was updated after a replacement. Querying battery."
 		runIn(10, "queryBattery", [overwrite: true, forceForLocallyExecuting: true])
-		state.batteryQueries += 1
+		state.batteryQueries = state.batteryQueries + 1
 		sendHubCommand(secure(zwave.batteryV1.batteryGet()))
 	}
 }

--- a/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
+++ b/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
@@ -695,7 +695,7 @@ private Boolean secondsPast(timestamp, seconds) {
 private queryBattery() {
 	log.debug "Running queryBattery"
 	if (state.batteryQueries == null) state.batteryQueries = 0
-	if ((!state.lastbatt || now() - state.lastbatt > 10*1000) && (state.batteryQueries != null && state.batteryQueries < 5)) {
+	if ((!state.lastbatt || now() - state.lastbatt > 10*1000) && state.batteryQueries < 5) {
 		log.debug "It's been more than 10s since battery was updated after a replacement. Querying battery."
 		runIn(10, "queryBattery", [overwrite: true, forceForLocallyExecuting: true])
 		state.batteryQueries = state.batteryQueries + 1

--- a/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
+++ b/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
@@ -694,6 +694,7 @@ private Boolean secondsPast(timestamp, seconds) {
 
 private queryBattery() {
 	log.debug "Running queryBattery"
+	if (state.batteryQueries == null) state.batteryQueries = 0
 	if ((!state.lastbatt || now() - state.lastbatt > 10*1000) && (state.batteryQueries != null && state.batteryQueries < 5)) {
 		log.debug "It's been more than 10s since battery was updated after a replacement. Querying battery."
 		runIn(10, "queryBattery", [overwrite: true, forceForLocallyExecuting: true])

--- a/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
+++ b/devicetypes/smartthings/zwave-lock-without-codes.src/zwave-lock-without-codes.groovy
@@ -408,6 +408,7 @@ private def handleBatteryAlarmReport(cmd) {
 		case 0x01: //power has been applied, check if the battery level updated
 			log.debug "Batteries replaced. Queueing a battery get."
 			runIn(10, "queryBattery", [overwrite: true, forceForLocallyExecuting: true])
+			state.batteryQueries = 0
 			result << response(secure(zwave.batteryV1.batteryGet()))
 			break;
 		case 0x0A:
@@ -693,9 +694,10 @@ private Boolean secondsPast(timestamp, seconds) {
 
 private queryBattery() {
 	log.debug "Running queryBattery"
-	if (!state.lastbatt || now() - state.lastbatt > 10*1000) {
+	if ((!state.lastbatt || now() - state.lastbatt > 10*1000) && (state.batteryQueries != null && state.batteryQueries < 5)) {
 		log.debug "It's been more than 10s since battery was updated after a replacement. Querying battery."
 		runIn(10, "queryBattery", [overwrite: true, forceForLocallyExecuting: true])
+		state.batteryQueries += 1
 		sendHubCommand(secure(zwave.batteryV1.batteryGet()))
 	}
 }

--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -635,6 +635,7 @@ private def handleBatteryAlarmReport(cmd) {
 		case 0x01: //power has been applied, check if the battery level updated
 			log.debug "Batteries replaced. Queueing a battery get."
 			runIn(10, "queryBattery", [overwrite: true, forceForLocallyExecuting: true])
+			state.batteryQueries = 0
 			result << response(secure(zwave.batteryV1.batteryGet()))
 			break;
 		case 0x0A:
@@ -774,6 +775,7 @@ private def handleAlarmReportUsingAlarmType(cmd) {
 			map = [ descriptionText: "Batteries replaced", isStateChange: true ]
 			log.debug "Batteries replaced. Queueing a battery check."
 			runIn(10, "queryBattery", [overwrite: true, forceForLocallyExecuting: true])
+			state.batteryQueries = 0
 			result << response(secure(zwave.batteryV1.batteryGet()))
 			break
 		case 131: // Disabled user entered at keypad
@@ -1809,9 +1811,10 @@ def readCodeSlotId(physicalgraph.zwave.commands.alarmv2.AlarmReport cmd) {
 
 private queryBattery() {
 	log.debug "Running queryBattery"
-	if (!state.lastbatt || now() - state.lastbatt > 10*1000) {
+	if ((!state.lastbatt || now() - state.lastbatt > 10*1000) && (state.batteryQueries != null && state.batteryQueries < 5)) {
 		log.debug "It's been more than 10s since battery was updated after a replacement. Querying battery."
 		runIn(10, "queryBattery", [overwrite: true, forceForLocallyExecuting: true])
+		state.batteryQueries += 1
 		sendHubCommand(secure(zwave.batteryV1.batteryGet()))
 	}
 }

--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -1814,7 +1814,7 @@ private queryBattery() {
 	if ((!state.lastbatt || now() - state.lastbatt > 10*1000) && (state.batteryQueries != null && state.batteryQueries < 5)) {
 		log.debug "It's been more than 10s since battery was updated after a replacement. Querying battery."
 		runIn(10, "queryBattery", [overwrite: true, forceForLocallyExecuting: true])
-		state.batteryQueries += 1
+		state.batteryQueries = state.batteryQueries + 1
 		sendHubCommand(secure(zwave.batteryV1.batteryGet()))
 	}
 }

--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -1812,7 +1812,7 @@ def readCodeSlotId(physicalgraph.zwave.commands.alarmv2.AlarmReport cmd) {
 private queryBattery() {
 	log.debug "Running queryBattery"
 	if (state.batteryQueries == null) state.batteryQueries = 0
-	if ((!state.lastbatt || now() - state.lastbatt > 10*1000) && null && state.batteryQueries < 5) {
+	if ((!state.lastbatt || now() - state.lastbatt > 10*1000) && state.batteryQueries < 5) {
 		log.debug "It's been more than 10s since battery was updated after a replacement. Querying battery."
 		runIn(10, "queryBattery", [overwrite: true, forceForLocallyExecuting: true])
 		state.batteryQueries = state.batteryQueries + 1

--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -1811,7 +1811,8 @@ def readCodeSlotId(physicalgraph.zwave.commands.alarmv2.AlarmReport cmd) {
 
 private queryBattery() {
 	log.debug "Running queryBattery"
-	if ((!state.lastbatt || now() - state.lastbatt > 10*1000) && (state.batteryQueries != null && state.batteryQueries < 5)) {
+	if (state.batteryQueries == null) state.batteryQueries = 0
+	if ((!state.lastbatt || now() - state.lastbatt > 10*1000) && null && state.batteryQueries < 5) {
 		log.debug "It's been more than 10s since battery was updated after a replacement. Querying battery."
 		runIn(10, "queryBattery", [overwrite: true, forceForLocallyExecuting: true])
 		state.batteryQueries = state.batteryQueries + 1


### PR DESCRIPTION
Locks will query for battery state after a battery replace event, but in some cases, the lock will go offline before responding resulting in an infinite loop of querying the battery, which can clog the z-wave message queue.