### PR TITLE
[CHAD-5726] Z-Wave Radiator Thermostat - removed extra thermostat mode capability entry

### DIFF
--- a/devicetypes/smartthings/zwave-radiator-thermostat.src/zwave-radiator-thermostat.groovy
+++ b/devicetypes/smartthings/zwave-radiator-thermostat.src/zwave-radiator-thermostat.groovy
@@ -14,7 +14,6 @@
  */
 metadata {
 	definition (name: "Z-Wave Radiator Thermostat", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.thermostat") {
-		capability "Thermostat Mode"
 		capability "Refresh"
 		capability "Battery"
 		capability "Thermostat Heating Setpoint"


### PR DESCRIPTION
@greens @SmartThingsCommunity/srpol-pe-team 
I've noticed that there's extra "Thermostat Mode" in the DTH added in #49771 
Dunno if it's breaking anything, but I believe it's better to get it sorted out anyway