### PR TITLE
[BUG-3171] Double socket child device icon fix

### DIFF
--- a/devicetypes/smartthings/child-switch-health-power.src/child-switch-health-power.groovy
+++ b/devicetypes/smartthings/child-switch-health-power.src/child-switch-health-power.groovy
@@ -12,7 +12,7 @@
  *
  */
 metadata {
-	definition(name: "Child Switch Health Power", namespace: "smartthings", author: "SmartThings", mnmn: "SmartThings", vid: "generic-switch-power") {
+	definition(name: "Child Switch Health Power", namespace: "smartthings", author: "SmartThings", ocfDeviceType: "oic.d.smartplug", mnmn: "SmartThings", vid: "generic-switch-power") {
 		capability "Switch"
 		capability "Actuator"
 		capability "Sensor"


### PR DESCRIPTION
Adding ocfDeviceType: "oic.d.smartplug", to the metadata for Child Switch Health Power to change the icon from a dimmer switch to an outlet. This device is used by the child device of the Aurora AOne double socket. Currently the parent device, ZigBee Multi Switch Power, uses an outlet icon. This will result in both devices reflecting properly with an outlet icon.

