### PR TITLE
ICP-13140 For IKEA blinds return the current state of the blinds when pause is called if the blinds are not moving

### DIFF
--- a/devicetypes/smartthings/zigbee-window-shade-battery.src/zigbee-window-shade-battery.groovy
+++ b/devicetypes/smartthings/zigbee-window-shade-battery.src/zigbee-window-shade-battery.groovy
@@ -189,7 +189,12 @@ def setLevel(data, rate = null) {
 
 def pause() {
 	log.info "pause()"
-	zigbee.command(CLUSTER_WINDOW_COVERING, COMMAND_PAUSE)
+	// If the window shade isn't moving when we receive a pause() command then just echo back the current state for the mobile client.
+	if (device.currentValue("windowShade") != "opening" && device.currentValue("windowShade") != "closing") {
+		sendEvent(name: "windowShade", value: device.currentValue("windowShade"), isStateChange: true, display: false)
+	} else {
+		zigbee.command(CLUSTER_WINDOW_COVERING, COMMAND_PAUSE)
+	}
 }
 
 def presetPosition() {

--- a/devicetypes/smartthings/zigbee-window-shade-battery.src/zigbee-window-shade-battery.groovy
+++ b/devicetypes/smartthings/zigbee-window-shade-battery.src/zigbee-window-shade-battery.groovy
@@ -192,9 +192,8 @@ def pause() {
 	// If the window shade isn't moving when we receive a pause() command then just echo back the current state for the mobile client.
 	if (device.currentValue("windowShade") != "opening" && device.currentValue("windowShade") != "closing") {
 		sendEvent(name: "windowShade", value: device.currentValue("windowShade"), isStateChange: true, display: false)
-	} else {
-		zigbee.command(CLUSTER_WINDOW_COVERING, COMMAND_PAUSE)
 	}
+	zigbee.command(CLUSTER_WINDOW_COVERING, COMMAND_PAUSE)
 }
 
 def presetPosition() {

--- a/devicetypes/smartthings/zigbee-window-shade-battery.src/zigbee-window-shade-battery.groovy
+++ b/devicetypes/smartthings/zigbee-window-shade-battery.src/zigbee-window-shade-battery.groovy
@@ -191,7 +191,7 @@ def pause() {
 	log.info "pause()"
 	// If the window shade isn't moving when we receive a pause() command then just echo back the current state for the mobile client.
 	if (device.currentValue("windowShade") != "opening" && device.currentValue("windowShade") != "closing") {
-		sendEvent(name: "windowShade", value: device.currentValue("windowShade"), isStateChange: true, display: false)
+		sendEvent(name: "windowShade", value: device.currentValue("windowShade"), isStateChange: true, displayed: false)
 	}
 	zigbee.command(CLUSTER_WINDOW_COVERING, COMMAND_PAUSE)
 }


### PR DESCRIPTION
The mobile client expects a response so if `pause()` is called but the blinds aren't moving (and likely to not reply to the command) then send the current state to prevent a network error dialog.