### PR TITLE
CHAD-5256 Hotfix to update child DNIs of zigbee-multi-switch

### DIFF
--- a/devicetypes/smartthings/zigbee-multi-switch.src/zigbee-multi-switch.groovy
+++ b/devicetypes/smartthings/zigbee-multi-switch.src/zigbee-multi-switch.groovy
@@ -87,8 +87,8 @@ def updated() {
 	log.debug "updated()"
 	updateDataValue("onOff", "catchall")
 	for (child in childDevices) {
-		if (!child.deviceNetworkId.startsWith(device.deviceNetworkId) ||
-				!child.deviceNetworkId.split(':')[-1].startsWith('0')) { //parent DNI has changed after rejoin
+		if (!child.deviceNetworkId.startsWith(device.deviceNetworkId) || //parent DNI has changed after rejoin
+				!child.deviceNetworkId.split(':')[-1].startsWith('0')) {
 			child.setDeviceNetworkId("${device.deviceNetworkId}:0${getChildEndpoint(child.deviceNetworkId)}")
 		}
 	}
@@ -124,10 +124,12 @@ def parse(String description) {
 }
 
 private void createChildDevices() {
-	def x = getChildCount()
-	for (i in 2..x) {
-		addChildDevice("Child Switch Health", "${device.deviceNetworkId}:0${i}", device.hubId,
-			[completedSetup: true, label: "${device.displayName[0..-2]}${i}", isComponent: false])
+	if (!childDevices) {
+		def x = getChildCount()
+		for (i in 2..x) {
+			addChildDevice("Child Switch Health", "${device.deviceNetworkId}:0${i}", device.hubId,
+				[completedSetup: true, label: "${device.displayName[0..-2]}${i}", isComponent: false])
+		}
 	}
 }
 

--- a/devicetypes/smartthings/zigbee-multi-switch.src/zigbee-multi-switch.groovy
+++ b/devicetypes/smartthings/zigbee-multi-switch.src/zigbee-multi-switch.groovy
@@ -88,7 +88,7 @@ def updated() {
 	updateDataValue("onOff", "catchall")
 	for (child in childDevices) {
 		if (!child.deviceNetworkId.startsWith(device.deviceNetworkId)) { //parent DNI has changed after rejoin
-			child.setDeviceNetworkId("${device.deviceNetworkId}:${getChildEndpoint(child.deviceNetworkId)}")
+			child.setDeviceNetworkId("${device.deviceNetworkId}:0${getChildEndpoint(child.deviceNetworkId)}")
 		}
 	}
 	refresh()
@@ -125,7 +125,7 @@ def parse(String description) {
 private void createChildDevices() {
 	def x = getChildCount()
 	for (i in 2..x) {
-		addChildDevice("Child Switch Health", "${device.deviceNetworkId}:${i}", device.hubId,
+		addChildDevice("Child Switch Health", "${device.deviceNetworkId}:0${i}", device.hubId,
 			[completedSetup: true, label: "${device.displayName[0..-2]}${i}", isComponent: false])
 	}
 }

--- a/devicetypes/smartthings/zigbee-multi-switch.src/zigbee-multi-switch.groovy
+++ b/devicetypes/smartthings/zigbee-multi-switch.src/zigbee-multi-switch.groovy
@@ -87,7 +87,8 @@ def updated() {
 	log.debug "updated()"
 	updateDataValue("onOff", "catchall")
 	for (child in childDevices) {
-		if (!child.deviceNetworkId.startsWith(device.deviceNetworkId)) { //parent DNI has changed after rejoin
+		if (!child.deviceNetworkId.startsWith(device.deviceNetworkId) ||
+				!child.deviceNetworkId.split(':')[-1].startsWith('0')) { //parent DNI has changed after rejoin
 			child.setDeviceNetworkId("${device.deviceNetworkId}:0${getChildEndpoint(child.deviceNetworkId)}")
 		}
 	}


### PR DESCRIPTION
There was more code using the leading 0 of child devices than I first noticed, so the leading zero in the child DNI has simply been re-added.