### PR TITLE
ICP-14065 Notification Gets resulting in false positives

### DIFF
--- a/devicetypes/smartthings/zwave-basic-smoke-alarm.src/zwave-basic-smoke-alarm.groovy
+++ b/devicetypes/smartthings/zwave-basic-smoke-alarm.src/zwave-basic-smoke-alarm.groovy
@@ -21,7 +21,7 @@ metadata {
 		fingerprint deviceId: "0xA100", inClusters: "0x20,0x80,0x70,0x85,0x71,0x72,0x86", deviceJoinName: "Smoke Detector"
 		fingerprint mfr:"0138", prod:"0001", model:"0001", deviceJoinName: "First Alert Smoke Detector" //First Alert Smoke Detector
 		//zw:S type:0701 mfr:026F prod:0001 model:0001 ver:1.07 zwv:4.24 lib:03 cc:5E,86,72,5A,73,80,71,85,59,84 role:06 ff:8C01 ui:8C01
-		fingerprint mfr: "026F ", prod: "0001", model: "0001", deviceJoinName: "FireAngel Smoke Detector" //FireAngel Thermoptek Smoke Alarm
+		fingerprint mfr: "026F", prod: "0001", model: "0001", deviceJoinName: "FireAngel Smoke Detector" //FireAngel Thermoptek Smoke Alarm
 		fingerprint mfr: "013C", prod: "0002", model: "001E", deviceJoinName: "Philio Smoke Detector" //Philio Smoke Alarm PSG01
 		fingerprint mfr: "0154", prod: "0004", model: "0010", deviceJoinName: "POPP Smoke Detector" //POPP 10Year Smoke Sensor
 		fingerprint mfr: "0154", prod: "0100", model: "0201", deviceJoinName: "POPP Smoke Detector" //POPP Smoke Detector with Siren
@@ -189,19 +189,16 @@ def zwaveEvent(physicalgraph.zwave.commands.sensoralarmv1.SensorAlarmReport cmd,
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.wakeupv1.WakeUpNotification cmd, results) {
+    cmds = []
 	results << createEvent(descriptionText: "$device.displayName woke up", isStateChange: false)
 	if (!state.lastbatt || (now() - state.lastbatt) >= 56*60*60*1000) {
-		results << response(delayBetween([
-				zwave.notificationV3.notificationGet(notificationType: 0x01).format(),
-				zwave.batteryV1.batteryGet().format(),
-				zwave.wakeUpV1.wakeUpNoMoreInformation().format()
-		], 2000))
-	} else {
-		results << response(delayBetween([
-				zwave.notificationV3.notificationGet(notificationType: 0x01).format(),
-				zwave.wakeUpV1.wakeUpNoMoreInformation().format()
-		], 2000))
+		cmds << zwave.batteryV1.batteryGet().format()
 	}
+	if (zwaveInfo.mfr == "0154") {
+		cmds << zwave.notificationV3.notificationGet(notificationType: 0x01).format()
+	}
+	cmds << zwave.wakeUpV1.wakeUpNoMoreInformation().format()
+	results << response(delayBetween(cmds, 2000))
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.batteryv1.BatteryReport cmd, results) {

--- a/devicetypes/smartthings/zwave-smoke-alarm.src/zwave-smoke-alarm.groovy
+++ b/devicetypes/smartthings/zwave-smoke-alarm.src/zwave-smoke-alarm.groovy
@@ -189,19 +189,16 @@ def zwaveEvent(physicalgraph.zwave.commands.sensoralarmv1.SensorAlarmReport cmd,
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.wakeupv1.WakeUpNotification cmd, results) {
+	cmds = []
 	results << createEvent(descriptionText: "$device.displayName woke up", isStateChange: false)
 	if (!state.lastbatt || (now() - state.lastbatt) >= 56*60*60*1000) {
-		results << response(delayBetween([
-				zwave.notificationV3.notificationGet(notificationType: 0x01).format(),
-				zwave.batteryV1.batteryGet().format(),
-				zwave.wakeUpV1.wakeUpNoMoreInformation().format()
-		], 2000))
-	} else {
-		results << response(delayBetween([
-				zwave.notificationV3.notificationGet(notificationType: 0x01).format(),
-				zwave.wakeUpV1.wakeUpNoMoreInformation().format()
-		], 2000))
+		cmds << zwave.batteryV1.batteryGet().format()
 	}
+	if (zwaveInfo.mfr == "0154") {
+		cmds << zwave.notificationV3.notificationGet(notificationType: 0x01).format()
+	}
+	cmds << zwave.wakeUpV1.wakeUpNoMoreInformation().format()
+	results << response(delayBetween(cmds, 2000))
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.batteryv1.BatteryReport cmd, results) {


### PR DESCRIPTION
FireAngel users reported getting periodic false positives from notification gets sent in response to wakeups. I believe this is due to some gray areas in the Z-Wave spec, but notification gets are not the same as gets for other command classes.