### PR TITLE
ICP-14136 Qubino Flush Thermostat - removed unnecesary temperature conversion

### DIFF
--- a/devicetypes/smartthings/qubino-flush-thermostat.src/qubino-flush-thermostat.groovy
+++ b/devicetypes/smartthings/qubino-flush-thermostat.src/qubino-flush-thermostat.groovy
@@ -277,7 +277,6 @@ def setCoolingSetpoint(setpoint) {
 }
 
 def updateSetpoint(setpoint, setpointType) {
-	setpoint = temperatureScale == 'C' ? setpoint : fahrenheitToCelsius(setpoint)
 	setpoint = Math.max(Math.min(setpoint.doubleValue(), maxSetpointTemperature.doubleValue()), minSetpointTemperature.doubleValue())
 	[
 			secure(zwave.thermostatSetpointV2.thermostatSetpointSet([precision: 1, scale: 0, scaledValue: setpoint, setpointType: setpointType, size: 2])),

--- a/devicetypes/smartthings/qubino-flush-thermostat.src/qubino-flush-thermostat.groovy
+++ b/devicetypes/smartthings/qubino-flush-thermostat.src/qubino-flush-thermostat.groovy
@@ -172,7 +172,7 @@ def zwaveEvent(physicalgraph.zwave.commands.thermostatsetpointv2.ThermostatSetpo
 			map.name = "coolingSetpoint"
 			break
 	}
-	map.value = convertTemperatureIfNeeded(cmd.scaledValue, cmd.scale ? 'F' : 'C', cmd.precision)
+	map.value = cmd.scaledValue
 	map.unit = temperatureScale
 	createEvent(map)
 }
@@ -204,8 +204,7 @@ def zwaveEvent(physicalgraph.zwave.commands.meterv3.MeterReport cmd) {
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.sensormultilevelv5.SensorMultilevelReport cmd) {
-	def deviceTemperatureScale = cmd.scale ? 'F' : 'C'
-	createEvent(name: "temperature", value: convertTemperatureIfNeeded(cmd.scaledSensorValue, deviceTemperatureScale, cmd.precision), unit: temperatureScale)
+	createEvent(name: "temperature", value: cmd.scaledSensorValue, unit: temperatureScale)
 }
 
 def zwaveEvent(physicalgraph.zwave.commands.configurationv2.ConfigurationReport cmd) {
@@ -277,16 +276,19 @@ def setCoolingSetpoint(setpoint) {
 }
 
 def updateSetpoint(setpoint, setpointType) {
-	setpoint = temperatureScale == 'C' ? setpoint : fahrenheitToCelsius(setpoint)
+	def scale = temperatureScale == 'C' ? 0 : 1
 	[
-			secure(zwave.thermostatSetpointV2.thermostatSetpointSet([precision: 1, scale: 0, scaledValue: setpoint, setpointType: setpointType, size: 2])),
+			secure(zwave.thermostatSetpointV2.thermostatSetpointSet([precision: 1, scale: scale, scaledValue: setpoint, setpointType: setpointType, size: 2])),
 			"delay 2000",
 			secure(zwave.thermostatSetpointV2.thermostatSetpointGet(setpointType: setpointType))
 	]
 }
 
 def configure() {
-	secure(zwave.configurationV1.configurationGet(parameterNumber: 59))
+	[
+		secure(zwave.configurationV1.configurationSet(parameterNumber: 78, scaledConfigurationValue: temperatureScale == 'C' ? 0 : 1, size: 1))
+		secure(zwave.configurationV1.configurationGet(parameterNumber: 59)),
+	]
 }
 
 def refresh() {

--- a/devicetypes/smartthings/qubino-flush-thermostat.src/qubino-flush-thermostat.groovy
+++ b/devicetypes/smartthings/qubino-flush-thermostat.src/qubino-flush-thermostat.groovy
@@ -286,8 +286,8 @@ def updateSetpoint(setpoint, setpointType) {
 
 def configure() {
 	[
-		secure(zwave.configurationV1.configurationSet(parameterNumber: 78, scaledConfigurationValue: temperatureScale == 'C' ? 0 : 1, size: 1))
-		secure(zwave.configurationV1.configurationGet(parameterNumber: 59)),
+		secure(zwave.configurationV1.configurationSet(parameterNumber: 78, scaledConfigurationValue: temperatureScale == 'C' ? 0 : 1, size: 1)),
+		secure(zwave.configurationV1.configurationGet(parameterNumber: 59))
 	]
 }
 

--- a/devicetypes/smartthings/qubino-flush-thermostat.src/qubino-flush-thermostat.groovy
+++ b/devicetypes/smartthings/qubino-flush-thermostat.src/qubino-flush-thermostat.groovy
@@ -277,7 +277,7 @@ def setCoolingSetpoint(setpoint) {
 }
 
 def updateSetpoint(setpoint, setpointType) {
-	setpoint = Math.max(Math.min(setpoint.doubleValue(), maxSetpointTemperature.doubleValue()), minSetpointTemperature.doubleValue())
+	setpoint = temperatureScale == 'C' ? setpoint : fahrenheitToCelsius(setpoint)
 	[
 			secure(zwave.thermostatSetpointV2.thermostatSetpointSet([precision: 1, scale: 0, scaledValue: setpoint, setpointType: setpointType, size: 2])),
 			"delay 2000",


### PR DESCRIPTION
@greens @SmartThingsCommunity/srpol-pe-team 
Qubino reported that there's an issue with setting correct setpoints when location uses Fahrenheit.
It turned out, that before sending a command to a device, setpoint's value is converted twice - firstly by plugin, and later by DTH.