### PR TITLE
WWST-7201, WWST-7223, WWST-7239 moves Enbrighten, Jasco devices between DTHs

### DIFF
--- a/devicetypes/smartthings/zigbee-metering-plug.src/zigbee-metering-plug.groovy
+++ b/devicetypes/smartthings/zigbee-metering-plug.src/zigbee-metering-plug.groovy
@@ -162,13 +162,17 @@ def configure() {
 }
 
 private int getPowerDiv() {
-    isSengledOutlet() ? 10 : 1
+	(isSengledOutlet() || isJascoProductsOutlet()) ? 10 : 1
 }
 
 private int getEnergyDiv() {
-    isSengledOutlet() ? 10000 : 100
+	(isSengledOutlet() || isJascoProductsOutlet()) ? 10000 : 100
 }
 
 private boolean isSengledOutlet() {
-    device.getDataValue("model") == "E1C-NB7"
+	device.getDataValue("model") == "E1C-NB7"
+}
+
+private boolean isJascoProductsOutlet() {
+	device.getDataValue("manufacturer") == "Jasco Products"
 }

--- a/devicetypes/smartthings/zigbee-metering-plug.src/zigbee-metering-plug.groovy
+++ b/devicetypes/smartthings/zigbee-metering-plug.src/zigbee-metering-plug.groovy
@@ -36,7 +36,7 @@ metadata {
         fingerprint profileId: "0104", manufacturer: "frient A/S", model: "SPLZB-137",  deviceJoinName: "frient Outlet" // frient smart plug mini, raw description: 02 0104 0051 10 09 0000 0702 0003 0009 0B04 0006 0004 0005 0002 05 0000 0019 000A 0003 0406
         fingerprint profileId: "0104", manufacturer: "frient A/S", model: "SMRZB-143",  deviceJoinName: "frient Outlet" // frient smart cable, raw description: 02 0104 0051 10 09 0000 0702 0003 0009 0B04 0006 0004 0005 0002 05 0000 0019 000A 0003 0406
         fingerprint manufacturer: "Jasco Products", model: "43095", deviceJoinName: "Enbrighten Outlet" //Enbrighten Plug-in Smart Switch With Energy Monitoring 43095, Raw Description: 01 0104 0100 00 07 0000 0003 0004 0005 0006 0702 0B05 02 000A 0019
-        fingerprint manufacturer: "Jasco Products", model: "43132", deviceJoinName: "Enbrighten Outlet" //Enbrighten In-Wall Smart Outlet With Energy Monitoring 43132, Raw Description: 01 0104 0100 00 07 0000 0003 0004 0005 0006 0702 0B05 02 000A 0019
+        fingerprint manufacturer: "Jasco Products", model: "43132", deviceJoinName: "Jasco Outlet" //Enbrighten In-Wall Smart Outlet With Energy Monitoring 43132, Raw Description: 01 0104 0100 00 07 0000 0003 0004 0005 0006 0702 0B05 02 000A 0019
 	}
 
     tiles(scale: 2){

--- a/devicetypes/smartthings/zigbee-metering-plug.src/zigbee-metering-plug.groovy
+++ b/devicetypes/smartthings/zigbee-metering-plug.src/zigbee-metering-plug.groovy
@@ -162,17 +162,17 @@ def configure() {
 }
 
 private int getPowerDiv() {
-	(isSengledOutlet() || isJascoProductsOutlet()) ? 10 : 1
+    (isSengledOutlet() || isJascoProductsOutlet()) ? 10 : 1
 }
 
 private int getEnergyDiv() {
-	(isSengledOutlet() || isJascoProductsOutlet()) ? 10000 : 100
+    (isSengledOutlet() || isJascoProductsOutlet()) ? 10000 : 100
 }
 
 private boolean isSengledOutlet() {
-	device.getDataValue("model") == "E1C-NB7"
+    device.getDataValue("model") == "E1C-NB7"
 }
 
 private boolean isJascoProductsOutlet() {
-	device.getDataValue("manufacturer") == "Jasco Products"
+    device.getDataValue("manufacturer") == "Jasco Products"
 }

--- a/devicetypes/smartthings/zigbee-metering-plug.src/zigbee-metering-plug.groovy
+++ b/devicetypes/smartthings/zigbee-metering-plug.src/zigbee-metering-plug.groovy
@@ -37,6 +37,7 @@ metadata {
         fingerprint profileId: "0104", manufacturer: "frient A/S", model: "SMRZB-143",  deviceJoinName: "frient Outlet" // frient smart cable, raw description: 02 0104 0051 10 09 0000 0702 0003 0009 0B04 0006 0004 0005 0002 05 0000 0019 000A 0003 0406
         fingerprint manufacturer: "Jasco Products", model: "43095", deviceJoinName: "Enbrighten Outlet" //Enbrighten Plug-in Smart Switch With Energy Monitoring 43095, Raw Description: 01 0104 0100 00 07 0000 0003 0004 0005 0006 0702 0B05 02 000A 0019
         fingerprint manufacturer: "Jasco Products", model: "43132", deviceJoinName: "Jasco Outlet" //Enbrighten In-Wall Smart Outlet With Energy Monitoring 43132, Raw Description: 01 0104 0100 00 07 0000 0003 0004 0005 0006 0702 0B05 02 000A 0019
+        fingerprint manufacturer: "Jasco Products", model: "43078", deviceJoinName: "Enbrighten Switch", ocfDeviceType: "oic.d.switch" //Enbrighten In-Wall Smart Switch With Energy Monitoring 43078, Raw Description: 01 0104 0100 00 07 0000 0003 0004 0005 0006 0702 0B05 02 000A 0019
 	}
 
     tiles(scale: 2){

--- a/devicetypes/smartthings/zigbee-metering-plug.src/zigbee-metering-plug.groovy
+++ b/devicetypes/smartthings/zigbee-metering-plug.src/zigbee-metering-plug.groovy
@@ -35,6 +35,8 @@ metadata {
         fingerprint profileId: "0104", manufacturer: "frient A/S", model: "SPLZB-134",  deviceJoinName: "frient Outlet" // frient smart plug mini, raw description: 02 0104 0051 10 09 0000 0702 0003 0009 0B04 0006 0004 0005 0002 05 0000 0019 000A 0003 0406
         fingerprint profileId: "0104", manufacturer: "frient A/S", model: "SPLZB-137",  deviceJoinName: "frient Outlet" // frient smart plug mini, raw description: 02 0104 0051 10 09 0000 0702 0003 0009 0B04 0006 0004 0005 0002 05 0000 0019 000A 0003 0406
         fingerprint profileId: "0104", manufacturer: "frient A/S", model: "SMRZB-143",  deviceJoinName: "frient Outlet" // frient smart cable, raw description: 02 0104 0051 10 09 0000 0702 0003 0009 0B04 0006 0004 0005 0002 05 0000 0019 000A 0003 0406
+        fingerprint manufacturer: "Jasco Products", model: "43095", deviceJoinName: "Enbrighten Outlet" //Enbrighten Plug-in Smart Switch With Energy Monitoring 43095, Raw Description: 01 0104 0100 00 07 0000 0003 0004 0005 0006 0702 0B05 02 000A 0019
+        fingerprint manufacturer: "Jasco Products", model: "43132", deviceJoinName: "Enbrighten Outlet" //Enbrighten In-Wall Smart Outlet With Energy Monitoring 43132, Raw Description: 01 0104 0100 00 07 0000 0003 0004 0005 0006 0702 0B05 02 000A 0019
 	}
 
     tiles(scale: 2){

--- a/devicetypes/smartthings/zigbee-switch-power.src/zigbee-switch-power.groovy
+++ b/devicetypes/smartthings/zigbee-switch-power.src/zigbee-switch-power.groovy
@@ -57,8 +57,6 @@ metadata {
 
 		// Enbrighten
 		fingerprint manufacturer: "Jasco Products", model: "43078", deviceJoinName: "Enbrighten Switch" //Enbrighten In-Wall Smart Switch With Energy Monitoring 43078, Raw Description: 01 0104 0100 00 07 0000 0003 0004 0005 0006 0702 0B05 02 000A 0019
-		fingerprint manufacturer: "Jasco Products", model: "43095", deviceJoinName: "Enbrighten Switch" //Enbrighten Plug-in Smart Switch With Energy Monitoring 43095, Raw Description: 01 0104 0100 00 07 0000 0003 0004 0005 0006 0702 0B05 02 000A 0019
-		fingerprint manufacturer: "Jasco Products", model: "43132", deviceJoinName: "Enbrighten Switch" //Enbrighten In-Wall Smart Outlet With Energy Monitoring 43132, Raw Description: 01 0104 0100 00 07 0000 0003 0004 0005 0006 0702 0B05 02 000A 0019
 	}
 
 	tiles(scale: 2) {

--- a/devicetypes/smartthings/zigbee-switch-power.src/zigbee-switch-power.groovy
+++ b/devicetypes/smartthings/zigbee-switch-power.src/zigbee-switch-power.groovy
@@ -54,9 +54,6 @@ metadata {
 		fingerprint profileId: "0104", deviceId: "0051", inClusters: "0000, 0003, 0004, 0005, 0006, 0B04, 1000, 0702", outClusters: "0019", manufacturer: "AduroSmart Eria", model: "AD-SmartPlug3001", deviceJoinName: "Eria Switch" //Eria Zigbee Smart Plug
 		fingerprint profileId: "0104", deviceId: "010A", inClusters: "0000, 0003, 0004, 0005, 0006, 1000", outClusters: "0019", manufacturer: "AduroSmart Eria", model: "BPU3", deviceJoinName: "Eria Switch" //Eria Zigbee On/Off Plug
 		fingerprint profileId: "0104", deviceId: "0101", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 1000", outClusters: "0019", manufacturer: "AduroSmart Eria", model: "BDP3001", deviceJoinName: "Eria Switch" //Eria Zigbee Dimmable Plug
-
-		// Enbrighten
-		fingerprint manufacturer: "Jasco Products", model: "43078", deviceJoinName: "Enbrighten Switch" //Enbrighten In-Wall Smart Switch With Energy Monitoring 43078, Raw Description: 01 0104 0100 00 07 0000 0003 0004 0005 0006 0702 0B05 02 000A 0019
 	}
 
 	tiles(scale: 2) {


### PR DESCRIPTION
WWST-7201, WWST-7223, WWST-7239 moves Enbrighten, Jasco devices between DTHs
Those all devices support also "Energy meter" capability, so they have to be moved between DTHs.
(in both cases, a manufacturer is: "Jasco Products" )

@greens Please, could You take a look at the code ?

cc: @SmartThingsCommunity/srpol-pe-team 