### PR TITLE
BUG-1052 Do not display level events for fan controllers

### DIFF
--- a/devicetypes/smartthings/zwave-fan-controller.src/zwave-fan-controller.groovy
+++ b/devicetypes/smartthings/zwave-fan-controller.src/zwave-fan-controller.groovy
@@ -120,7 +120,7 @@ def fanEvents(physicalgraph.zwave.Command cmd) {
 	if (0 <= rawLevel && rawLevel <= 100) {
 		def value = (rawLevel ? "on" : "off")
 		result << createEvent(name: "switch", value: value)
-		result << createEvent(name: "level", value: rawLevel == 99 ? 100 : rawLevel)
+		result << createEvent(name: "level", value: rawLevel == 99 ? 100 : rawLevel, displayed: false)
 
 		def fanLevel = 0
 


### PR DESCRIPTION
Level events were showing up in history, but this is not preferred.