### PR TITLE
Stop running build on all branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ workflows:
                 - master
                 - staging
                 - acceptance
+                - production
       - deploy-dev:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,13 @@ workflows:
   version: 2
   deploy:
     jobs:
-      - build
+      - build:
+          filters:
+            branches:
+              only:
+                - master
+                - staging
+                - acceptance
       - deploy-dev:
           requires:
             - build


### PR DESCRIPTION
Build was running on _all_ branches that were not from a fork. Considering the number of direct branches opened via DevWS, this is not economical.