### PR TITLE
BUG-5328 - removes deprecated "Thermostat" capability

### DIFF
--- a/devicetypes/stelpro/stelpro-ki-thermostat.src/stelpro-ki-thermostat.groovy
+++ b/devicetypes/stelpro/stelpro-ki-thermostat.src/stelpro-ki-thermostat.groovy
@@ -23,7 +23,6 @@ metadata {
 		capability "Actuator"
 		capability "Temperature Measurement"
 		capability "Temperature Alarm"
-		capability "Thermostat"
 		capability "Thermostat Mode"
 		capability "Thermostat Operating State"
 		capability "Thermostat Heating Setpoint"


### PR DESCRIPTION
@greens @SmartThingsCommunity/srpol-pe-team 