### PR TITLE
ICP-13534, ICP-13535, ICP-13538 - Fix for setting zwave associations. Remove redundant polling.

### DIFF
--- a/devicetypes/qubino/qubino-dimmer.src/qubino-dimmer.groovy
+++ b/devicetypes/qubino/qubino-dimmer.src/qubino-dimmer.groovy
@@ -230,12 +230,9 @@ def configure() {
 		Group 5: Multilevel sensor report (external temperature sensor report).
 
 	*/
-	commands << zwave.associationV1.associationSet(groupingIdentifier:1, nodeId:[zwaveHubNodeId])
-	commands << zwave.associationV1.associationSet(groupingIdentifier:2, nodeId:[zwaveHubNodeId])
-	commands << zwave.associationV1.associationSet(groupingIdentifier:3, nodeId:[zwaveHubNodeId])
-	commands << zwave.associationV1.associationSet(groupingIdentifier:4, nodeId:[zwaveHubNodeId])
-	commands << zwave.associationV1.associationSet(groupingIdentifier:5, nodeId:[zwaveHubNodeId])
-	commands << zwave.associationV1.associationSet(groupingIdentifier:6, nodeId:[zwaveHubNodeId])
+	commands << zwave.multiChannelAssociationV2.multiChannelAssociationRemove(groupingIdentifier:1, nodeId:[])
+	commands << zwave.multiChannelAssociationV2.multiChannelAssociationSet(groupingIdentifier:1, nodeId:[zwaveHubNodeId])
+	commands << zwave.multiChannelAssociationV2.multiChannelAssociationGet(groupingIdentifier: 1)
 	commands << zwave.multiChannelV3.multiChannelEndPointGet()
 	commands += getRefreshCommands()
 	commands += getReadConfigurationFromTheDeviceCommands()
@@ -334,26 +331,8 @@ def zwaveEvent(physicalgraph.zwave.commands.basicv1.BasicReport cmd, ep = null) 
 	dimmerEvents(cmd)
 }
 
-def zwaveEvent(physicalgraph.zwave.commands.basicv1.BasicSet cmd, ep = null) {
-	log.debug "BasicSet: ${cmd}"
-	def input1SwitchType = Integer.parseInt(state.currentPreferencesState.input1SwitchType.value)
-
-	if(input1SwitchType == INPUT_TYPE_POTENTIOMETER) {
-		log.debug "BasicSet: ${cmd} / INPUT_TYPE_POTENTfIOMETER"
-		sendHubCommand(encap(zwave.switchMultilevelV3.switchMultilevelGet()))
-	} else if (input1SwitchType == INPUT_TYPE_BI_STABLE_SWITCH) {
-		log.debug "BasicSet: ${cmd} / INPUT_TYPE_BI_STABLE_SWITCH"
-		dimmerEvents(cmd)
-	}
-}
-
 def zwaveEvent(physicalgraph.zwave.commands.switchmultilevelv3.SwitchMultilevelReport cmd, ep = null) {
 	log.debug "SwitchMultilevelReport: ${cmd}"
-	dimmerEvents(cmd)
-}
-
-def zwaveEvent(physicalgraph.zwave.commands.switchmultilevelv3.SwitchMultilevelSet cmd, ep = null) {
-	log.debug "SwitchMultilevelSet: ${cmd}"
 	dimmerEvents(cmd)
 }
 
@@ -383,11 +362,6 @@ private dimmerEvents(physicalgraph.zwave.Command cmd, ep = null) {
 	def result = [createEvent(name: "switch", value: value)]
 	if (cmdValue && cmdValue <= 100) {
 		result << createEvent(name: "level", value: cmdValue == 99 ? 100 : cmdValue)
-	}
-
-	if(supportsPowerMeter()){
-		log.debug "query device for power meter values"
-		sendHubCommand(encapCommands(getPowerMeterCommands()))
 	}
 
 	return result
@@ -458,7 +432,6 @@ def createChildDevice(childDthNamespace, childDthName, childDni, childComponentL
 def on() {
 	def commands = [
 		zwave.switchMultilevelV3.switchMultilevelSet(value: 0xFF, dimmingDuration: 0x00),
-		zwave.switchMultilevelV3.switchMultilevelGet()
 	]
 
 	encapCommands(commands, 3000)
@@ -467,7 +440,6 @@ def on() {
 def off() {
 	def commands = [
 		zwave.switchMultilevelV3.switchMultilevelSet(value: 0x00, dimmingDuration: 0x00),
-		zwave.switchMultilevelV3.switchMultilevelGet()
 	]
 
 	encapCommands(commands, 3000)
@@ -490,9 +462,7 @@ def setLevel(value, duration = null) {
 	}
 
 	def adjustedLevel = adjustValueToRange(level)
-
 	commands << zwave.switchMultilevelV3.switchMultilevelSet(value: adjustedLevel, dimmingDuration: dimmingDuration)
-	commands << zwave.switchMultilevelV3.switchMultilevelGet()
 
 	encapCommands(commands, getStatusDelay)
 }

--- a/devicetypes/qubino/qubino-dimmer.src/qubino-dimmer.groovy
+++ b/devicetypes/qubino/qubino-dimmer.src/qubino-dimmer.groovy
@@ -233,7 +233,6 @@ def configure() {
 	commands << zwave.multiChannelAssociationV2.multiChannelAssociationRemove(groupingIdentifier:1, nodeId:[])
 	commands << zwave.multiChannelAssociationV2.multiChannelAssociationSet(groupingIdentifier:1, nodeId:[zwaveHubNodeId])
 	commands << zwave.multiChannelAssociationV2.multiChannelAssociationGet(groupingIdentifier: 1)
-	commands << zwave.multiChannelV3.multiChannelEndPointGet()
 	commands += getRefreshCommands()
 	commands += getReadConfigurationFromTheDeviceCommands()
 


### PR DESCRIPTION
ICP-13534, ICP-13535, ICP-13538 -  Fix for setting zwave associations. Remove redundant polling (device reports it itself when its state is changed).

It turned out that when zwave.multiChannelAssociationV2.multiChannelAssociationSet is used (instead of zwave.associationV2.associationSet) then the device starts reporting its state when it's changed manually by the user (it reports power meter values [W] itself too).
@greens Please, could You take a look at the code ?

cc: @SmartThingsCommunity/srpol-pe-team