### PR TITLE
BUG-3164 Overlapping lock events

### DIFF
--- a/devicetypes/smartthings/zigbee-lock-without-codes.src/zigbee-lock-without-codes.groovy
+++ b/devicetypes/smartthings/zigbee-lock-without-codes.src/zigbee-lock-without-codes.groovy
@@ -213,7 +213,7 @@ private def parseAttributeResponse(String description) {
 				with less info will be marked as not displayed
 			 */
 			log.debug "Lock attribute report received: ${responseMap.value}. Delaying event."
-			runIn(1, "delayLockEvent", [data : [map : responseMap]])
+			runIn(1, "delayLockEvent", [overwrite: true, forceForLocallyExecuting: true, data: [map: responseMap]])
 			return [:]
 		}
 	} else {

--- a/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
+++ b/devicetypes/smartthings/zigbee-lock.src/zigbee-lock.groovy
@@ -506,7 +506,7 @@ private def parseAttributeResponse(String description) {
 				with less info will be marked as not displayed
 			 */
 			log.debug "Lock attribute report received: ${responseMap.value}. Delaying event."
-			runIn(1, "delayLockEvent", [data : [map : responseMap]])
+			runIn(1, "delayLockEvent", [overwrite: true, forceForLocallyExecuting: true, data: [map: responseMap]])
 			return [:]
 		}
 	} else if (clusterInt == CLUSTER_DOORLOCK && attrInt == DOORLOCK_ATTR_MIN_PIN_LENGTH && descMap.value) {

--- a/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
+++ b/devicetypes/smartthings/zwave-lock.src/zwave-lock.groovy
@@ -380,7 +380,7 @@ def zwaveEvent(DoorLockOperationReport cmd) {
 	}
 	if (generatesDoorLockOperationReportBeforeAlarmReport()) {
 		// we're expecting lock events to come after notification events, but for specific yale locks they come out of order
-		runIn(3, "delayLockEvent", [data: [map: map]])
+		runIn(3, "delayLockEvent", [overwrite: true, forceForLocallyExecuting: true, data: [map: map]])
 		return [:]
 	} else {
 		return result ? [createEvent(map), *result] : createEvent(map)


### PR DESCRIPTION
Lock events for devices for which we delay the sending of lock operation reports that happen too close together will cause incorrect state to temporarily be displayed.

Overwriting the scheduled function call responsible for these events should be enough to essentially drop the "bad" event on the floor so it never has a chance to overwrite good state.