### PR TITLE
CHAD-5256 Hotfix to update child DNIs of zigbee-multi-switch (#38146)

### DIFF
--- a/devicetypes/smartthings/zigbee-multi-switch.src/zigbee-multi-switch.groovy
+++ b/devicetypes/smartthings/zigbee-multi-switch.src/zigbee-multi-switch.groovy
@@ -95,8 +95,9 @@ def updated() {
 	log.debug "updated()"
 	updateDataValue("onOff", "catchall")
 	for (child in childDevices) {
-		if (!child.deviceNetworkId.startsWith(device.deviceNetworkId)) { //parent DNI has changed after rejoin
-			child.setDeviceNetworkId("${device.deviceNetworkId}:${getChildEndpoint(child.deviceNetworkId)}")
+		if (!child.deviceNetworkId.startsWith(device.deviceNetworkId) || //parent DNI has changed after rejoin
+				!child.deviceNetworkId.split(':')[-1].startsWith('0')) {
+			child.setDeviceNetworkId("${device.deviceNetworkId}:0${getChildEndpoint(child.deviceNetworkId)}")
 		}
 	}
 	refresh()
@@ -131,10 +132,12 @@ def parse(String description) {
 }
 
 private void createChildDevices() {
-	def x = getChildCount()
-	for (i in 2..x) {
-		addChildDevice("Child Switch Health", "${device.deviceNetworkId}:${i}", device.hubId,
-			[completedSetup: true, label: "${device.displayName[0..-2]}${i}", isComponent: false])
+	if (!childDevices) {
+		def x = getChildCount()
+		for (i in 2..x) {
+			addChildDevice("Child Switch Health", "${device.deviceNetworkId}:0${i}", device.hubId,
+				[completedSetup: true, label: "${device.displayName[0..-2]}${i}", isComponent: false])
+		}
 	}
 }
 


### PR DESCRIPTION
* CHAD-5256 change re-addressing code

There was more code using the leading 0 of child devices than I first noticed, so the leading zero in the child DNI has simply been re-added.

* adds a fix for devices that were migrated while this bug was active.

* add code to avoid a bug encountered if installed and updated are called in succession