### PR TITLE
ICP-14076, ICP-14077 - fixes for level and energy meter handling (disables local execution)

### DIFF
--- a/devicetypes/smartthings/zigbee-metering-dimmer.src/zigbee-metering-dimmer.groovy
+++ b/devicetypes/smartthings/zigbee-metering-dimmer.src/zigbee-metering-dimmer.groovy
@@ -13,7 +13,7 @@
  */
 import physicalgraph.zigbee.zcl.DataType
 metadata {
-	definition (name: "ZigBee Metering Dimmer", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.switch",  mnmn: "SmartThings", vid:"generic-dimmer-power-energy", runLocally: true, executeCommandsLocally: true, genericHandler: "Zigbee", minHubCoreVersion: '000.019.00012') {
+	definition (name: "ZigBee Metering Dimmer", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.switch",  mnmn: "SmartThings", vid:"generic-dimmer-power-energy") {
 
 		capability "Actuator"
 		capability "Configuration"


### PR DESCRIPTION
Fixes: ICP-14076, ICP-14077
@greens this one works better with local execution disabled.
(DTH contains one fingerprint only / device is still in the certification process)
Please, could You review the code ?

@SmartThingsCommunity/srpol-pe-team 