### PR TITLE
Recessed Door Sensor 7 device type update

### DIFF
--- a/devicetypes/smartthings/zwave-door-window-sensor.src/zwave-door-window-sensor.groovy
+++ b/devicetypes/smartthings/zwave-door-window-sensor.src/zwave-door-window-sensor.groovy
@@ -133,7 +133,11 @@ def updated() {
 }
 
 def configure() {
-	// currently supported devices do not require initial configuration
+	//Recessed Door Sensor 7 - Enable Binary Sensor Report for S2 Authenticated
+	if (state.MSR == "0371-0102-00BB" || state.MSR == "0371-0002-00BB") {
+		result << response(command(zwave.configurationV1.configurationSet(parameterNumber: 1, size: 1, scaledConfigurationValue: 1)))
+		result
+	}
 }
 
 def sensorValueEvent(value) {

--- a/devicetypes/smartthings/zwave-door-window-sensor.src/zwave-door-window-sensor.groovy
+++ b/devicetypes/smartthings/zwave-door-window-sensor.src/zwave-door-window-sensor.groovy
@@ -134,7 +134,7 @@ def updated() {
 
 def configure() {
 	//Recessed Door Sensor 7 - Enable Binary Sensor Report for S2 Authenticated
-	if (state.MSR == "0371-0102-00BB" || state.MSR == "0371-0002-00BB") {
+	if (zwaveInfo.mfr == "0371" || zwaveInfo.model == "00BB") {
 		result << response(command(zwave.configurationV1.configurationSet(parameterNumber: 1, size: 1, scaledConfigurationValue: 1)))
 		result
 	}


### PR DESCRIPTION
Lines 136 - 140 - configure Recessed Door Sensor 7 upon pairing to enable Binary Sensor Report - fixes issue where Open/Close status does not update when paired using S2 Authentication.

Checks if Recessed Door Sensor 7 is being paired, if true, push configuration to enable binary sensor report.