### PR TITLE
WWST-7892, Add a DTH code for ABL CPX Lighting(Light with a motion sensor)

### DIFF
--- a/devicetypes/smartthings/zigbee-motion-sensor-light.src/led-cpx-light.groovy
+++ b/devicetypes/smartthings/zigbee-motion-sensor-light.src/led-cpx-light.groovy
@@ -28,10 +28,10 @@ metadata {
 		capability "Switch Level"
 		
 		// ABL Lithonia
-		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 0300, 0406", outClusters: "0019", manufacturer: "Lithonia", model: "ABL-LIGHTSENSOR-Z-001", deviceJoinName: "CPX Smart Panel Light", mnmn: "Samsung Electronics", vid: "SAMSUNG-ITM-Z-001"
+		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 0300, 0406", outClusters: "0019", manufacturer: "Lithonia", model: "ABL-LIGHTSENSOR-Z-001", deviceJoinName: "CPX Smart Panel Light", mnmn: "Samsung Electronics", vid: "ABL-LIGHTSENSOR-Z-001"
 		
 		// Samsung LED
-		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 0300, 0406", outClusters: "0019", manufacturer: "Samsung Electronics", model: "SAMSUNG-ITM-Z-004", deviceJoinName: "ITM CPX Light", mnmn: "Samsung Electronics", vid: "SAMSUNG-ITM-Z-001"
+		fingerprint profileId: "0104", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 0300, 0406", outClusters: "0019", manufacturer: "Samsung Electronics", model: "SAMSUNG-ITM-Z-004", deviceJoinName: "ITM CPX Light", mnmn: "Samsung Electronics", vid: "SAMSUNG-ITM-Z-004"
 	}
 
 	// UI tile definitions


### PR DESCRIPTION
There is some changes in the zigbee-motion-sensor-light.
Please review it.

Edit vid for ABL Lithonia and Samsung LED.

- ABL Lithonia : SAMSUNG-ITM-Z-001 → **ABL-LIGHTSENSOR-Z-001**
- Samsung LED : SAMSUNG-ITM-Z-001 → **SAMSUNG-ITM-Z-004**