### PR TITLE
ICP-11574 - Query device for current status in response to WakeUpNotification

### DIFF
--- a/devicetypes/smartthings/zwave-basic-smoke-alarm.src/zwave-basic-smoke-alarm.groovy
+++ b/devicetypes/smartthings/zwave-basic-smoke-alarm.src/zwave-basic-smoke-alarm.groovy
@@ -252,6 +252,5 @@ def initialPoll() {
 	// check initial battery and smoke sensor state
 	request << zwave.batteryV1.batteryGet()
 	request << zwave.sensorBinaryV2.sensorBinaryGet(sensorType: zwave.sensorBinaryV2.SENSOR_TYPE_SMOKE)
-	request << zwave.wakeUpV1.wakeUpIntervalSet(seconds: 3600, nodeid: zwaveHubNodeId)
 	commands(request, 500) + ["delay 6000", command(zwave.wakeUpV1.wakeUpNoMoreInformation())]
 }

--- a/devicetypes/smartthings/zwave-basic-smoke-alarm.src/zwave-basic-smoke-alarm.groovy
+++ b/devicetypes/smartthings/zwave-basic-smoke-alarm.src/zwave-basic-smoke-alarm.groovy
@@ -195,12 +195,12 @@ def zwaveEvent(physicalgraph.zwave.commands.wakeupv1.WakeUpNotification cmd, res
 				zwave.notificationV3.notificationGet(notificationType: 0x01).format(),
 				zwave.batteryV1.batteryGet().format(),
 				zwave.wakeUpV1.wakeUpNoMoreInformation().format()
-		]), 2000 )
+		], 2000))
 	} else {
 		results << response(delayBetween([
 				zwave.notificationV3.notificationGet(notificationType: 0x01).format(),
 				zwave.wakeUpV1.wakeUpNoMoreInformation().format()
-		]), 2000 )
+		], 2000))
 	}
 }
 

--- a/devicetypes/smartthings/zwave-basic-smoke-alarm.src/zwave-basic-smoke-alarm.groovy
+++ b/devicetypes/smartthings/zwave-basic-smoke-alarm.src/zwave-basic-smoke-alarm.groovy
@@ -252,5 +252,6 @@ def initialPoll() {
 	// check initial battery and smoke sensor state
 	request << zwave.batteryV1.batteryGet()
 	request << zwave.sensorBinaryV2.sensorBinaryGet(sensorType: zwave.sensorBinaryV2.SENSOR_TYPE_SMOKE)
+	request << zwave.wakeUpV1.wakeUpIntervalSet(seconds: 3600, nodeid: zwaveHubNodeId)
 	commands(request, 500) + ["delay 6000", command(zwave.wakeUpV1.wakeUpNoMoreInformation())]
 }

--- a/devicetypes/smartthings/zwave-smoke-alarm.src/zwave-smoke-alarm.groovy
+++ b/devicetypes/smartthings/zwave-smoke-alarm.src/zwave-smoke-alarm.groovy
@@ -195,12 +195,12 @@ def zwaveEvent(physicalgraph.zwave.commands.wakeupv1.WakeUpNotification cmd, res
 				zwave.notificationV3.notificationGet(notificationType: 0x01).format(),
 				zwave.batteryV1.batteryGet().format(),
 				zwave.wakeUpV1.wakeUpNoMoreInformation().format()
-		]), 2000 )
+		], 2000))
 	} else {
 		results << response(delayBetween([
 				zwave.notificationV3.notificationGet(notificationType: 0x01).format(),
 				zwave.wakeUpV1.wakeUpNoMoreInformation().format()
-		]), 2000 )
+		], 2000))
 	}
 }
 


### PR DESCRIPTION
ICP-11574_2 - query device for current status in response to WakeUpNotification

I've found a bug in a code that crashes the script. 
Could it be deployed to production as a hot fix ? (if the previous pull request has been deployed to production already)

@greens @dkirker 
cc: @SmartThingsCommunity/srpol-pe-team 