### PR TITLE
Adding fingerprint for an alternate Fibaro radiator thermostat model 

### DIFF
--- a/devicetypes/smartthings/fibaro-heat-controller.src/fibaro-heat-controller.groovy
+++ b/devicetypes/smartthings/fibaro-heat-controller.src/fibaro-heat-controller.groovy
@@ -27,6 +27,7 @@ metadata {
 		command "switchMode"
 
 		fingerprint mfr: "010F", prod: "1301", model: "1000", deviceJoinName: "Fibaro Thermostat" //Fibaro Heat Controller
+		fingerprint mfr: "010F", prod: "1301", model: "1001", deviceJoinName: "Fibaro Thermostat" //Fibaro Heat Controller
 	}
 
 	tiles(scale: 2) {


### PR DESCRIPTION
Fibaro has a _slightly_ different model of this device that functions the same but has a small difference in fingerprint. Adding the fingerprint for this other model so it pairs correctly.