### PR TITLE
[BUG-3052] Updating Ecolink URL

### DIFF
--- a/smartapps/smartthings/ecobee-connect.src/ecobee-connect.groovy
+++ b/smartapps/smartthings/ecobee-connect.src/ecobee-connect.groovy
@@ -201,7 +201,7 @@ def callback() {
 			redirect_uri: callbackUrl
 		]
 
-		def tokenUrl = "https://www.ecobee.com/home/token?${toQueryString(tokenParams)}"
+		def tokenUrl = "${apiEndpoint}/token?${toQueryString(tokenParams)}"
 
 		httpPost(uri: tokenUrl) { resp ->
 			state.refreshToken = resp.data.refresh_token


### PR DESCRIPTION
Old URL caused a mismatch in SSL ciphers and updating to api.ecobee.com resolved the issue.