### PR TITLE
[WWST-5667] - Development - Somfy Sonesse 30

### DIFF
--- a/devicetypes/smartthings/zigbee-window-shade.src/zigbee-window-shade.groovy
+++ b/devicetypes/smartthings/zigbee-window-shade.src/zigbee-window-shade.groovy
@@ -34,6 +34,7 @@ metadata {
 		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0102", outClusters: "0003", manufacturer: "REXENSE", model: "KG0001", deviceJoinName: "Window Treatment" //Smart Curtain Motor(BCM300D)
 		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0102", outClusters: "0003", manufacturer: "REXENSE", model: "DY0010", deviceJoinName: "Window Treatment" //Smart Curtain Motor(DT82TV)
 		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0102", outClusters: "0003", manufacturer: "SOMFY", model: "Glydea Somfy", deviceJoinName: "Somfy Window Treatment" //Somfy Glydea Ultra
+		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0020, 0102", outClusters: "0003", manufacturer: "SOMFY", model: "Roller", deviceJoinName: "Somfy Window Treatment" // Somfy Sonesse 30 Zigbee LI-ION Pack
 	}
 
 	preferences {
@@ -272,7 +273,7 @@ private List readDeviceBindingTable() {
 }
 
 def shouldInvertLiftPercentage() {
-	return isIkeaKadrilj() || isIkeaFyrtur() || isSomfyGlydea()
+	return isIkeaKadrilj() || isIkeaFyrtur() || isSomfyGlydea() || isSomfySonesse()
 }
 
 def reportsBatteryPercentage() {
@@ -289,4 +290,9 @@ def isIkeaFyrtur() {
 
 def isSomfyGlydea() {
 	device.getDataValue("model") == "Glydea Somfy"
+}
+
+def isSomfySonesse() {
+	// the default model name can be changed by the user from the Somfy Set&Go bluetooth app.
+	device.getDataValue("model") == "Roller"
 }


### PR DESCRIPTION
The latest Somfy motors work perfect after adding the fingerprint. 

In order to set the shade's limits or configure the motor (if it has not been done by the manufacturer) the Somfy Set&Go mobile app is required. 

It must be noted that with the Set&Go app the user can change the default model name ("Roller") so that it will no longer match with the fingerprint.

@KKlimczukS @PKacprowiczS @ZWozniakS @MGoralczykS @MWierzbinskaS  

@tpmanley could please take a look at the code?