### PR TITLE
Add Fingerprints for Door Window Sensor 7 Gen7 (ZWA011)

### DIFF
--- a/devicetypes/smartthings/zwave-door-window-sensor.src/zwave-door-window-sensor.groovy
+++ b/devicetypes/smartthings/zwave-door-window-sensor.src/zwave-door-window-sensor.groovy
@@ -62,6 +62,9 @@ metadata {
 		fingerprint mfr: "0371", prod: "0002", model: "000C", deviceJoinName: "Aeotec Open/Closed Sensor", mnmn: "SmartThings", vid: "generic-contact-5" //EU //Aeotec Door/Window Sensor 7 Pro
 		fingerprint mfr: "0371", prod: "0102", model: "000C", deviceJoinName: "Aeotec Open/Closed Sensor", mnmn: "SmartThings", vid: "generic-contact-5" //US //Aeotec Door/Window Sensor 7 Pro
 		fingerprint mfr: "0371", prod: "0202", model: "000C", deviceJoinName: "Aeotec Open/Closed Sensor", mnmn: "SmartThings", vid: "generic-contact-5" //AU //Aeotec Door/Window Sensor 7 Pro
+		fingerprint mfr: "0371", prod: "0002", model: "000B", deviceJoinName: "Aeotec Open/Closed Sensor" //EU //Aeotec Door/Window Sensor 7 (Gen7 - Basic)
+		fingerprint mfr: "0371", prod: "0102", model: "000B", deviceJoinName: "Aeotec Open/Closed Sensor" //US //Aeotec Door/Window Sensor 7 (Gen7 - Basic)
+		fingerprint mfr: "0371", prod: "0202", model: "000B", deviceJoinName: "Aeotec Open/Closed Sensor" //AU //Aeotec Door/Window Sensor 7 (Gen7 - Basic)
 	}
 
 	// simulator metadata


### PR DESCRIPTION
Fingerprints added for Door Window Sensor 7 (Gen7) Basic (ZWA011)

Note - Not to mistake this update for Door Window Sensor (Gen7) Pro (ZWA012)