### PR TITLE
Initial support for ZRC-90US first 6 buttons only

### DIFF
--- a/devicetypes/smartthings/zwave-multi-button.src/zwave-multi-button.groovy
+++ b/devicetypes/smartthings/zwave-multi-button.src/zwave-multi-button.groovy
@@ -26,12 +26,14 @@ metadata {
 
 		// While adding new device to this DTH, remember to update method getProdNumberOfButtons()
 		fingerprint mfr: "010F", prod: "1001", model: "1000", deviceJoinName: "Fibaro Remote Control", mnmn: "SmartThings", vid: "generic-6-button" //EU //Fibaro KeyFob
-		fingerprint mfr: "010F", prod: "1001", model: "2000", deviceJoinName: "Fibaro Remote Control", mnmn: "SmartThings", vid: "generic-6-button"  //US //Fibaro KeyFob
+		fingerprint mfr: "010F", prod: "1001", model: "2000", deviceJoinName: "Fibaro Remote Control", mnmn: "SmartThings", vid: "generic-6-button" //US //Fibaro KeyFob
 		fingerprint mfr: "0371", prod: "0102", model: "0003", deviceJoinName: "Aeotec Remote Control", mnmn: "SmartThings", vid: "generic-4-button" //US //Aeotec NanoMote Quad
 		fingerprint mfr: "0371", prod: "0002", model: "0003", deviceJoinName: "Aeotec Remote Control", mnmn: "SmartThings", vid: "generic-4-button" //EU //Aeotec NanoMote Quad
 		fingerprint mfr: "0086", prod: "0101", model: "0058", deviceJoinName: "Aeotec Remote Control", mnmn: "SmartThings", vid: "generic-4-button" //US //Aeotec KeyFob
 		fingerprint mfr: "0086", prod: "0001", model: "0058", deviceJoinName: "Aeotec Remote Control", mnmn: "SmartThings", vid: "generic-4-button" //EU //Aeotec KeyFob
 		fingerprint mfr: "010F", prod: "1001", model: "3000", deviceJoinName: "Fibaro Remote Control", mnmn: "SmartThings", vid: "generic-6-button" //AU //Fibaro KeyFob
+		// ZRC-90 is an 8-button device, but there appears to be no suitable profile, hence using generic-6-button and ignoring 2 buttons for now.
+		fingerprint mfr: "5254", prod: "0000", model: "8510", deviceJoinName: "Remotec Remote Control", mnmn: "SmartThings", vid: "generic-6-button" //US //ZRC-90US
 	}
 
 	tiles(scale: 2) {
@@ -147,6 +149,10 @@ def zwaveEvent(physicalgraph.zwave.commands.centralscenev1.CentralSceneNotificat
 
 def sendEventToChild(buttonNumber, event) {
 	String childDni = "${device.deviceNetworkId}:$buttonNumber"
+	if (buttonNumber > prodNumberOfButtons[zwaveInfo.prod]) {
+		log.debug "Ignoring button $buttonNumber - button number too high"
+		return
+	}
 	def child = childDevices.find { it.deviceNetworkId == childDni }
 	child?.sendEvent(event)
 }
@@ -176,6 +182,10 @@ def zwaveEvent(physicalgraph.zwave.commands.batteryv1.BatteryReport cmd) {
 
 def zwaveEvent(physicalgraph.zwave.Command cmd) {
 	log.warn "Unhandled command: ${cmd}"
+}
+
+def ping() {
+    log.debug "Battery Device - Not sending ping commands"
 }
 
 private secure(cmd) {
@@ -218,12 +228,14 @@ private getProdNumberOfButtons() {[
 		"0102" : 4,
 		"0002" : 4,
 		"0101" : 4,
-		"0001" : 4
+		"0001" : 4,
+		"0000" : 6  // Really 8
 ]}
 
 private getSupportedButtonValues() {
 	def values = ["pushed", "held"]
 	if (isFibaro()) values += ["double", "down_hold", "pushed_3x"]
+	else if (isRemotec()) values += ["double", "down_hold"]
 	return values
 }
 
@@ -241,4 +253,8 @@ private isUntrackedAeotec() {
 
 private isAeotecKeyFob() {
 	zwaveInfo.mfr?.contains("0086")
+}
+
+private isRemotec() {
+    zwaveInfo.mfr?.contains("5254")
 }


### PR DESCRIPTION
The current device handler for this device is not useful in the new SmartThings app.

This sets up a device handler which almost works, for 6 of the 8 buttons on the device.  (Changing the number to 8 makes this fully functional in the classic app, but even more broken in the new app.)

Attempts to save actions from the new app still fail with "A network or server error occurred, try again later", but at least the UI elements exist to attempt to set them (for 6 buttons).