### PR TITLE
[ICP-13896] Fixed lack of energy meter reports

### DIFF
--- a/devicetypes/qubino/qubino-dimmer.src/qubino-dimmer.groovy
+++ b/devicetypes/qubino/qubino-dimmer.src/qubino-dimmer.groovy
@@ -327,6 +327,7 @@ def zwaveEvent(physicalgraph.zwave.Command cmd) {
 
 def zwaveEvent(physicalgraph.zwave.commands.basicv1.BasicReport cmd, ep = null) {
 	log.debug "BasicReport: ${cmd}"
+	sendHubCommand(encapCommands(getPowerMeterCommands()))
 	dimmerEvents(cmd)
 }
 


### PR DESCRIPTION
@SmartThingsCommunity/srpol-pe-team 
@greens 
Could you please take a look at the code?

This device did not send energy meter report itself and because it sends BasicReport every 15 minutes it was not asked about this report via ping and refresh. 