### PR TITLE
fibaro-door-window-sensor-zw5-with-temperature vid: "generic-contact-2"

### DIFF
--- a/devicetypes/fibargroup/fibaro-door-window-sensor-zw5-with-temperature.src/fibaro-door-window-sensor-zw5-with-temperature.groovy
+++ b/devicetypes/fibargroup/fibaro-door-window-sensor-zw5-with-temperature.src/fibaro-door-window-sensor-zw5-with-temperature.groovy
@@ -14,7 +14,7 @@
  *
  */
 metadata {
-	definition (name: "Fibaro Door/Window Sensor ZW5 with Temperature", namespace: "fibargroup", author: "Fibar Group S.A.", ocfDeviceType: "x.com.st.d.sensor.contact") {
+	definition (name: "Fibaro Door/Window Sensor ZW5 with Temperature", namespace: "fibargroup", author: "Fibar Group S.A.", ocfDeviceType: "x.com.st.d.sensor.contact", mnmn: "SmartThings", vid: "generic-contact-2") {
 		capability "Battery"
 		capability "Contact Sensor"
 		capability "Sensor"


### PR DESCRIPTION
This is a resubmittal of https://github.com/SmartThingsCommunity/SmartThingsPublic/pull/51384
due to its automatic closure upon renaming the source branch from "rtyle" to "fibaro-door-window-sensor-zw5-with-temperature"
to better reflect the intent of the branch (this narrow pull request).
Original pull request comment:

The "Fibaro Door Window Sensor ZW5 with Temperature" device handler does not present its (Fibaro FGK 10x ZW5 with DS18B20 temperature probe) devices in the new SmartThings App. Actual temperature measurement and integration of such with SmartApps will work but the SmartThings App will not report anything about the device. The SmartThings App will report on the non-temperature capabilities ("Battery", "Contact Sensor" and "Tamper Alert") if the "Fibaro Door Window Sensor ZW5" device handler is used but SmartApps will not get any temperature measurement.

The difference between these device handlers is the "Temperature Measurement" capability and implementation. The SmartThings App seems to be able to figure out the appropriate presentation of "Fibaro Door Window Sensor ZW5" capabilities but not when "Temperature Measurement" is added. This change adds explicit direction in the "Fibaro Door Window Sensor ZW5 with Temperature" device handler to tell the SmartThings App to use its known "SmartThings" "generic-contact-2" presentation. This will get the "Temperature Measurement" capability presented in the SmartThings App but, unfortunately, will lose the "Tamper Alert" capability presentation. Certainly, this is better than nothing.

A complete fix would include presentation of all its capabilities ("Battery", "Contact Sensor", "Tamper Alert" and "Temperature Measurement"). This might be supported with a custom capability presentation but, I would argue, there should be nothing "custom" about this and it is not clear how to publish such for the whole community. The new SmartThings App should support this natively just as the old one did. Perhaps it would be best if another "generic-contact-*' variant might be supported, used and documented.