### PR TITLE
CHAD-5290 Add DoorLockOperationReport delay for ALL z-wave locks

### DIFF
--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -379,11 +379,11 @@ def zwaveEvent(DoorLockOperationReport cmd) {
 		}
 	}
 
-    // If the door lock operation report comes before the notification report, the extra info in the notification
+	// If the door lock operation report comes before the notification report, the extra info in the notification
 	// report will not be used because it will be marked as a duplicate. We delay the door lock operation report
 	// so that hopefully the notification report comes in and we can create a more info-rich event
-    runIn(2, "delayLockEvent", [data: [map: map]])
-    return [:]
+	runIn(2, "delayLockEvent", [data: [map: map]])
+	return [:]
 }
 
 def delayLockEvent(data) {


### PR DESCRIPTION
The same issue (less-useful DoorLockOperationReport arriving before
more-useful NotificationReport) was observed to occur for a user with a
Schlage lock, not just the Yales we'd seen it in before. As a result,
we're extending this workaround to ALL z-wave locks.