### PR TITLE
[ICP-14234] Zigbee Window Shade - included lastLevel in methods scope as local variable

### DIFF
--- a/devicetypes/smartthings/zigbee-window-shade.src/zigbee-window-shade.groovy
+++ b/devicetypes/smartthings/zigbee-window-shade.src/zigbee-window-shade.groovy
@@ -132,10 +132,10 @@ def getLastLevel() {
 }
 
 def levelEventHandler(currentLevel) {
-	def lastLevel = getLastLevel()
-	log.debug "levelEventHandle - currentLevel: ${currentLevel} lastLevel: ${lastLevel}"
+	def priorLevel = lastLevel
+	log.debug "levelEventHandle - currentLevel: ${currentLevel} priorLevel: ${priorLevel}"
 
-	if ((lastLevel == "undefined" || currentLevel == lastLevel) && state.invalidSameLevelEvent) { //Ignore invalid reports
+	if ((priorLevel == "undefined" || currentLevel == priorLevel) && state.invalidSameLevelEvent) { //Ignore invalid reports
 		log.debug "Ignore invalid reports"
 	} else {
 		state.invalidSameLevelEvent = true
@@ -146,9 +146,9 @@ def levelEventHandler(currentLevel) {
 		if (currentLevel == 0 || currentLevel == 100) {
 			sendEvent(name: "windowShade", value: currentLevel == 0 ? "closed" : "open")
 		} else {
-			if (lastLevel < currentLevel) {
+			if (priorLevel < currentLevel) {
 				sendEvent([name:"windowShade", value: "opening"])
-			} else if (lastLevel > currentLevel) {
+			} else if (priorLevel > currentLevel) {
 				sendEvent([name:"windowShade", value: "closing"])
 			}
 			runIn(1, "updateFinalState", [overwrite:true])

--- a/devicetypes/smartthings/zigbee-window-shade.src/zigbee-window-shade.groovy
+++ b/devicetypes/smartthings/zigbee-window-shade.src/zigbee-window-shade.groovy
@@ -132,6 +132,7 @@ def getLastLevel() {
 }
 
 def levelEventHandler(currentLevel) {
+	def lastLevel = getLastLevel()
 	log.debug "levelEventHandle - currentLevel: ${currentLevel} lastLevel: ${lastLevel}"
 
 	if ((lastLevel == "undefined" || currentLevel == lastLevel) && state.invalidSameLevelEvent) { //Ignore invalid reports


### PR DESCRIPTION
@greens @dkirker @SmartThingsCommunity/srpol-pe-team 
This is needed, cause comparison `currentLevel < (or) > lastLevel` was always false, as lastLevel value was being acquired after shadeLevel was set.