### PR TITLE
[WWST-6725] Fingerprint for Inovelli Dimmer LZW31

### DIFF
--- a/devicetypes/smartthings/inovelli-dimmer.src/inovelli-dimmer.groovy
+++ b/devicetypes/smartthings/inovelli-dimmer.src/inovelli-dimmer.groovy
@@ -27,6 +27,7 @@ metadata {
 		capability "Power Meter"
 
 		fingerprint mfr: "031E", prod: "0001", model: "0001", deviceJoinName: "Inovelli Dimmer Switch", mnmn: "SmartThings", vid: "SmartThings-smartthings-Inovelli_Dimmer" //Inovelli Dimmer LZW31-SN
+		fingerprint mfr: "031E", prod: "0003", model: "0001", deviceJoinName: "Inovelli Dimmer Switch", mnmn: "SmartThings", vid: "SmartThings-smartthings-Inovelli_Dimmer_LZW31" //Inovelli Dimmer LZW31
 	}
 
 	tiles(scale: 2) {
@@ -119,10 +120,12 @@ def installed() {
 		}
 	}
 // Preferences template end
-	createChildButtonDevices()
-	def value = ['pushed', 'pushed_2x', 'pushed_3x', 'pushed_4x', 'pushed_5x'].encodeAsJson()
-	sendEvent(name: "supportedButtonValues", value: value)
-	sendEvent(name: "numberOfButtons", value: 3, displayed: true)
+	if(isInovelliDimmerLZW31SN()) {
+		createChildButtonDevices()
+		def value = ['pushed', 'pushed_2x', 'pushed_3x', 'pushed_4x', 'pushed_5x'].encodeAsJson()
+		sendEvent(name: "supportedButtonValues", value: value)
+		sendEvent(name: "numberOfButtons", value: 3, displayed: true)
+	}
 	createChildDevice("smartthings", "Child Color Control", "${device.deviceNetworkId}:4", "LED Bar", "LEDColorConfiguration")
 }
 
@@ -509,6 +512,10 @@ private encap(cmd, endpoint = null) {
 
 private encapSequence(cmds, Integer delay = 250) {
 	delayBetween(cmds.collect { encap(it) }, delay)
+}
+
+private isInovelliDimmerLZW31SN(){
+	zwaveInfo.mfr.equals("031E") && zwaveInfo.prod.equals("0001") && zwaveInfo.model.equals("0001")
 }
 
 private getParameterMap() {


### PR DESCRIPTION
@KKlimczukS @PKacprowiczS @ZWozniakS @MGoralczykS 
I added fingerprint for Inovelli Dimmer LZW31 and ensured that this device will not have child buttons.

This device is similar to LZW31-SN - it also supports LED Bar and the same configuration parameters which are used in DTH for LZW31-SN, but it has few differences - it does not support Energy Meter, Power Meter and Button capabilities. I decided to put those two devices in one DTH to avoid code duplication and use different metadata.

@greens 
Could you please take a look at the code?