### PR TITLE
BUG-2759 Make strobe command strobe

### DIFF
--- a/devicetypes/smartthings/ozom-smart-siren.src/ozom-smart-siren.groovy
+++ b/devicetypes/smartthings/ozom-smart-siren.src/ozom-smart-siren.groovy
@@ -160,7 +160,7 @@ def siren() {
 
 def strobe() {
 	log.debug "strobe()"
-	startCmd(ALARM_SIREN)
+	startCmd(ALARM_STROBE)
 }
 
 def startCmd(cmd) {


### PR DESCRIPTION
a likely typo resulted in the strobe command sending "siren" to the device.