### PR TITLE
GPD-1105 Remove number from preference title

### DIFF
--- a/devicetypes/fibargroup/fibaro-co-sensor-zw5.src/fibaro-co-sensor-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-co-sensor-zw5.src/fibaro-co-sensor-zw5.groovy
@@ -69,7 +69,7 @@ metadata {
 	preferences {
 		parameterMap().each {
 			input (
-					title: "${it.num}. ${it.title}",
+					title: "${it.title}",
 					description: it.descr,
 					type: "paragraph",
 					element: "paragraph"

--- a/devicetypes/fibargroup/fibaro-dimmer-2-zw5.src/fibaro-dimmer-2-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-dimmer-2-zw5.src/fibaro-dimmer-2-zw5.groovy
@@ -70,7 +70,7 @@ metadata {
 	preferences {
 		parameterMap().each {
 			input (
-					title: "${it.num}. ${it.title}",
+					title: "${it.title}",
 					description: it.descr,
 					type: "paragraph",
 					element: "paragraph"

--- a/devicetypes/fibargroup/fibaro-door-window-sensor-2.src/fibaro-door-window-sensor-2.groovy
+++ b/devicetypes/fibargroup/fibaro-door-window-sensor-2.src/fibaro-door-window-sensor-2.groovy
@@ -91,7 +91,7 @@ metadata {
 		
 		parameterMap().each {
 			input (
-				title: "${it.num}. ${it.title}",
+				title: "${it.title}",
 				description: it.descr,
 				type: "paragraph",
 				element: "paragraph"

--- a/devicetypes/fibargroup/fibaro-double-switch-2-zw5.src/fibaro-double-switch-2-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-double-switch-2-zw5.src/fibaro-double-switch-2-zw5.groovy
@@ -45,7 +45,7 @@ metadata {
 	preferences {
 		parameterMap().each {
 			input (
-					title: "${it.num}. ${it.title}",
+					title: "${it.title}",
 					description: it.descr,
 					type: "paragraph",
 					element: "paragraph"

--- a/devicetypes/fibargroup/fibaro-motion-sensor-zw5.src/fibaro-motion-sensor-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-motion-sensor-zw5.src/fibaro-motion-sensor-zw5.groovy
@@ -91,7 +91,7 @@ metadata {
 		)
 		parameterMap().each {
 			input(
-				title: "${it.num}. ${it.title}",
+				title: "${it.title}",
 				description: it.descr,
 				type: "paragraph",
 				element: "paragraph"

--- a/devicetypes/fibargroup/fibaro-single-switch-2-zw5.src/fibaro-single-switch-2-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-single-switch-2-zw5.src/fibaro-single-switch-2-zw5.groovy
@@ -47,7 +47,7 @@ metadata {
     preferences {
         parameterMap().each {
             input (
-                    title: "${it.num}. ${it.title}",
+                    title: "${it.title}",
                     description: it.descr,
                     type: "paragraph",
                     element: "paragraph"
@@ -75,7 +75,7 @@ private getPrefsFor(String name) {
     parameterMap().findAll( {it.key.contains(name)} ).each {
         input (
                 name: it.key,
-                title: "${it.num}. ${it.title}",
+                title: "${it.title}",
                 description: it.descr,
                 type: it.type,
                 options: it.options,

--- a/devicetypes/fibargroup/fibaro-wall-plug-eu-zw5.src/fibaro-wall-plug-eu-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-wall-plug-eu-zw5.src/fibaro-wall-plug-eu-zw5.groovy
@@ -47,7 +47,7 @@ metadata {
 	preferences {
 		parameterMap().each {
 			input (
-					title: "${it.num}. ${it.title}",
+					title: "${it.title}",
 					description: it.descr,
 					type: "paragraph",
 					element: "paragraph"

--- a/devicetypes/fibargroup/fibaro-wall-plug-us-zw5.src/fibaro-wall-plug-us-zw5.groovy
+++ b/devicetypes/fibargroup/fibaro-wall-plug-us-zw5.src/fibaro-wall-plug-us-zw5.groovy
@@ -48,7 +48,7 @@ metadata {
 	preferences {
 		parameterMap().each {
 			input (
-					title: "${it.num}. ${it.title}",
+					title: "${it.title}",
 					description: it.descr,
 					type: "paragraph",
 					element: "paragraph"

--- a/devicetypes/widomsrl/widom-smart-dry-contact.src/widom-smart-dry-contact.groovy
+++ b/devicetypes/widomsrl/widom-smart-dry-contact.src/widom-smart-dry-contact.groovy
@@ -33,7 +33,7 @@ metadata {
 
 		parameterMap().each {
 			input (
-					title: "${it.num}. ${it.title}",
+					title: "${it.title}",
 					description: it.descr,
 					type: "paragraph",
 					element: "paragraph"


### PR DESCRIPTION
Teams have reported that they are unsatisfied with the format that Fibaro used for their preference titles.