### PR TITLE
  SmartThingsPublic WWST-7893, Added a health check code for ABL CPX Lighting(Light with a motion sensor)

### DIFF
--- a/devicetypes/smartthings/zigbee-motion-sensor-light.src/led-cpx-light.groovy
+++ b/devicetypes/smartthings/zigbee-motion-sensor-light.src/led-cpx-light.groovy
@@ -113,6 +113,8 @@ def setLevel(value, rate=null) {
 }
 
 def configure() {
+	sendEvent(name: "checkInterval", value: 2 * 10 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+	
 	zigbee.configureReporting(MOTION_CLUSTER, MOTION_STATUS_ATTRIBUTE, 0x18, 30, 600, null) +
 		zigbee.onOffConfig() +
 		zigbee.levelConfig() +


### PR DESCRIPTION
By the reason for WWST certification failed, I added a health check code in the configure function. After added a health check code the device changed to offline about 20 mins later from when I remove the power of device or reset the device.

TC_Health_Check_3 - Coming back to the online state after performing action on a device(Fail)
problem : This test case fails because the device does not show as Offline in the SmartThings app after remove power from device.

TC_Reset_1 - Correct device behavior after manual reset(Fail)
problem : This test case fails because the device does not show as Offline in the SmartThings app after reset.