### PR TITLE
CHAD-5355 Zigbee lock event de-duplication

### DIFF
--- a/devicetypes/smartthings/zigbee-lock-without-codes.src/zigbee-lock-without-codes.groovy
+++ b/devicetypes/smartthings/zigbee-lock-without-codes.src/zigbee-lock-without-codes.groovy
@@ -212,6 +212,7 @@ private def parseAttributeResponse(String description) {
 				If we don't get one, then it's okay to send. If we send the event with more info first, the event
 				with less info will be marked as not displayed
 			 */
+            log.debug "Lock attribute report received: ${responseMap.value}. Delaying event."
 			runIn(1, "delayLockEvent", [data : [map : responseMap]])
 			return [:]
 		}

--- a/devicetypes/smartthings/zigbee-lock-without-codes.src/zigbee-lock-without-codes.groovy
+++ b/devicetypes/smartthings/zigbee-lock-without-codes.src/zigbee-lock-without-codes.groovy
@@ -212,7 +212,7 @@ private def parseAttributeResponse(String description) {
 				If we don't get one, then it's okay to send. If we send the event with more info first, the event
 				with less info will be marked as not displayed
 			 */
-            log.debug "Lock attribute report received: ${responseMap.value}. Delaying event."
+			log.debug "Lock attribute report received: ${responseMap.value}. Delaying event."
 			runIn(1, "delayLockEvent", [data : [map : responseMap]])
 			return [:]
 		}

--- a/devicetypes/smartthings/zigbee-lock-without-codes.src/zigbee-lock-without-codes.groovy
+++ b/devicetypes/smartthings/zigbee-lock-without-codes.src/zigbee-lock-without-codes.groovy
@@ -207,11 +207,27 @@ private def parseAttributeResponse(String description) {
 			responseMap.value = "unknown"
 			responseMap.descriptionText = "Unknown state"
 		}
+		if (responseMap.value &&
+				device.currentValue("lock") &&
+				device.currentValue("lock") != responseMap.value) {
+			/* if this event indicates a state change (and we haven't gotten an operation event yet), delay
+				it for a second in the hopes that we get the operation event (which has more info). If we don't get
+				one, then it's okay to send. If we send the event with more info first, the event with less info
+				will be marked as not displayed
+			 */
+			runIn(1, "delayLockEvent", [data : [map : responseMap]])
+			return [:]
+		}
 	} else {
 		return null
 	}
 	result << createEvent(responseMap)
 	return result
+}
+
+def delayLockEvent(data) {
+	log.debug "Sending cached lock operation: $data.map"
+	sendEvent(data.map)
 }
 
 private def parseIasMessage(String description) {

--- a/devicetypes/smartthings/zigbee-lock-without-codes.src/zigbee-lock-without-codes.groovy
+++ b/devicetypes/smartthings/zigbee-lock-without-codes.src/zigbee-lock-without-codes.groovy
@@ -224,7 +224,7 @@ private def parseAttributeResponse(String description) {
 }
 
 def delayLockEvent(data) {
-	log.debug "Sending cached lock operation: $data.map"
+	log.debug "Sending cached lock operation: ${data.map}"
 	sendEvent(data.map)
 }
 

--- a/devicetypes/smartthings/zigbee-lock-without-codes.src/zigbee-lock-without-codes.groovy
+++ b/devicetypes/smartthings/zigbee-lock-without-codes.src/zigbee-lock-without-codes.groovy
@@ -207,13 +207,10 @@ private def parseAttributeResponse(String description) {
 			responseMap.value = "unknown"
 			responseMap.descriptionText = "Unknown state"
 		}
-		if (responseMap.value &&
-				device.currentValue("lock") &&
-				device.currentValue("lock") != responseMap.value) {
-			/* if this event indicates a state change (and we haven't gotten an operation event yet), delay
-				it for a second in the hopes that we get the operation event (which has more info). If we don't get
-				one, then it's okay to send. If we send the event with more info first, the event with less info
-				will be marked as not displayed
+		if (responseMap.value) {
+			/*  delay this event for a second in the hopes that we get the operation event (which has more info).
+				If we don't get one, then it's okay to send. If we send the event with more info first, the event
+				with less info will be marked as not displayed
 			 */
 			runIn(1, "delayLockEvent", [data : [map : responseMap]])
 			return [:]

--- a/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
+++ b/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
@@ -493,13 +493,10 @@ private def parseAttributeResponse(String description) {
 			responseMap.value = "unknown"
 			responseMap.descriptionText = "Unknown state"
 		}
-		if (responseMap.value &&
-				device.currentValue("lock") &&
-				device.currentValue("lock") != responseMap.value) {
-			/* if this event indicates a state change (and we haven't gotten an operation event yet), delay
-				it for a second in the hopes that we get the operation event (which has more info). If we don't get
-				one, then it's okay to send. If we send the event with more info first, the event with less info
-				will be marked as not displayed
+		if (responseMap.value) {
+			/*  delay this event for a second in the hopes that we get the operation event (which has more info).
+				If we don't get one, then it's okay to send. If we send the event with more info first, the event
+				with less info will be marked as not displayed
 			 */
 			runIn(1, "delayLockEvent", [data : [map : responseMap]])
 			return [:]

--- a/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
+++ b/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
@@ -527,7 +527,7 @@ private def parseAttributeResponse(String description) {
 }
 
 def delayLockEvent(data) {
-	log.debug "Sending cached lock operation: $data.map"
+	log.debug "Sending cached lock operation: ${data.map}"
 	sendEvent(data.map)
 }
 

--- a/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
+++ b/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
@@ -493,6 +493,17 @@ private def parseAttributeResponse(String description) {
 			responseMap.value = "unknown"
 			responseMap.descriptionText = "Unknown state"
 		}
+		if (responseMap.value &&
+				device.currentValue("lock") &&
+				device.currentValue("lock") != responseMap.value) {
+			/* if this event indicates a state change (and we haven't gotten an operation event yet), delay
+				it for a second in the hopes that we get the operation event (which has more info). If we don't get
+				one, then it's okay to send. If we send the event with more info first, the event with less info
+				will be marked as not displayed
+			 */
+			runIn(1, "delayLockEvent", [data : [map : responseMap]])
+			return [:]
+		}
 	} else if (clusterInt == CLUSTER_DOORLOCK && attrInt == DOORLOCK_ATTR_MIN_PIN_LENGTH && descMap.value) {
 		def minCodeLength = Integer.parseInt(descMap.value, 16)
 		responseMap = [name: "minCodeLength", value: minCodeLength, descriptionText: "Minimum PIN length is ${minCodeLength}", displayed: false]
@@ -515,6 +526,11 @@ private def parseAttributeResponse(String description) {
 	result << createEvent(responseMap)
 	log.info "ZigBee DTH - parseAttributeResponse() returning with result:- $result"
 	return result
+}
+
+def delayLockEvent(data) {
+	log.debug "Sending cached lock operation: $data.map"
+	sendEvent(data.map)
 }
 
 /**

--- a/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
+++ b/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
@@ -498,6 +498,7 @@ private def parseAttributeResponse(String description) {
 				If we don't get one, then it's okay to send. If we send the event with more info first, the event
 				with less info will be marked as not displayed
 			 */
+			log.debug "Lock attribute report received: ${responseMap.value}. Delaying event."
 			runIn(1, "delayLockEvent", [data : [map : responseMap]])
 			return [:]
 		}


### PR DESCRIPTION
Uses logic similar to what we do in z-wave locks to delay events created from lock attribute reports in case we receive a much more detailed operation event later.

If the operation event is sent first, the lock attribute event will be marked as not displayed.