### PR TITLE
BUG-3088 Force metadata refresh for CT100 thermostat

### DIFF
--- a/devicetypes/smartthings/ct100-thermostat.src/ct100-thermostat.groovy
+++ b/devicetypes/smartthings/ct100-thermostat.src/ct100-thermostat.groovy
@@ -1,6 +1,6 @@
 metadata {
 	// Automatically generated. Make future change here.
-	definition (name: "CT100 Thermostat", namespace: "smartthings", author: "SmartThings") {
+	definition (name: "CT100 Thermostat", namespace: "smartthings", author: "SmartThings", mnmn: "SmartThings", vid: "SmartThings-smartthings-CT100_Thermostat") {
 		capability "Actuator"
 		capability "Temperature Measurement"
 		capability "Relative Humidity Measurement"


### PR DESCRIPTION
The fingerprinting database doesn't handle deletion of metadata info for groovy device handlers -- you can only add or replace reliably.