### PR TITLE
BUG-2032 Send previous setpoint value if we don't intend to update the setpoint

### DIFF
--- a/devicetypes/zenwithin/zen-thermostat.src/zen-thermostat.groovy
+++ b/devicetypes/zenwithin/zen-thermostat.src/zen-thermostat.groovy
@@ -591,6 +591,8 @@ def setHeatingSetpoint(degrees) {
         state.heatingSetpoint = degrees.toDouble()
         // Use runIn to enable both setpoints to be changed if a routine/SA changes heating/cooling setpoint at the same time
         runIn(2, "updateSetpoints", [overwrite: true])
+    } else {
+        sendEvent(name: "heatingSetpoint", value: device.currentValue("heatingSetpoint"), unit: getTemperatureScale())
     }
 }
 
@@ -600,6 +602,8 @@ def setCoolingSetpoint(degrees) {
         state.coolingSetpoint = degrees.toDouble()
         // Use runIn to enable both setpoints to be changed if a routine/SA changes heating/cooling setpoint at the same time
         runIn(2, "updateSetpoints", [overwrite: true])
+    } else {
+        sendEvent(name: "coolingSetpoint", value: device.currentValue("coolingSetpoint"), unit: getTemperatureScale())
     }
 }
 


### PR DESCRIPTION
The thermostat won't accept commands to change a setpoint that doesn't match the current mode. To appears the mobile client we need to send an event for the specified setpoint. So, we will just send the current value.