### PR TITLE
[ICP-13278] Changed minimum dimmer level range in settings for Aeotec Nano Dimmer

### DIFF
--- a/devicetypes/smartthings/zwave-metering-dimmer.src/zwave-metering-dimmer.groovy
+++ b/devicetypes/smartthings/zwave-metering-dimmer.src/zwave-metering-dimmer.groovy
@@ -107,8 +107,8 @@ metadata {
 						description: "This may need to be adjusted for bulbs that are not dimming properly.",
 						name: "minDimmingLevel",
 						type: "number",
-						range: "0..99",
-						defaultValue: 0
+						range: "1..99",
+						defaultValue: 1
 				)
 			}
 	}
@@ -304,10 +304,10 @@ def normalizeLevel(level) {
 
 def getAeotecNanoDimmerConfigurationCommands() {
 	def result = []
-	Integer minDimmingLevel = (settings.minDimmingLevel as Integer) ?: 0 // default value (parameter 131) for Aeotec Nano Dimmer
+	Integer minDimmingLevel = (settings.minDimmingLevel as Integer) ?: 1 // default value (parameter 131) for Aeotec Nano Dimmer
 
 	if (!state.minDimmingLevel) {
-		state.minDimmingLevel = 0 // default value (parameter 131) for Aeotec Nano Dimmer
+		state.minDimmingLevel = 1 // default value (parameter 131) for Aeotec Nano Dimmer
 	}
 
 	if (!state.configured || (minDimmingLevel != state.minDimmingLevel)) {


### PR DESCRIPTION
@greens @dkirker could You please look at the code? Thanks!

Change is applied only to the parameter 131 - minimum dimmer range possible to choose.

@SmartThingsCommunity/srpol-pe-team 