### PR TITLE
BUG-979 Update DTH vid for Aeon Key Fob to metadata that has the main component visible in the device details page

### DIFF
--- a/devicetypes/erocm123/inovelli-2-channel-smart-plug-mcd.src/inovelli-2-channel-smart-plug-mcd.groovy
+++ b/devicetypes/erocm123/inovelli-2-channel-smart-plug-mcd.src/inovelli-2-channel-smart-plug-mcd.groovy
@@ -237,7 +237,9 @@ def installed() {
 
 	sendEvent(name: "checkInterval", value: checkInterval, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
 
-	createChildDevices()
+	if (!childDevices) {
+		createChildDevices()
+	}
 	response(refresh())
 }
 

--- a/devicetypes/smartthings/aeon-key-fob.src/aeon-key-fob.groovy
+++ b/devicetypes/smartthings/aeon-key-fob.src/aeon-key-fob.groovy
@@ -13,7 +13,7 @@ import groovy.json.JsonOutput
  *
  */
 metadata {
-	definition (name: "Aeon Key Fob", namespace: "smartthings", author: "SmartThings", runLocally: true, minHubCoreVersion: '000.017.0012', executeCommandsLocally: false, ocfDeviceType: "x.com.st.d.remotecontroller", mnmn: "SmartThings", vid: "generic-4-button", mcdSync: true) {
+	definition (name: "Aeon Key Fob", namespace: "smartthings", author: "SmartThings", runLocally: true, minHubCoreVersion: '000.017.0012', executeCommandsLocally: false, ocfDeviceType: "x.com.st.d.remotecontroller", mnmn: "SmartThings", vid: "generic-4-button-alt", mcdSync: true) {
 		capability "Actuator"
 		capability "Button"
 		capability "Holdable Button"


### PR DESCRIPTION
Also update the Inovelli 2-Channel Smart Plug MCD DTH to protect createChildDevices so that changing to that DTH doesn't get interrupted with an exception