### PR TITLE
ICP-11537 - add vid (custom UI Metadata) to Aeotec Nano Dimmer fingerprints

### DIFF
--- a/devicetypes/smartthings/zwave-metering-dimmer.src/zwave-metering-dimmer.groovy
+++ b/devicetypes/smartthings/zwave-metering-dimmer.src/zwave-metering-dimmer.groovy
@@ -35,8 +35,8 @@ metadata {
 		fingerprint mfr:"0086", prod:"0003", model:"001B", deviceJoinName: "Aeotec Dimmer Switch" //Aeotec Micro Smart Dimmer 2E
 		fingerprint mfr:"0086", prod:"0103", model:"0063", deviceJoinName: "Aeotec Dimmer Switch"  //US //Aeotec Smart Dimmer 6
 		fingerprint mfr:"0086", prod:"0003", model:"0063", deviceJoinName: "Aeotec Dimmer Switch" //EU //Aeotec Smart Dimmer 6
-		fingerprint mfr:"0086", prod:"0103", model:"006F", deviceJoinName: "Aeotec Dimmer Switch" //Aeotec Nano Dimmer
-		fingerprint mfr:"0086", prod:"0003", model:"006F", deviceJoinName: "Aeotec Dimmer Switch" //Aeotec Nano Dimmer
+		fingerprint mfr:"0086", prod:"0103", model:"006F", deviceJoinName: "Aeotec Dimmer Switch", mnmn: "SmartThings", vid: "SmartThings-smartthings-Aeotec_Nano_Dimmer" //Aeotec Nano Dimmer
+		fingerprint mfr:"0086", prod:"0003", model:"006F", deviceJoinName: "Aeotec Dimmer Switch", mnmn: "SmartThings", vid: "SmartThings-smartthings-Aeotec_Nano_Dimmer" //Aeotec Nano Dimmer
 		fingerprint mfr:"0086", prod:"0203", model:"006F", deviceJoinName: "Aeotec Dimmer Switch" //AU //Aeotec Nano Dimmer
 		fingerprint mfr:"014F", prod:"5044", model:"3533", deviceJoinName: "GoControl Dimmer Switch" //GoControl Plug-in Dimmer
 	}


### PR DESCRIPTION
ICP-11537 

We need to use device specific UI metadata. Manufacturer has confirmed that:
_"I can confirm now that the external switch is hard-coded only to dim between 5 - 99%, this is intentional design in the Nano Dimmer. "

@dkirker @greens Please, could You take a look at the code ?
cc: @SmartThingsCommunity/srpol-pe-team 