### PR TITLE
WWST-7205 - Enbrighten Smart Dimmer / new generic DTH to support dimmers that report both power [W] and energy [kWh] values.

### DIFF
--- a/devicetypes/smartthings/zigbee-metering-dimmer.src/zigbee-metering-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-metering-dimmer.src/zigbee-metering-dimmer.groovy
@@ -41,7 +41,7 @@ def parse(String description) {
 	if (event) {
 		log.info event
 		if (event.name == "power") {
-			def powerDiv = device.getDataValue("powerDivisor")
+			def powerDiv = device.getDataValue("divisor")
 			powerDiv = powerDiv ? (powerDiv as int) : 1
 			event.value = event.value/powerDiv
 			event.unit = "W"
@@ -67,7 +67,7 @@ def parse(String description) {
 			if (it.value && it.clusterInt == zigbee.SIMPLE_METERING_CLUSTER && it.attrInt == ATTRIBUTE_HISTORICAL_CONSUMPTION) {
 				log.debug "power"
 				map.name = "power"
-				def powerDiv = device.getDataValue("powerDivisor")
+				def powerDiv = device.getDataValue("divisor")
 				powerDiv = powerDiv ? (powerDiv as int) : 1
 				map.value = zigbee.convertHexToInt(it.value)/powerDiv
 				map.unit = "W"
@@ -122,10 +122,10 @@ def configure() {
 	log.debug "Configuring Reporting and Bindings."
 
 	if (isJascoProducts())  {
-		device.updateDataValue("powerDivisor", "10")
+		device.updateDataValue("divisor", "10")
 		device.updateDataValue("energyDivisor", "10000")
 	} else {
-		device.updateDataValue("powerDivisor", "1")
+		device.updateDataValue("divisor", "1")
 		device.updateDataValue("energyDivisor", "100")
 	}
 

--- a/devicetypes/smartthings/zigbee-metering-dimmer.src/zigbee-metering-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-metering-dimmer.src/zigbee-metering-dimmer.groovy
@@ -13,7 +13,7 @@
  */
 import physicalgraph.zigbee.zcl.DataType
 metadata {
-	definition (name: "ZigBee Metering Dimmer", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.light",  mnmn: "SmartThings", vid:"generic-dimmer-power-energy", runLocally: true, executeCommandsLocally: true, genericHandler: "Zigbee") {
+	definition (name: "ZigBee Metering Dimmer", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.light",  mnmn: "SmartThings", vid:"generic-dimmer-power-energy", runLocally: true, executeCommandsLocally: true, genericHandler: "Zigbee", minHubCoreVersion: '000.019.00012') {
 
 		capability "Actuator"
 		capability "Configuration"

--- a/devicetypes/smartthings/zigbee-metering-dimmer.src/zigbee-metering-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-metering-dimmer.src/zigbee-metering-dimmer.groovy
@@ -1,0 +1,133 @@
+/**
+ *  Copyright 2021 SmartThings
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ *  for the specific language governing permissions and limitations under the License.
+ *
+ */
+import physicalgraph.zigbee.zcl.DataType
+metadata {
+	definition (name: "ZigBee Metering Dimmer", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.light",  mnmn: "SmartThings", vid:"generic-dimmer-power-energy") {
+
+		capability "Actuator"
+		capability "Configuration"
+		capability "Refresh"
+		capability "Power Meter"
+		capability "Energy Meter"
+		capability "Switch"
+		capability "Switch Level"
+		capability "Health Check"
+
+		// Enbrighten/Jasco
+		fingerprint manufacturer: "Jasco Products", model: "43082", deviceJoinName: "Enbrighten Switch" //Enbrighten, in-Wall Smart Dimmer With Energy Monitoring 43082, Raw Description: 01 0104 0101 00 08 0000 0003 0004 0005 0006 0008 0702 0B05 02 000A 0019
+	}
+}
+
+def getATTRIBUTE_READING_INFO_SET() { 0x0000 }
+def getATTRIBUTE_HISTORICAL_CONSUMPTION() { 0x0400 }
+
+// Parse incoming device messages to generate events
+def parse(String description) {
+	log.debug "description is $description"
+	List result = []
+
+	def event = zigbee.getEvent(description)
+	if (event) {
+		log.info event
+		if (event.name== "power") {
+			event.value = event.value/getPowerDiv()
+			event.unit = "W"
+		} else if (event.name== "energy") {
+			event.value = event.value/getEnergyDiv()
+			event.unit = "kWh"
+		}
+		log.info "event: $event"
+		result << event
+	} else {
+		def descMap = zigbee.parseDescriptionAsMap(description)
+		log.debug "descMap: $descMap"
+
+		List attrData = [[clusterInt: descMap.clusterInt ,attrInt: descMap.attrInt, value: descMap.value]]
+		descMap.additionalAttrs.each {
+			attrData << [clusterInt: descMap.clusterInt, attrInt: it.attrInt, value: it.value]
+		}
+
+		attrData.each {
+			def map = [:]
+			if (it.value && it.clusterInt == zigbee.SIMPLE_METERING_CLUSTER && it.attrInt == ATTRIBUTE_HISTORICAL_CONSUMPTION) {
+				log.debug "power"
+				map.name = "power"
+				map.value = zigbee.convertHexToInt(it.value)/getPowerDiv()
+				map.unit = "W"
+			}
+			else if (it.value && it.clusterInt == zigbee.SIMPLE_METERING_CLUSTER && it.attrInt == ATTRIBUTE_READING_INFO_SET) {
+				log.debug "energy"
+				map.name = "energy"
+				map.value = zigbee.convertHexToInt(it.value)/getEnergyDiv()
+				map.unit = "kWh"
+			}
+
+			if (map) {
+				result << createEvent(map)
+			}
+		}
+	}
+	log.debug "result: ${result}"
+	return result
+}
+
+def off() {
+	zigbee.off()
+}
+
+def on() {
+	zigbee.on()
+}
+
+def setLevel(value, rate = null) {
+	zigbee.setLevel(value) + (value?.toInteger() > 0 ? zigbee.on() : [])
+}
+
+/**
+ * PING is used by Device-Watch in attempt to reach the Device
+ * */
+def ping() {
+	log.debug "ping"
+	return refresh()
+}
+
+def refresh() {
+	log.debug "refresh"
+	zigbee.onOffRefresh() +
+			zigbee.levelRefresh() +
+			zigbee.simpleMeteringPowerRefresh() +
+			zigbee.readAttribute(zigbee.SIMPLE_METERING_CLUSTER, ATTRIBUTE_READING_INFO_SET)
+}
+
+def configure() {
+	log.debug "Configuring Reporting and Bindings."
+	sendEvent(name: "checkInterval", value: 2 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+	return refresh() +
+			zigbee.onOffConfig() +
+			zigbee.levelConfig() +
+			zigbee.simpleMeteringPowerConfig() +
+			zigbee.configureReporting(zigbee.SIMPLE_METERING_CLUSTER, ATTRIBUTE_READING_INFO_SET, DataType.UINT48, 1, 600, 1)
+}
+
+private int getPowerDiv() {
+	isJascoProducts() ? 10 : 1
+}
+
+private int getEnergyDiv() {
+	isJascoProducts() ? 10000 : 100
+}
+
+private boolean isJascoProducts() {
+	device.getDataValue("manufacturer") == "Jasco Products"
+}

--- a/devicetypes/smartthings/zigbee-metering-dimmer.src/zigbee-metering-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-metering-dimmer.src/zigbee-metering-dimmer.groovy
@@ -41,10 +41,14 @@ def parse(String description) {
 	if (event) {
 		log.info event
 		if (event.name == "power") {
-			event.value = event.value/getPowerDiv()
+			def powerDiv = device.getDataValue("powerDivisor")
+			powerDiv = powerDiv ? (powerDiv as int) : 1
+			event.value = event.value/powerDiv
 			event.unit = "W"
 		} else if (event.name == "energy") {
-			event.value = event.value/getEnergyDiv()
+			def energyDiv = device.getDataValue("energyDivisor")
+			energyDiv = energyDiv ? (energyDiv as int) : 100
+			event.value = event.value/energyDiv
 			event.unit = "kWh"
 		}
 		log.info "event: $event"
@@ -64,6 +68,7 @@ def parse(String description) {
 				log.debug "power"
 				map.name = "power"
 				def powerDiv = device.getDataValue("powerDivisor")
+				powerDiv = powerDiv ? (powerDiv as int) : 1
 				map.value = zigbee.convertHexToInt(it.value)/powerDiv
 				map.unit = "W"
 			}
@@ -71,6 +76,7 @@ def parse(String description) {
 				log.debug "energy"
 				map.name = "energy"
 				def energyDiv = device.getDataValue("energyDivisor")
+				energyDiv = energyDiv ? (energyDiv as int) : 100
 				map.value = zigbee.convertHexToInt(it.value)/energyDiv
 				map.unit = "kWh"
 			}
@@ -125,10 +131,10 @@ def configure() {
 
 	sendEvent(name: "checkInterval", value: 2 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
 	return refresh() +
-	zigbee.onOffConfig() +
-	zigbee.levelConfig() +
-	zigbee.simpleMeteringPowerConfig() +
-	zigbee.configureReporting(zigbee.SIMPLE_METERING_CLUSTER, ATTRIBUTE_READING_INFO_SET, DataType.UINT48, 1, 600, 1)
+		zigbee.onOffConfig() +
+		zigbee.levelConfig() +
+		zigbee.simpleMeteringPowerConfig() +
+		zigbee.configureReporting(zigbee.SIMPLE_METERING_CLUSTER, ATTRIBUTE_READING_INFO_SET, DataType.UINT48, 1, 600, 1)
 }
 
 private boolean isJascoProducts() {

--- a/devicetypes/smartthings/zigbee-metering-dimmer.src/zigbee-metering-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-metering-dimmer.src/zigbee-metering-dimmer.groovy
@@ -25,7 +25,7 @@ metadata {
 		capability "Health Check"
 
 		// Enbrighten/Jasco
-		fingerprint manufacturer: "Jasco Products", model: "43082", deviceJoinName: "Enbrighten Switch" //Enbrighten, in-Wall Smart Dimmer With Energy Monitoring 43082, Raw Description: 01 0104 0101 00 08 0000 0003 0004 0005 0006 0008 0702 0B05 02 000A 0019
+		fingerprint manufacturer: "Jasco Products", model: "43082", deviceJoinName: "Enbrighten Dimmer Switch" //Enbrighten, in-Wall Smart Dimmer With Energy Monitoring 43082, Raw Description: 01 0104 0101 00 08 0000 0003 0004 0005 0006 0008 0702 0B05 02 000A 0019
 	}
 }
 

--- a/devicetypes/smartthings/zigbee-metering-dimmer.src/zigbee-metering-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-metering-dimmer.src/zigbee-metering-dimmer.groovy
@@ -105,19 +105,19 @@ def ping() {
 def refresh() {
 	log.debug "refresh"
 	zigbee.onOffRefresh() +
-			zigbee.levelRefresh() +
-			zigbee.simpleMeteringPowerRefresh() +
-			zigbee.readAttribute(zigbee.SIMPLE_METERING_CLUSTER, ATTRIBUTE_READING_INFO_SET)
+	zigbee.levelRefresh() +
+	zigbee.simpleMeteringPowerRefresh() +
+	zigbee.readAttribute(zigbee.SIMPLE_METERING_CLUSTER, ATTRIBUTE_READING_INFO_SET)
 }
 
 def configure() {
 	log.debug "Configuring Reporting and Bindings."
 	sendEvent(name: "checkInterval", value: 2 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
 	return refresh() +
-			zigbee.onOffConfig() +
-			zigbee.levelConfig() +
-			zigbee.simpleMeteringPowerConfig() +
-			zigbee.configureReporting(zigbee.SIMPLE_METERING_CLUSTER, ATTRIBUTE_READING_INFO_SET, DataType.UINT48, 1, 600, 1)
+	zigbee.onOffConfig() +
+	zigbee.levelConfig() +
+	zigbee.simpleMeteringPowerConfig() +
+	zigbee.configureReporting(zigbee.SIMPLE_METERING_CLUSTER, ATTRIBUTE_READING_INFO_SET, DataType.UINT48, 1, 600, 1)
 }
 
 private int getPowerDiv() {

--- a/devicetypes/smartthings/zigbee-metering-dimmer.src/zigbee-metering-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-metering-dimmer.src/zigbee-metering-dimmer.groovy
@@ -40,10 +40,10 @@ def parse(String description) {
 	def event = zigbee.getEvent(description)
 	if (event) {
 		log.info event
-		if (event.name== "power") {
+		if (event.name == "power") {
 			event.value = event.value/getPowerDiv()
 			event.unit = "W"
-		} else if (event.name== "energy") {
+		} else if (event.name == "energy") {
 			event.value = event.value/getEnergyDiv()
 			event.unit = "kWh"
 		}

--- a/devicetypes/smartthings/zigbee-metering-dimmer.src/zigbee-metering-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-metering-dimmer.src/zigbee-metering-dimmer.groovy
@@ -13,7 +13,7 @@
  */
 import physicalgraph.zigbee.zcl.DataType
 metadata {
-	definition (name: "ZigBee Metering Dimmer", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.light",  mnmn: "SmartThings", vid:"generic-dimmer-power-energy", runLocally: true, executeCommandsLocally: true, genericHandler: "Zigbee", minHubCoreVersion: '000.019.00012') {
+	definition (name: "ZigBee Metering Dimmer", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.switch",  mnmn: "SmartThings", vid:"generic-dimmer-power-energy", runLocally: true, executeCommandsLocally: true, genericHandler: "Zigbee", minHubCoreVersion: '000.019.00012') {
 
 		capability "Actuator"
 		capability "Configuration"


### PR DESCRIPTION
WWST-7205 - new generic DTH to support dimmers that report both power [W] and energy [kWh] values.
(It was based partially on zigbee-dimmer-power and zigbee-metering-plug)

for now - there is only one fingerprint for Enbrighten, in-Wall Smart Dimmer With Energy Monitoring, 43082
@greens Please, could You take a look at the code ?
cc: @SmartThingsCommunity/srpol-pe-team 