### PR TITLE
CHAD-5976 Add explicit metadata for thermostats that are missing it

### DIFF
--- a/devicetypes/smartthings/centralite-thermostat.src/centralite-thermostat.groovy
+++ b/devicetypes/smartthings/centralite-thermostat.src/centralite-thermostat.groovy
@@ -16,7 +16,8 @@
  *	Date: 2013-12-02
  */
 metadata {
-	definition (name: "CentraLite Thermostat", namespace: "smartthings", author: "SmartThings", runLocally: true, minHubCoreVersion: '000.017.0012', executeCommandsLocally: false) {
+	definition (name: "CentraLite Thermostat", namespace: "smartthings", author: "SmartThings", runLocally: true, minHubCoreVersion: '000.017.0012',
+			executeCommandsLocally: false, mnmn: "SmartThings", vid: "SmartThings-smartthings-Honeywell_TCC_8000/9000_Thermostat") {
 		capability "Actuator"
 		capability "Temperature Measurement"
 		capability "Thermostat"

--- a/devicetypes/smartthings/centralite-thermostat.src/centralite-thermostat.groovy
+++ b/devicetypes/smartthings/centralite-thermostat.src/centralite-thermostat.groovy
@@ -17,7 +17,7 @@
  */
 metadata {
 	definition (name: "CentraLite Thermostat", namespace: "smartthings", author: "SmartThings", runLocally: true, minHubCoreVersion: '000.017.0012',
-			executeCommandsLocally: false, mnmn: "SmartThings", vid: "SmartThings-smartthings-Honeywell_TCC_8000/9000_Thermostat") {
+			executeCommandsLocally: false, mnmn: "SmartThings", vid: "SmartThings-smartthings-Z-Wave_Thermostat") {
 		capability "Actuator"
 		capability "Temperature Measurement"
 		capability "Thermostat"

--- a/devicetypes/smartthings/ct100-thermostat.src/ct100-thermostat.groovy
+++ b/devicetypes/smartthings/ct100-thermostat.src/ct100-thermostat.groovy
@@ -1,6 +1,6 @@
 metadata {
 	// Automatically generated. Make future change here.
-	definition (name: "CT100 Thermostat", namespace: "smartthings", author: "SmartThings") {
+	definition (name: "CT100 Thermostat", namespace: "smartthings", author: "SmartThings", mnmn: "SmartThings", vid: "SmartThings-smartthings-Honeywell_TCC_8000/9000_Thermostat") {
 		capability "Actuator"
 		capability "Temperature Measurement"
 		capability "Relative Humidity Measurement"

--- a/devicetypes/smartthings/ct100-thermostat.src/ct100-thermostat.groovy
+++ b/devicetypes/smartthings/ct100-thermostat.src/ct100-thermostat.groovy
@@ -1,6 +1,6 @@
 metadata {
 	// Automatically generated. Make future change here.
-	definition (name: "CT100 Thermostat", namespace: "smartthings", author: "SmartThings", mnmn: "SmartThings", vid: "SmartThings-smartthings-Honeywell_TCC_8000/9000_Thermostat") {
+	definition (name: "CT100 Thermostat", namespace: "smartthings", author: "SmartThings", mnmn: "SmartThings", vid: "SmartThings-smartthings-Z-Wave_Thermostat") {
 		capability "Actuator"
 		capability "Temperature Measurement"
 		capability "Relative Humidity Measurement"

--- a/devicetypes/smartthings/zwave-radiator-thermostat.src/zwave-radiator-thermostat.groovy
+++ b/devicetypes/smartthings/zwave-radiator-thermostat.src/zwave-radiator-thermostat.groovy
@@ -13,7 +13,8 @@
  *
  */
 metadata {
-	definition (name: "Z-Wave Radiator Thermostat", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.thermostat") {
+	definition (name: "Z-Wave Radiator Thermostat", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.thermostat",
+			mnmn: "SmartThings", vid: "SmartThings-smartthings-Fibaro_Heat_Controller") {
 		capability "Refresh"
 		capability "Battery"
 		capability "Thermostat Heating Setpoint"


### PR DESCRIPTION
The recent changes that added discrete thermostat capabilities to several devices previously using the monolithic capabilities caused issues with the fallback metadata being used for devices which previously did not have explicit metadata. The fallback metadata would see values for the duplicated attributes and create UI for both of them, leading to duplicated controls. Setting the devices to use explicit metadata should remedy this.