### PR TITLE
Clarify zip code scope

### DIFF
--- a/devicetypes/smartthings/smartweather-station-tile.src/smartweather-station-tile.groovy
+++ b/devicetypes/smartthings/smartweather-station-tile.src/smartweather-station-tile.groovy
@@ -37,7 +37,7 @@ metadata {
     }
 
     preferences {
-        input "zipCode", "text", title: "Zip Code (optional)", required: false
+        input "zipCode", "text", title: "USA Zip Code (optional)", required: false
         input "stationId", "text", title: "Personal Weather Station ID (optional)", required: false
     }
 


### PR DESCRIPTION
Zip codes only work in the US, avoid confusion for users trying to enter a non US zip code.
@dkirker I've come across folks trying to enter a non US zipcode and wonder why it's returning incorrect data. This clarifies the settings.