### PR TITLE
C2C-1027 Ecobee Capability Migration in Groovy integration

### DIFF
--- a/devicetypes/smartthings/ecobee-thermostat.src/ecobee-thermostat.groovy
+++ b/devicetypes/smartthings/ecobee-thermostat.src/ecobee-thermostat.groovy
@@ -31,6 +31,7 @@ metadata {
 		capability "Thermostat Heating Setpoint"
 		capability "Thermostat Mode"
 		capability "Thermostat Fan Mode"
+		capability "Thermostat Operating State"
 
 		command "generateEvent"
 		command "resumeProgram"


### PR DESCRIPTION
Adding missed thermostat capability "Thermostat Operating State" (id: thermostatOperatingState)