### PR TITLE
ICP-13200 - longer delay between BasicSet and BasicGet commands

### DIFF
--- a/devicetypes/fibargroup/fibaro-walli-double-switch.src/fibaro-walli-double-switch.groovy
+++ b/devicetypes/fibargroup/fibaro-walli-double-switch.src/fibaro-walli-double-switch.groovy
@@ -346,7 +346,7 @@ private onOffCmd(value, endpoint = 1) {
 	delayBetween([
 		encap(zwave.basicV1.basicSet(value: value), endpoint),
 		encap(zwave.basicV1.basicGet(), endpoint)
-	])
+	], 1000)
 }
 
 private refreshAll(includeMeterGet = true) {


### PR DESCRIPTION
ICP-13200 - added longer delay between BasicSet and BasicGet commands.

@greens @dkirker Please, could You take a look at the code ?

@SmartThingsCommunity/srpol-pe-team @BJanuszS 