### PR TITLE
Update aeotec-wallmote.groovy

### DIFF
--- a/devicetypes/smartthings/aeotec-wallmote.src/aeotec-wallmote.groovy
+++ b/devicetypes/smartthings/aeotec-wallmote.src/aeotec-wallmote.groovy
@@ -27,7 +27,6 @@ metadata {
         fingerprint mfr: "0086", model: "0081", deviceJoinName: "Aeotec Remote Control", mnmn: "SmartThings", vid: "generic-2-button" //Aeotec Wallmote
         fingerprint mfr: "0060", model: "0003", deviceJoinName: "Everspring Remote Control", mnmn: "SmartThings", vid: "generic-2-button" //Everspring Wall Switch
         fingerprint mfr: "0371", model: "0016", deviceJoinName: "Aeotec Remote Control", mnmn: "SmartThings", vid: "generic-2-button" //Aeotec illumino Wallmote 7
-        fingerprint mfr: "0312", prod: "0924", model: "D001", deviceJoinName: "Minoston Remote Control", mnmn: "SmartThings", vid: "generic-4-button" //Minoston Wallmote
     }
 
     tiles(scale: 2) {


### PR DESCRIPTION
We test the device "Minoston Remote Control" and find that the deviceJoinName is not take effect. 
It is always showed as "Aeotec Wallmote", the DTH name. 
Another brand is showed, which is not acceptable. 
So I have to create another DTH and start a new PR(https://github.com/SmartThingsCommunity/SmartThingsPublic/pull/78439).
I will cancel the PRs if your guys can fix it soon. 
Thanks!