### PR TITLE
ICP-13718 - ignore redundant misinterpreted UP events

### DIFF
--- a/devicetypes/smartthings/ikea-button.src/ikea-button.groovy
+++ b/devicetypes/smartthings/ikea-button.src/ikea-button.groovy
@@ -326,7 +326,9 @@ private Map getButtonEvent(Map descMap) {
 				buttonNumber = OPENCLOSE_BUTTONS.DOWN
 			}
 		}
-	} else if (isSomfySituo()){
+	} else if (isSomfySituo() && descMap.data?.size() == 0){
+		// Somfy Situo Remotes query their shades directly after "My"(stop) button  is pressed (that's intended behavior)
+		// descMap contains 'data':['00', '00'] in such cases, so we have to ignore those redundant misinterpreted UP events
 		if (descMap.clusterInt == CLUSTER_WINDOW_COVERING) {
 			buttonState = "pushed"
 			if (descMap.commandInt == 0x00) {


### PR DESCRIPTION
Somfy Situo Remotes query their shades directly after "My"(stop) button is pressed (that's intended behavior, those remotes are being sold with Somfy Shades)
descMap contains 'data':['00', '00'] in such cases, so we have to ignore those redundant misinterpreted UP events.

@greens @tpmanley @dkirker 
Please, could You take a look at the code ?

cc: @SmartThingsCommunity/srpol-pe-team 