### PR TITLE
CHAD-5656 Change reporting interval for zigbee rgbw bulb

### DIFF
--- a/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zigbee-rgbw-bulb.src/zigbee-rgbw-bulb.groovy
@@ -223,8 +223,8 @@ def configure() {
 
 	cmds += refresh() +
 	// OnOff, level minReportTime 0 seconds, maxReportTime 5 min. Reporting interval if no activity
-	zigbee.onOffConfig(0, 300) +
-	zigbee.levelConfig(0, 300)
+	zigbee.onOffConfig() +
+	zigbee.levelConfig()
 	cmds
 }
 


### PR DESCRIPTION
A reporting interval of 0 for the level value was causing the bulb to
send us erroneous intermediary reports that were breaking some
automations.