### PR TITLE
Aeotec Doorbell Siren 6 sound/volume configuration fix

### DIFF
--- a/devicetypes/smartthings/aeotec-doorbell-siren-6.src/aeotec-doorbell-siren-6.groovy
+++ b/devicetypes/smartthings/aeotec-doorbell-siren-6.src/aeotec-doorbell-siren-6.groovy
@@ -347,7 +347,7 @@ private mcEncap(cmd) {
 			device.updateSetting("sirenDoorbellSend", [value:"false",type:"bool"]) //reset preference toggle button when leaving setting page
 			return response(zwave.securityV1.securityMessageEncapsulation().encapsulate(cmd).format()) //used to process Sound Switch Configuration SET
 		} else {
-			cmd.format()
+			return response(cmd.format()) //used to process Sound Switch Configuration SET when S2_FAILED or non-secure.
 		}
 	}
 }


### PR DESCRIPTION
Fixes issue where Sound/Volume cannot be configured if paired with No Security (S2_FAILED or No Security level)