### PR TITLE
[ICP-12754] Fix for: "Qubino Flush On Off Thermostat 2 – Cannot set a heating temperature"

### DIFF
--- a/devicetypes/smartthings/qubino-flush-thermostat.src/qubino-flush-thermostat.groovy
+++ b/devicetypes/smartthings/qubino-flush-thermostat.src/qubino-flush-thermostat.groovy
@@ -278,7 +278,7 @@ def setCoolingSetpoint(setpoint) {
 
 def updateSetpoint(setpoint, setpointType) {
 	setpoint = temperatureScale == 'C' ? setpoint : fahrenheitToCelsius(setpoint)
-	setpoint = Math.max(Math.min(setpoint.doubleValue(), maxSetpointTemperature.doubleValue()), minSetpointTemperature)
+	setpoint = Math.max(Math.min(setpoint.doubleValue(), maxSetpointTemperature.doubleValue()), minSetpointTemperature.doubleValue())
 	[
 			secure(zwave.thermostatSetpointV2.thermostatSetpointSet([precision: 1, scale: 0, scaledValue: setpoint, setpointType: setpointType, size: 2])),
 			"delay 2000",

--- a/devicetypes/smartthings/qubino-flush-thermostat.src/qubino-flush-thermostat.groovy
+++ b/devicetypes/smartthings/qubino-flush-thermostat.src/qubino-flush-thermostat.groovy
@@ -278,7 +278,7 @@ def setCoolingSetpoint(setpoint) {
 
 def updateSetpoint(setpoint, setpointType) {
 	setpoint = temperatureScale == 'C' ? setpoint : fahrenheitToCelsius(setpoint)
-	setpoint = Math.max(Math.min(setpoint, maxSetpointTemperature), minSetpointTemperature)
+	setpoint = Math.max(Math.min(setpoint.doubleValue(), maxSetpointTemperature.doubleValue()), minSetpointTemperature)
 	[
 			secure(zwave.thermostatSetpointV2.thermostatSetpointSet([precision: 1, scale: 0, scaledValue: setpoint, setpointType: setpointType, size: 2])),
 			"delay 2000",


### PR DESCRIPTION
When I changed the setpoint value I get this error 
`groovy.lang.GroovyRuntimeException: Ambiguous method overloading for method java.lang.Math#min.
Cannot resolve which method to invoke for [class java.math.BigDecimal, class java.lang.Integer] due to overlapping prototypes between:
[double, double]
[float, float] @line 281 (updateSetpoint)`

I cast those two values to double to fix this. 

@greens @SmartThingsCommunity/srpol-pe-team 