### PR TITLE
CHAD-5235 CHAD-5236 Spot fixes for translations

### DIFF
--- a/devicetypes/smartthings/fibaro-smoke-sensor.src/fibaro-smoke-sensor.groovy
+++ b/devicetypes/smartthings/fibaro-smoke-sensor.src/fibaro-smoke-sensor.groovy
@@ -55,25 +55,25 @@ metadata {
 				title: "To check smoke detection state", displayDuringSetup: true, type: "paragraph", element: "paragraph"
 		input description: "Please consult Fibaro Smoke Sensor operating manual for advanced setting options. You can skip this configuration to use default settings",
 				title: "Advanced settings", displayDuringSetup: true, type: "paragraph", element: "paragraph"
-		input "smokeSensorSensitivity", "enum", title: "Smoke sensor sensitivity", options: ["High", "Medium", "Low"], defaultValue: "${smokeSensorSensitivity}", displayDuringSetup: true
+		input "smokeSensorSensitivity", "enum", title: "Smoke sensor sensitivity", options: ["High", "Medium", "Low"], defaultValue: "Medium", displayDuringSetup: true
 		input "zwaveNotificationStatus", "enum", title: "Notifications", options: ["None", "Casing opened", "Exceeding temperature threshold", "Lack of Z-Wave range", "All"],
 			   // defaultValue: "${zwaveNotificationStatus}", displayDuringSetup: true
 			   //Setting the default to casing opened so it can work in SmartThings mobile app.
 				defaultValue: "Casing opened", displayDuringSetup: true
 		input "visualIndicatorNotificationStatus", "enum", title: "Visual indicator notifications status",
 				options: ["None", "Casing opened", "Exceeding temperature threshold", "Lack of Z-Wave range", "All"],
-				defaultValue: "${visualIndicatorNotificationStatus}", displayDuringSetup: true
+				defaultValue: "None", displayDuringSetup: true
 		input "soundNotificationStatus", "enum", title: "Sound notifications status",
 				options: ["None", "Casing opened", "Exceeding temperature threshold", "Lack of Z-Wave range", "All"],
-				defaultValue: "${soundNotificationStatus}", displayDuringSetup: true
+				defaultValue: "None", displayDuringSetup: true
 		input "temperatureReportInterval", "enum", title: "Temperature report interval",
-				options: ["Reports inactive", "5 minutes", "15 minutes", "30 minutes", "1 hour", "6 hours", "12 hours", "18 hours", "24 hours"], defaultValue: "${temperatureReportInterval}", displayDuringSetup: true
+				options: ["Reports inactive", "5 minutes", "15 minutes", "30 minutes", "1 hour", "6 hours", "12 hours", "18 hours", "24 hours"], defaultValue: "30 minutes", displayDuringSetup: true
 		input "temperatureReportHysteresis", "number", title: "Temperature report hysteresis", description: "Available settings: 1-100 C", range: "1..100", displayDuringSetup: true
 		input "temperatureThreshold", "number", title: "Overheat temperature threshold", description: "Available settings: 0 or 2-100 C", range: "0..100", displayDuringSetup: true
 		input "excessTemperatureSignalingInterval", "enum", title: "Excess temperature signaling interval",
-				options: ["5 minutes", "15 minutes", "30 minutes", "1 hour", "6 hours", "12 hours", "18 hours", "24 hours"], defaultValue: "${excessTemperatureSignalingInterval}", displayDuringSetup: true
+				options: ["5 minutes", "15 minutes", "30 minutes", "1 hour", "6 hours", "12 hours", "18 hours", "24 hours"], defaultValue: "30 minutes", displayDuringSetup: true
 		input "lackOfZwaveRangeIndicationInterval", "enum", title: "Lack of Z-Wave range indication interval",
-				options: ["5 minutes", "15 minutes", "30 minutes", "1 hour", "6 hours", "12 hours", "18 hours", "24 hours"], defaultValue: "${lackOfZwaveRangeIndicationInterval}", displayDuringSetup: true
+				options: ["5 minutes", "15 minutes", "30 minutes", "1 hour", "6 hours", "12 hours", "18 hours", "24 hours"], defaultValue: "6 hours", displayDuringSetup: true
 	}
 	tiles (scale: 2){
 		multiAttributeTile(name:"smoke", type: "lighting", width: 6, height: 4){

--- a/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
+++ b/devicetypes/smartthings/zwave-siren.src/zwave-siren.groovy
@@ -83,7 +83,7 @@ metadata {
 			// defaultValue: 10
 			input name: "alarmLEDflash", type: "bool", title: "Alarm LED flash", description: "This setting only applies to Yale sirens."
 			// defaultValue: false
-			input name: "comfortLED", type: "number", title: "Comfort LED (x10 sec.)", description: "This setting only applies to Yale sirens.", range: "0..25"
+			input name: "comfortLED", type: "number", title: "Comfort LED (x10 sec)", description: "This setting only applies to Yale sirens.", range: "0..25"
 			// defaultValue: 0
 			input name: "tamper", type: "bool", title: "Tamper alert", description: "This setting only applies to Yale sirens."
 			// defaultValue: false


### PR DESCRIPTION
Programmatic default values are overwritten by "Tap to set" in DM if
they have not yet been set and "tap to set" is not translated.

Fixes missing period that was preventing the application of translations.