### PR TITLE
[WWST-7227, WWST-7213, WWST-7197] Fingerprints for Enbrighten dimmers

### DIFF
--- a/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-dimmer.src/zigbee-dimmer.groovy
@@ -126,6 +126,11 @@ metadata {
 
 		// Wemo
 		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, FF00", outClusters: "0019", manufacturer: "MRVL", model: "MZ100", deviceJoinName: "Wemo Light" //Wemo Bulb
+
+		// Enbrighten/Jasco
+		fingerprint manufacturer: "Jasco Products", model: "43096", deviceJoinName: "Enbrighten Dimmer", ocfDeviceType: "oic.d.switch" //Enbrighten, Plug-in Smart Dimmer, 43096, Raw Description: 01 0104 0101 00 07 0000 0003 0004 0005 0006 0008 0B05 02 000A 0019
+		fingerprint manufacturer: "Jasco Products", model: "43090", deviceJoinName: "Enbrighten Dimmer", ocfDeviceType: "oic.d.switch" //Enbrighten, In-Wall Smart Dimmer, Toggle. 43090, Raw Description: 01 0104 0101 00 07 0000 0003 0004 0005 0006 0008 0B05 02 000A 0019
+		fingerprint manufacturer: "Jasco Products", model: "43080", deviceJoinName: "Enbrighten Dimmer", ocfDeviceType: "oic.d.switch" //Enbrighten, In-Wall Smart Dimmer, 43080, Raw Description: 01 0104 0101 00 07 0000 0003 0004 0005 0006 0008 0B05 02 000A 0019
 	}
 
 	tiles(scale: 2) {


### PR DESCRIPTION
Fingerprints for Enbrighten dimmers: 
- WWST-7227 Plug-in Smart Dimmer, 43096
- WWST-7213 In-Wall Smart Dimmer, Toggle. 43090
- WWST-7197 In-Wall Smart Dimmer, 43080

@SmartThingsCommunity/srpol-pe-team 
@greens  Could you please take a look at the code?