### PR TITLE
Cleanup duplicate capabilities

### DIFF
--- a/devicetypes/smartthings/fibaro-heat-controller.src/fibaro-heat-controller.groovy
+++ b/devicetypes/smartthings/fibaro-heat-controller.src/fibaro-heat-controller.groovy
@@ -20,7 +20,6 @@ metadata {
 		capability "Thermostat Heating Setpoint"
 		capability "Health Check"
 		capability "Thermostat"
-		capability "Thermostat Mode"
 		capability "Temperature Measurement"
 
 		command "setThermostatSetpointUp"


### PR DESCRIPTION
Fibaro Heat Controller defines the capability Thermostat Mode twice