### PR TITLE
WWST-7239 - new fingerprint for Jasco, In-Wall Smart Outlet With Energy Monitoring, 43132

### DIFF
--- a/devicetypes/smartthings/zigbee-switch-power.src/zigbee-switch-power.groovy
+++ b/devicetypes/smartthings/zigbee-switch-power.src/zigbee-switch-power.groovy
@@ -58,6 +58,7 @@ metadata {
 		// Enbrighten
 		fingerprint manufacturer: "Jasco Products", model: "43078", deviceJoinName: "Enbrighten Switch" //Enbrighten In-Wall Smart Switch With Energy Monitoring 43078, Raw Description: 01 0104 0100 00 07 0000 0003 0004 0005 0006 0702 0B05 02 000A 0019
 		fingerprint manufacturer: "Jasco Products", model: "43095", deviceJoinName: "Enbrighten Switch" //Enbrighten Plug-in Smart Switch With Energy Monitoring 43095, Raw Description: 01 0104 0100 00 07 0000 0003 0004 0005 0006 0702 0B05 02 000A 0019
+		fingerprint manufacturer: "Jasco Products", model: "43132", deviceJoinName: "Enbrighten Switch" //Enbrighten In-Wall Smart Outlet With Energy Monitoring 43132, Raw Description: 01 0104 0100 00 07 0000 0003 0004 0005 0006 0702 0B05 02 000A 0019
 	}
 
 	tiles(scale: 2) {


### PR DESCRIPTION
WWST-7239 - new fingerprint for Jasco, In-Wall Smart Outlet With Energy Monitoring, 43132

@greens Please, could You take a look at the code ?
cc: @SmartThingsCommunity/srpol-pe-team 