### PR TITLE
[ICP-13928] Delete Qubino 1D Relay model from defaultEndpoint()

### DIFF
--- a/devicetypes/qubino/qubino-flush-2-relay.src/qubino-flush-2-relay.groovy
+++ b/devicetypes/qubino/qubino-flush-2-relay.src/qubino-flush-2-relay.groovy
@@ -336,7 +336,6 @@ def zwaveEvent(physicalgraph.zwave.commands.basicv1.BasicSet cmd, ep = null) {
 	changeSwitch(ep, cmd)
 }
 
-
 def zwaveEvent(physicalgraph.zwave.Command cmd, ep) {
 	log.warn "Unhandled ${cmd}" + (ep ? " from endpoint $ep" : "")
 }

--- a/devicetypes/qubino/qubino-flush-2-relay.src/qubino-flush-2-relay.groovy
+++ b/devicetypes/qubino/qubino-flush-2-relay.src/qubino-flush-2-relay.groovy
@@ -253,7 +253,7 @@ def zwaveEvent(physicalgraph.zwave.commands.switchbinaryv1.SwitchBinaryReport cm
 }
 
 def defaultEndpoint() {
-	if (zwaveInfo?.model?.equals("0052") || zwaveInfo?.model?.equals("0053")) {
+	if (zwaveInfo?.model?.equals("0052")) {
 		return null
 	} else {
 		return 1

--- a/devicetypes/qubino/qubino-flush-2-relay.src/qubino-flush-2-relay.groovy
+++ b/devicetypes/qubino/qubino-flush-2-relay.src/qubino-flush-2-relay.groovy
@@ -331,6 +331,12 @@ def zwaveEvent(physicalgraph.zwave.commands.sensormultilevelv5.SensorMultilevelR
 	createEvent(map)
 }
 
+def zwaveEvent(physicalgraph.zwave.commands.basicv1.BasicSet cmd, ep = null) { 
+	log.debug "Basic ${cmd}" + (ep ? " from endpoint $ep" : "")
+	changeSwitch(ep, cmd)
+}
+
+
 def zwaveEvent(physicalgraph.zwave.Command cmd, ep) {
 	log.warn "Unhandled ${cmd}" + (ep ? " from endpoint $ep" : "")
 }


### PR DESCRIPTION
@SmartThingsCommunity/srpol-pe-team @greens 
I and tester performed about 20 tests (per device) on Qubino 1D Relay (pairing and checking basic funcs) and device always paired on endpoint 1.